### PR TITLE
overworld: fog fixes

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2119,7 +2119,7 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
 
                         stack.Move(step.X - stack.X(), step.Y - stack.Y(), terrainCost)
                         game.showMovement(yield, oldX, oldY, stack)
-                        player.LiftFog(stack.X(), stack.Y(), 2, stack.Plane())
+                        player.LiftFog(stack.X(), stack.Y(), 1, stack.Plane())
 
                         game.doMagicEncounter(yield, player, stack, node)
 
@@ -2135,7 +2135,7 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
                     if game.confirmLairEncounter(yield, lair) {
                         stack.Move(step.X - stack.X(), step.Y - stack.Y(), terrainCost)
                         game.showMovement(yield, oldX, oldY, stack)
-                        player.LiftFog(stack.X(), stack.Y(), 2, stack.Plane())
+                        player.LiftFog(stack.X(), stack.Y(), 1, stack.Plane())
 
                         game.doLairEncounter(yield, player, stack, lair)
 
@@ -2151,7 +2151,7 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
 
                 stack.Move(step.X - stack.X(), step.Y - stack.Y(), terrainCost)
                 game.showMovement(yield, oldX, oldY, stack)
-                player.LiftFog(stack.X(), stack.Y(), 2, stack.Plane())
+                player.LiftFog(stack.X(), stack.Y(), 1, stack.Plane())
 
                 for _, otherPlayer := range game.Players[1:] {
                     otherStack := otherPlayer.FindStack(stack.X(), stack.Y())
@@ -2316,7 +2316,7 @@ func (game *Game) Update(yield coroutine.YieldFunc) GameState {
                                     oldY := stack.Y()
                                     stack.Move(to.X - stack.X(), to.Y - stack.Y(), terrainCost)
                                     game.showMovement(yield, oldX, oldY, stack)
-                                    player.LiftFog(stack.X(), stack.Y(), 2, stack.Plane())
+                                    player.LiftFog(stack.X(), stack.Y(), 1, stack.Plane())
 
                                     for _, enemy := range game.GetEnemies(player) {
                                         enemyStack := enemy.FindStack(stack.X(), stack.Y())
@@ -4114,22 +4114,12 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
 
     FogEdge_N_E := fogImage(0)
     FogEdge_S_E := fogImage(1)
+    FogEdge_E := fogImage(2)
     FogEdge_S_W := fogImage(3)
     FogEdge_S := fogImage(5)
     FogEdge_N_W := fogImage(7)
     FogEdge_N := fogImage(8)
-    FogEdge_W := fogImage(9)
-
-    /*
-    FogEdge_SW := fogImage(6)
-    FogEdge_SW_W_NW_N_NE := fogImage(7)
-    FogEdge_NW_N_NE := fogImage(8)
-    FogEdge_SW_N := fogImage(9)
-    FogEdge_NW_W := fogImage(10)
-    FogEdge_SW_W_NW_N := fogImage(11)
-    */
-
-    // fogBlack := game.GetFogImage()
+    FogEdge_W := fogImage(11)
 
     tileWidth := overworld.Map.TileWidth()
     tileHeight := overworld.Map.TileHeight()
@@ -4139,16 +4129,6 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
     var options ebiten.DrawImageOptions
 
     fog := overworld.Fog
-
-    /*
-    fogNW := func(x int, y int) bool {
-        if x == 0 || y == 0 {
-            return false
-        }
-
-        return fog[x - 1][y - 1]
-    }
-    */
 
     checkFog := func(x int, y int) bool {
         x = overworld.Map.WrapX(x)
@@ -4163,43 +4143,13 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
         return checkFog(x, y - 1)
     }
 
-    /*
-    fogNE := func(x int, y int) bool {
-        if x == len(fog) - 1 || y == 0 {
-            return false
-        }
-
-        return fog[x + 1][y - 1]
-    }
-    */
-
     fogE := func(x int, y int) bool {
         return checkFog(x+1, y)
     }
 
-    /*
-    fogSE := func(x int, y int) bool {
-        if x == len(fog) - 1 || y == len(fog[0]) - 1 {
-            return false
-        }
-
-        return fog[x + 1][y + 1]
-    }
-    */
-
     fogS := func(x int, y int) bool {
         return checkFog(x, y + 1)
     }
-
-    /*
-    fogSW := func(x int, y int) bool {
-        if x == 0 || y == len(fog[0]) - 1 {
-            return false
-        }
-
-        return fog[x - 1][y + 1]
-    }
-    */
 
     fogW := func(x int, y int) bool {
         return checkFog(x - 1, y)
@@ -4215,13 +4165,9 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
             options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
 
             if tileX >= 0 && tileY >= 0 && tileX < len(fog) && tileY < len(fog[tileX]) && fog[tileX][tileY] {
-                // nw := fogNW(tileX, tileY)
                 n := fogN(tileX, tileY)
-                // ne := fogNE(tileX, tileY)
                 e := fogE(tileX, tileY)
-                // se := fogSE(tileX, tileY)
                 s := fogS(tileX, tileY)
-                // sw := fogSW(tileX, tileY)
                 w := fogW(tileX, tileY)
 
                 if n && e {
@@ -4229,8 +4175,7 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
                 } else if n {
                     screen.DrawImage(FogEdge_N, &options)
                 } else if e {
-                    options.GeoM.Scale(1, -1)
-                    screen.DrawImage(FogEdge_W, &options)
+                    screen.DrawImage(FogEdge_E, &options)
                 }
 
                 if s && e {
@@ -4248,34 +4193,7 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
                 if s && w {
                     screen.DrawImage(FogEdge_S_W, &options)
                 }
-
-                /*
-                if nw && n && ne && e && se && !s && !sw && !w {
-                    screen.DrawImage(FogEdge_NW_N_NE_E_SE, &options)
-                } else if sw && s && se && e && ne && !n && !nw && !w {
-                    screen.DrawImage(FogEdge_SW_S_SE_E_NE, &options)
-                } else if nw && w && sw && s && se && !e && !ne && !n {
-                    screen.DrawImage(FogEdge_NW_W_SW_S_SE, &options)
-                } else if nw && s && !n && !ne && !e && !se && !sw && !w {
-                    screen.DrawImage(FogEdge_NW_S, &options)
-                } else if sw && s && se && !n && !ne && !e && !nw && !w {
-                    screen.DrawImage(FogEdge_SW_S_SE, &options)
-                } else if sw && !n && !ne && !e && !se && !s && !nw && !w {
-                    screen.DrawImage(FogEdge_SW, &options)
-                } else if nw && w && sw && !s && n && ne && !e && !se {
-                    screen.DrawImage(FogEdge_SW_W_NW_N_NE, &options)
-                } else if nw && n && ne && !s && !se && !e && !sw && !w {
-                    screen.DrawImage(FogEdge_NW_N_NE, &options)
-                } else if sw && n && !ne && !e && !se && !s && !nw && !w {
-                    screen.DrawImage(FogEdge_SW_N, &options)
-                } else if nw && w && !n && !ne && !e && !se && !s && !sw {
-                    screen.DrawImage(FogEdge_NW_W, &options)
-                } else if sw && w && nw && n && !ne && !e && !se && !s {
-                    screen.DrawImage(FogEdge_SW_W_NW_N, &options)
-                }
-                */
             } else {
-
                 if overworld.FogBlack != nil {
                     screen.DrawImage(overworld.FogBlack, &options)
                 }

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -181,7 +181,7 @@ func runGameInstance(yield coroutine.YieldFunc, magic *MagicGame, settings setup
         player.AddUnit(units.MakeOverworldUnitFromUnit(unit, cityX, cityY, startingPlane, wizard.Banner, player.MakeExperienceInfo()))
     }
 
-    player.LiftFog(cityX, cityY, 3, introCity.Plane)
+    player.LiftFog(cityX, cityY, 2, introCity.Plane)
 
     game.Events <- gamelib.StartingCityEvent(introCity)
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -515,7 +515,8 @@ func (player *Player) LiftFog(x int, y int, radius int, plane data.Plane){
                 continue
             }
 
-            if dx * dx + dy * dy <= radius * radius {
+            // dx^2 + dy^2 <= (radius + 0.5)^2
+            if 4 * (dx * dx + dy * dy) <= 4 * radius * radius + 4 * radius + 1 {
                 fog[mx][my] = true
             }
         }


### PR DESCRIPTION
I noticed some things in the overworld fog:
- The sprite for the west edge is wrong
- Using the west edge for east edge is not working
- The inital fog is a bit to small

This is the sprites from the [steam version](https://store.steampowered.com/app/1146370/Master_of_Magic_Classic/):
<img width="1013" alt="sprites" src="https://github.com/user-attachments/assets/7969e814-1d4c-4ad2-868f-6dc8273b2388" />

This is what it looks currently:
<img width="672" alt="initial" src="https://github.com/user-attachments/assets/27c22de1-df2c-46cb-b98f-d5668eac7e3b" />

This is what the [original](https://playclassic.games/games/4x-dos-games-online/play-master-of-magic-online/play/) looks like:
<img width="443" alt="original" src="https://github.com/user-attachments/assets/f1e3cd6d-9b1c-47d0-b4aa-a96814e3ebf2" />

This is what it looks like with the changes:
<img width="544" alt="changed" src="https://github.com/user-attachments/assets/d355f0a5-9670-44ec-b6b0-95273b258c68" />


Changes made:
- Fix sprite index for west edge
- Load and use sprite for east edge
- Removed commented-out code as this works otherwise very well
- Lower the threshold for lifting the fog by using `radius + 0.5` instead of `radius`
- Adapted the radius for initial city view and unit movement