### PR TITLE
city: use predefined city names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# macOS system files
+.DS_Store
+
+# Visual Studio Code editor settings
+.vscode/
+
+# Data files
+data/data/
+
+# Executables
+magic
+lbxdump

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -596,6 +596,61 @@ func (game *Game) FindValidCityLocationOnContinent(x int, y int) (int, int) {
     return 0, 0
 }
 
+func (game *Game) SuggestCityName(race data.Race) (string) {
+    allCities := game.AllCities()
+    fallback := fmt.Sprintf("City %d", len(allCities)+1)
+
+    predefinedNames, err := citylib.ReadCityNames(game.Cache)
+    if err != nil {
+        log.Printf("Unable to read predefined city names: %v", err)
+        return fallback
+    }
+
+    if len(predefinedNames) % 14 != 0 {
+        log.Printf("Predefined city names not dividable by number of races")
+        return fallback
+    }
+
+    raceIndex := 0
+    switch race {
+        case data.RaceBarbarian: raceIndex = 0
+        case data.RaceBeastmen: raceIndex = 1
+        case data.RaceDarkElf: raceIndex = 2
+        case data.RaceDraconian: raceIndex = 3
+        case data.RaceDwarf: raceIndex = 4
+        case data.RaceGnoll: raceIndex = 5
+        case data.RaceHalfling: raceIndex = 6
+        case data.RaceHighElf: raceIndex = 7
+        case data.RaceHighMen: raceIndex = 8
+        case data.RaceKlackon: raceIndex = 9
+        case data.RaceLizard: raceIndex = 10
+        case data.RaceNomad: raceIndex = 11
+        case data.RaceOrc: raceIndex = 12
+        case data.RaceTroll: raceIndex = 13
+    }
+
+    var existingNames []string
+    for _, city := range allCities {
+        existingNames = append(existingNames, city.Name)
+    }
+
+    entriesPerRace := len(predefinedNames) / 14
+    for i := 0; i < entriesPerRace; i++ {
+        name := predefinedNames[entriesPerRace * raceIndex + i]
+        if !slices.Contains(existingNames, name) {
+            return name
+        }
+    }
+    
+    for _, name := range predefinedNames {
+        if !slices.Contains(existingNames, name) {
+            return name
+        }
+    }
+
+    return fallback
+}
+
 func (game *Game) AllCities() []*citylib.City {
     var out []*citylib.City
 
@@ -3031,7 +3086,9 @@ func (game *Game) CityProductionBonus(x int, y int, plane data.Plane) int {
 }
 
 func (game *Game) CreateOutpost(settlers units.StackUnit, player *playerlib.Player) *citylib.City {
-    newCity := citylib.MakeCity("New City", settlers.GetX(), settlers.GetY(), settlers.GetRace(), settlers.GetBanner(), player.TaxRate, game.BuildingInfo, game.GetMap(settlers.GetPlane()))
+    cityName := game.SuggestCityName(settlers.GetRace())
+
+    newCity := citylib.MakeCity(cityName, settlers.GetX(), settlers.GetY(), settlers.GetRace(), settlers.GetBanner(), player.TaxRate, game.BuildingInfo, game.GetMap(settlers.GetPlane()))
     newCity.Plane = settlers.GetPlane()
     newCity.Population = 300
     newCity.Outpost = true

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -159,7 +159,9 @@ func runGameInstance(yield coroutine.YieldFunc, magic *MagicGame, settings setup
 
     cityX, cityY := game.FindValidCityLocation()
 
-    introCity := citylib.MakeCity("City1", cityX, cityY, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.GetMap(startingPlane))
+    cityName := game.SuggestCityName(player.Wizard.Race)
+
+    introCity := citylib.MakeCity(cityName, cityX, cityY, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.GetMap(startingPlane))
     introCity.Population = 4000
     introCity.Wall = false
     introCity.Plane = startingPlane


### PR DESCRIPTION
Hi @kazzmir

Great work on the Master of Magic clone!

This PR introduces a small enhancement: it suggests city names from the `cityname.lbx` file when creating a new settlement.

The name suggestions are based on the race of the settlers and whether the name has already been taken:
- Find the next name for a race not already taken.
- If all names for a particular race are already assigned, the next free name from any race is selected.
- If all predefined names are taken, a fallback suggestion of the format "City {number}" is provided.
- In contrast to the description in the [Master of Magic Wiki](https://masterofmagic.fandom.com/wiki/Town#Settlement_Names), no randomization is performed.

It seems that `cityname.lbx` contains an array of fixed-size strings, with both the size and the number of entries indicated by a small header. Comparing this structure with the [Master of Magic Wiki](https://masterofmagic.fandom.com/wiki/Town#Settlement_Names), it appears these strings are evenly distributed among the races, ordered alphabetically.

Let me know if you have any questions or need further adjustments.


