### PR TITLE
artifact: add autogenerated names

### DIFF
--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -65,7 +65,7 @@ func getName(artifact *Artifact, customName string) string {
         case artifact.ResistanceBonus() != 0: postfix = " of Protection"
         case artifact.MovementBonus() != 0: postfix = " of Speed"
         case artifact.ToHitBonus() != 0: postfix = " of Accuracy"
-        case artifact.DefenseBonus() != 0: postfix = " of Defense"
+        case artifact.HasDefensePower(): postfix = " of Defense"
     }
 
     return prefix + base + postfix

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -25,7 +25,7 @@ const (
     CreationCreateArtifact
 )
 
-func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, nameFont *font.Font, powerFont *font.Font, artifactType ArtifactType, picLow int, picHigh int, powerGroups [][]Power, artifact *Artifact) []*uilib.UIElement {
+func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, nameFont *font.Font, powerFont *font.Font, artifactType ArtifactType, picLow int, picHigh int, powerGroups [][]Power, artifact *Artifact, customName *string) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
     artifact.Image = picLow
@@ -102,19 +102,17 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
             nameFocused = false
         },
         TextEntry: func(element *uilib.UIElement, text string) string {
-            /*
-            for _, r := range char {
-                if len(artifact.Name) < 25 {
-                    artifact.Name += string(r)
-                }
-            }
-            */
-            artifact.Name = text
-            if len(artifact.Name) > 25 {
-                artifact.Name = artifact.Name[0:25]
+            newName := text
+            if len(newName) > 25 {
+                newName = newName[0:25]
             }
 
-            return artifact.Name
+            if artifact.Name != newName {
+                artifact.Name = newName
+                *customName = newName
+            }
+
+            return newName
         },
         HandleKeys: func(keys []ebiten.Key){
             u := false
@@ -788,6 +786,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
     ui.SetElementsFromArray(nil)
 
     var currentArtifact *Artifact
+    var customName string
 
     type PowerArtifact struct {
         Elements []*uilib.UIElement
@@ -801,7 +800,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
     makePowers := func(picLow int, picHigh int, artifactType ArtifactType, groups [][]Power) PowerArtifact {
         var artifact Artifact
         artifact.Type = artifactType
-        elements := makePowersFull(ui, cache, &imageCache, nameFont, powerFont, artifactType, picLow, picHigh, groups, &artifact)
+        elements := makePowersFull(ui, cache, &imageCache, nameFont, powerFont, artifactType, picLow, picHigh, groups, &artifact, &customName)
         return PowerArtifact{
             Elements: elements,
             Artifact: &artifact,
@@ -826,6 +825,9 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
 
         ui.AddElements(powers[index].Elements)
         currentArtifact = powers[index].Artifact
+        if customName != "" {
+            currentArtifact.Name = customName
+        }
     }
 
     var selectedButton *uilib.UIElement

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -60,11 +60,11 @@ func getName(artifact *Artifact, customName string) string {
     switch {
         // TODO: Spell Charges: " of {Spell Name} x4"
         // TODO: Ability: " of {Ability Name}" (probably ability with the highest cost)
-        case artifact.SpellSaveBonus() != 0: postfix = " of Power"
-        case artifact.SpellSkillBonus() != 0: postfix = " of Wizardry"
-        case artifact.ResistanceBonus() != 0: postfix = " of Protection"
-        case artifact.MovementBonus() != 0: postfix = " of Speed"
-        case artifact.ToHitBonus() != 0: postfix = " of Accuracy"
+        case artifact.HasSpellSavePower(): postfix = " of Power"
+        case artifact.HasSpellSkillPower(): postfix = " of Wizardry"
+        case artifact.HasResistancePower(): postfix = " of Protection"
+        case artifact.HasMovementPower(): postfix = " of Speed"
+        case artifact.HasToHitPower(): postfix = " of Accuracy"
         case artifact.HasDefensePower(): postfix = " of Defense"
     }
 

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -342,6 +342,15 @@ func (artifact *Artifact) RangedAttackBonus() int {
     }
 }
 
+func (artifact *Artifact) MagicAttackBonus() int {
+    switch artifact.Type {
+        case ArtifactTypeWand, ArtifactTypeStaff, ArtifactTypeMisc:
+            return addPowers[*PowerAttack](artifact.Powers)
+        default:
+            return 0
+    }
+}
+
 func (artifact *Artifact) DefenseBonus() int {
     base := addPowers[*PowerDefense](artifact.Powers)
     switch artifact.Type {
@@ -354,8 +363,24 @@ func (artifact *Artifact) DefenseBonus() int {
     return base
 }
 
+func (artifact *Artifact) ToHitBonus() int {
+    return addPowers[*PowerToHit](artifact.Powers)
+}
+
+func (artifact *Artifact) SpellSkillBonus() int {
+    return addPowers[*PowerSpellSkill](artifact.Powers)
+}
+
+func (artifact *Artifact) SpellSaveBonus() int {
+    return addPowers[*PowerSpellSave](artifact.Powers)
+}
+
 func (artifact *Artifact) ResistanceBonus() int {
     return addPowers[*PowerResistance](artifact.Powers)
+}
+
+func (artifact *Artifact) MovementBonus() int {
+    return addPowers[*PowerMovement](artifact.Powers)
 }
 
 func (artifact *Artifact) Cost() int {

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -378,6 +378,26 @@ func (artifact *Artifact) HasDefensePower() bool {
     return hasPower[*PowerDefense](artifact.Powers)
 }
 
+func (artifact *Artifact) HasSpellSavePower() bool {
+    return hasPower[*PowerSpellSave](artifact.Powers)
+}
+
+func (artifact *Artifact) HasSpellSkillPower() bool {
+    return hasPower[*PowerSpellSkill](artifact.Powers)
+}
+
+func (artifact *Artifact) HasResistancePower() bool {
+    return hasPower[*PowerResistance](artifact.Powers)
+}
+
+func (artifact *Artifact) HasMovementPower() bool {
+    return hasPower[*PowerMovement](artifact.Powers)
+}
+
+func (artifact *Artifact) HasToHitPower() bool {
+    return hasPower[*PowerToHit](artifact.Powers)
+}
+
 func (artifact *Artifact) ToHitBonus() int {
     return addPowers[*PowerToHit](artifact.Powers)
 }

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -312,6 +312,17 @@ func (artifact *Artifact) RemovePower(remove Power) {
     })
 }
 
+func hasPower[T Power](powers []Power) bool {
+    for _, power := range powers {
+        _, ok := power.(T)
+        if ok {
+            return true
+        }
+    }
+
+    return false
+}
+
 func addPowers[T Power](powers []Power) int {
     amount := 0
     for _, power := range powers {
@@ -361,6 +372,10 @@ func (artifact *Artifact) DefenseBonus() int {
     }
 
     return base
+}
+
+func (artifact *Artifact) HasDefensePower() bool {
+    return hasPower[*PowerDefense](artifact.Powers)
 }
 
 func (artifact *Artifact) ToHitBonus() int {


### PR DESCRIPTION
Adds autogeneration of artifact names.

Names are generated as in the original game based on the selected powers, for example "+3 Orb of Power". Names change when changing powers and/or (misc) icons. Once a name has been changed manually, autogeneration is disabled.

Names of abilities and spells are not implemented yet.

I also added more `XYZBonus` functions, but I'm not sure if this fits your plans (especially regarding magic ranged attack).