### PR TITLE
overland: zoom in/out using mouse wheel/trackpad

### DIFF
--- a/TODO
+++ b/TODO
@@ -63,4 +63,4 @@
 12/28/2024 * parse itemdata.lbx to get pre-made items
 12/31/2024 * combat: implement city walls
 1/4/2025 * city enchantments in overland
-??? * overworld: zoom in/out
+1/6/2025 * overworld: zoom in/out

--- a/TODO
+++ b/TODO
@@ -11,7 +11,6 @@
 * city enchantments in overland
 * overworld: ai controlled wizards/empires
 * combat: implement boulder ranged attacks
-* overworld: zoom in/out
 * combat: town damage, destroy buildings/people after a battle
 * combat: implement flying fortress
 
@@ -62,3 +61,4 @@
 12/28/2024 * combat: implement wall of darkness
 12/28/2024 * parse itemdata.lbx to get pre-made items
 12/31/2024 * combat: implement city walls
+??? * overworld: zoom in/out

--- a/game/magic/camera/camera.go
+++ b/game/magic/camera/camera.go
@@ -50,6 +50,12 @@ func (camera *Camera) GetZoomedY() float64 {
     return camera.GetOffsetY() - float64(camera.SizeY) / 2 / camera.GetAnimatedZoom()
 }
 
+func (camera *Camera) GetZoomedMaxY() float64 {
+    // FIXME: not sure why +1 is needed here. it doesn't fully solve the problem of there being
+    // a gap at the bottom of the map sometimes
+    return camera.GetOffsetY() + float64(camera.SizeY+1) / 2 / camera.GetAnimatedZoom()
+}
+
 func (camera *Camera) GetX() int {
     return camera.X
 }

--- a/game/magic/camera/camera.go
+++ b/game/magic/camera/camera.go
@@ -1,0 +1,83 @@
+package camera
+
+const ZoomMin = 3
+const ZoomMax = 10
+const ZoomDefault = 10
+const ZoomStep = 10
+
+type Camera struct {
+    // tile coordinates
+    X int
+    Y int
+    // fractional tile coordinates
+    DX float64
+    DY float64
+
+    Zoom int
+    AnimatedZoom float64
+}
+
+func (camera *Camera) SetOffset(x float64, y float64) {
+    camera.DX = x
+    camera.DY = y
+}
+
+func (camera *Camera) GetOffsetX() float64 {
+    return float64(camera.X) + camera.DX
+}
+
+func (camera *Camera) GetOffsetY() float64 {
+    return float64(camera.Y) + camera.DY
+}
+
+func (camera *Camera) GetZoom() float64 {
+    return camera.GetAnimatedZoom()
+    // return float64(camera.Zoom) / float64(ZoomStep)
+}
+
+func (camera *Camera) GetAnimatedZoom() float64 {
+    return ((float64(camera.Zoom) + camera.AnimatedZoom) / float64(ZoomStep))
+}
+
+func (camera *Camera) GetZoomedX() float64 {
+    return camera.GetOffsetX() - 6.0 / camera.GetAnimatedZoom()
+}
+
+func (camera *Camera) GetZoomedY() float64 {
+    return camera.GetOffsetY() - 5.0 / camera.GetAnimatedZoom()
+}
+
+func (camera *Camera) GetX() int {
+    return camera.X
+}
+
+func (camera *Camera) GetY() int {
+    return camera.Y
+}
+
+func (camera *Camera) Move(dx int, dy int) {
+    camera.X += dx
+    camera.Y += dy
+}
+
+func (camera *Camera) Center(x int, y int) {
+    camera.X = x
+    camera.Y = y
+
+    if camera.Y < 0 {
+        camera.Y = 0
+    }
+}
+
+func MakeCamera() Camera {
+    return MakeCameraAt(0, 0)
+}
+
+func MakeCameraAt(x int, y int) Camera {
+    return Camera{
+        X: x,
+        Y: y,
+        Zoom: ZoomDefault,
+        AnimatedZoom: 0,
+    }
+}

--- a/game/magic/camera/camera.go
+++ b/game/magic/camera/camera.go
@@ -69,6 +69,17 @@ func (camera *Camera) Center(x int, y int) {
     }
 }
 
+// return the bounds of a rectangle upper left (x1, y1) and lower right (x2, y2)
+// all tiles within these bounds are visible, with some margin of error to account for edges
+func (camera *Camera) GetTileBounds() (int, int, int, int) {
+    minX := int(camera.GetZoomedX() - 1)
+    minY := int(camera.GetZoomedY() - 1)
+    maxX := minX + int(12/camera.GetZoom() + 3)
+    maxY := minY + int(12/camera.GetZoom() + 3)
+
+    return minX, minY, maxX, maxY
+}
+
 func MakeCamera() Camera {
     return MakeCameraAt(0, 0)
 }

--- a/game/magic/camera/camera.go
+++ b/game/magic/camera/camera.go
@@ -15,6 +15,9 @@ type Camera struct {
 
     Zoom int
     AnimatedZoom float64
+
+    SizeX int
+    SizeY int
 }
 
 func (camera *Camera) SetOffset(x float64, y float64) {
@@ -40,11 +43,11 @@ func (camera *Camera) GetAnimatedZoom() float64 {
 }
 
 func (camera *Camera) GetZoomedX() float64 {
-    return camera.GetOffsetX() - 6.0 / camera.GetAnimatedZoom()
+    return camera.GetOffsetX() - float64(camera.SizeX) / 2 / camera.GetAnimatedZoom()
 }
 
 func (camera *Camera) GetZoomedY() float64 {
-    return camera.GetOffsetY() - 5.0 / camera.GetAnimatedZoom()
+    return camera.GetOffsetY() - float64(camera.SizeY) / 2 / camera.GetAnimatedZoom()
 }
 
 func (camera *Camera) GetX() int {
@@ -74,10 +77,17 @@ func (camera *Camera) Center(x int, y int) {
 func (camera *Camera) GetTileBounds() (int, int, int, int) {
     minX := int(camera.GetZoomedX() - 1)
     minY := int(camera.GetZoomedY() - 1)
+    // FIXME: 12 should be based on SizeX/SizeY
     maxX := minX + int(12/camera.GetZoom() + 3)
     maxY := minY + int(12/camera.GetZoom() + 3)
 
     return minX, minY, maxX, maxY
+}
+
+func (camera Camera) UpdateSize(sizeX int, sizeY int) Camera {
+    camera.SizeX = sizeX
+    camera.SizeY = sizeY
+    return camera
 }
 
 func MakeCamera() Camera {
@@ -88,6 +98,9 @@ func MakeCameraAt(x int, y int) Camera {
     return Camera{
         X: x,
         Y: y,
+        // default size of screen
+        SizeX: 12,
+        SizeY: 10,
         Zoom: ZoomDefault,
         AnimatedZoom: 0,
     }

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -2253,15 +2253,7 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
 
     // FIXME: handle right-click drag to move the camera
 
-    _, wheelY := ebiten.Wheel()
-
-    // on browsers, wheelY tends to be a very large number, which results in crazy zoom levels
-    // So just check if wheelY is positive or negative and use a zoom of 1/-1
-    if wheelY > 0 {
-        wheelY = 1
-    } else if wheelY < 0 {
-        wheelY = -1
-    }
+    _, wheelY := inputmanager.Wheel()
 
     wheelScale := 1 + float64(wheelY) / 10
     combat.CameraScale *= wheelScale

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -222,6 +222,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     })
 
     game.Drawer = func(screen *ebiten.Image, game *Game){
+        overworld.Zoom = game.GetAnimatedZoom()
         overworld.DrawOverworld(screen, ebiten.GeoM{})
 
         var miniGeom ebiten.GeoM
@@ -235,19 +236,21 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
         ui.Draw(ui, screen)
     }
 
+    var moveCounter uint64
     moveCamera := image.Pt(game.cameraX, game.cameraY)
     for !quit {
+        moveCounter += 1
         if game.GetZoom() > 0.9 {
             overworld.Counter += 1
         }
 
-        zoomed := game.doInputZoom()
-        overworld.Zoom = game.GetZoom()
+        zoomed := game.doInputZoom(yield)
+        _ = zoomed
         ui.StandardUpdate()
 
         x, y := inputmanager.MousePosition()
 
-        if overworld.Counter % 5 == 0 && (moveCamera.X != game.cameraX || moveCamera.Y != game.cameraY) {
+        if moveCounter % 5 == 0 && (moveCamera.X != game.cameraX || moveCamera.Y != game.cameraY) {
             if moveCamera.X < game.cameraX {
                 game.cameraX -= 1
             } else if moveCamera.X > game.cameraX {
@@ -273,7 +276,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
             // right click should move the camera
             rightClick := inputmanager.RightClick()
-            if rightClick || zoomed {
+            if rightClick /*|| zoomed */ {
                 moveCamera = newPoint.Add(image.Pt(-5, -5))
                 if moveCamera.Y < 0 {
                     moveCamera.Y = 0

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -237,7 +237,9 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
     moveCamera := image.Pt(game.cameraX, game.cameraY)
     for !quit {
-        overworld.Counter += 1
+        if game.GetZoom() > 0.9 {
+            overworld.Counter += 1
+        }
 
         game.doInputZoom()
         overworld.Zoom = game.GetZoom()

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -294,7 +294,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     }
 
     var moveCounter uint64
-    moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
+    // moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
     for !quit {
         moveCounter += 1
         if game.Camera.GetZoom() > 0.9 {
@@ -307,6 +307,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
         x, y := inputmanager.MousePosition()
 
+        /*
         if moveCounter % 5 == 0 && (moveCamera.X != game.Camera.GetX() || moveCamera.Y != game.Camera.GetY()) {
             if moveCamera.X < game.Camera.GetX() {
                 game.Camera.Move(-1, 0)
@@ -320,11 +321,12 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                 game.Camera.Move(0, 1)
             }
 
-            /*
+            / *
             overworld.CameraX = float64(game.Camera.GetX())
             overworld.CameraY = float64(game.Camera.GetY())
-            */
+            * /
         }
+        */
 
         // within the viewable area
         if x < 240 && y > 18 {
@@ -333,11 +335,12 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
             newX := game.cameraX + realX
             newY := game.cameraY + realY
             */
-            newPoint := image.Pt(newX, newY)
+            // newPoint := image.Pt(newX, newY)
 
             // right click should move the camera
             rightClick := inputmanager.RightClick()
             if rightClick /*|| zoomed */ {
+                /*
                 moveCamera = newPoint.Add(image.Pt(-5, -5))
                 if moveCamera.Y < 0 {
                     moveCamera.Y = 0
@@ -346,10 +349,12 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                 if moveCamera.Y >= game.CurrentMap().Height() - 11 {
                     moveCamera.Y = game.CurrentMap().Height() - 11
                 }
+                */
+                game.doMoveCamera(yield, newX, newY)
             }
 
             if inputmanager.LeftClick() {
-                tileX, tileY := game.ScreenToTile(float64(x), float64(y))
+                tileX, tileY := newX, newY
 
                 switch locationType {
                     case LocationTypeAny: return tileX, tileY, false

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -30,10 +30,12 @@ func (game *Game) doCastSpell(yield coroutine.YieldFunc, player *playerlib.Playe
                 return
             }
 
-            realX, realY := game.RealToTile(float64(screenX), float64(screenY))
+            tileX, tileY := game.ScreenToTile(float64(screenX), float64(screenY))
 
+            /*
             tileX := game.CurrentMap().WrapX(game.cameraX + realX)
             tileY := game.cameraY + realY
+            */
             game.CenterCamera(tileX, tileY)
 
             game.doCastEarthLore(yield, player)
@@ -119,8 +121,8 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     whiteFont := makeWhiteFont(fonts)
 
     overworld := Overworld{
-        CameraX: game.cameraX,
-        CameraY: game.cameraY,
+        CameraX: float64(game.cameraX),
+        CameraY: float64(game.cameraY),
         Counter: game.Counter,
         Map: game.CurrentMap(),
         Cities: cities,
@@ -263,15 +265,17 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                 game.cameraY += 1
             }
 
-            overworld.CameraX = game.cameraX
-            overworld.CameraY = game.cameraY
+            overworld.CameraX = float64(game.cameraX)
+            overworld.CameraY = float64(game.cameraY)
         }
 
         // within the viewable area
         if x < 240 && y > 18 {
-            realX, realY := game.RealToTile(float64(x), float64(y))
+            newX, newY := game.ScreenToTile(float64(x), float64(y))
+            /*
             newX := game.cameraX + realX
             newY := game.cameraY + realY
+            */
             newPoint := image.Pt(newX, newY)
 
             // right click should move the camera

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -41,7 +41,7 @@ func (game *Game) doCastSpell(yield coroutine.YieldFunc, player *playerlib.Playe
                 return
             }
 
-            game.CenterCamera(tileX, tileY)
+            game.Camera.Center(tileX, tileY)
 
             game.doCastEarthLore(yield, player)
 
@@ -79,7 +79,7 @@ func (game *Game) doCastSpell(yield coroutine.YieldFunc, player *playerlib.Playe
                 return
             }
 
-            game.CenterCamera(tileX, tileY)
+            game.Camera.Center(tileX, tileY)
             chosenCity := player.FindCity(tileX, tileY)
             if chosenCity == nil {
                 return
@@ -169,8 +169,8 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     whiteFont := makeWhiteFont(fonts)
 
     overworld := Overworld{
-        CameraX: float64(game.cameraX),
-        CameraY: float64(game.cameraY),
+        CameraX: float64(game.Camera.GetX()),
+        CameraY: float64(game.Camera.GetY()),
         Counter: game.Counter,
         Map: game.CurrentMap(),
         Cities: cities,
@@ -296,7 +296,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     }
 
     var moveCounter uint64
-    moveCamera := image.Pt(game.cameraX, game.cameraY)
+    moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
     for !quit {
         moveCounter += 1
         if game.GetZoom() > 0.9 {
@@ -309,21 +309,21 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
         x, y := inputmanager.MousePosition()
 
-        if moveCounter % 5 == 0 && (moveCamera.X != game.cameraX || moveCamera.Y != game.cameraY) {
-            if moveCamera.X < game.cameraX {
-                game.cameraX -= 1
-            } else if moveCamera.X > game.cameraX {
-                game.cameraX += 1
+        if moveCounter % 5 == 0 && (moveCamera.X != game.Camera.GetX() || moveCamera.Y != game.Camera.GetY()) {
+            if moveCamera.X < game.Camera.GetX() {
+                game.Camera.Move(-1, 0)
+            } else if moveCamera.X > game.Camera.GetX() {
+                game.Camera.Move(1, 0)
             }
 
-            if moveCamera.Y < game.cameraY {
-                game.cameraY -= 1
-            } else if moveCamera.Y > game.cameraY {
-                game.cameraY += 1
+            if moveCamera.Y < game.Camera.GetY() {
+                game.Camera.Move(0, -1)
+            } else if moveCamera.Y > game.Camera.GetY() {
+                game.Camera.Move(0, 1)
             }
 
-            overworld.CameraX = float64(game.cameraX)
-            overworld.CameraY = float64(game.cameraY)
+            overworld.CameraX = float64(game.Camera.GetX())
+            overworld.CameraY = float64(game.Camera.GetY())
         }
 
         // within the viewable area

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -241,7 +241,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
             overworld.Counter += 1
         }
 
-        game.doInputZoom()
+        zoomed := game.doInputZoom()
         overworld.Zoom = game.GetZoom()
         ui.StandardUpdate()
 
@@ -273,7 +273,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
             // right click should move the camera
             rightClick := inputmanager.RightClick()
-            if rightClick {
+            if rightClick || zoomed {
                 moveCamera = newPoint.Add(image.Pt(-5, -5))
                 if moveCamera.Y < 0 {
                     moveCamera.Y = 0

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -293,10 +293,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
         ui.Draw(ui, screen)
     }
 
-    var moveCounter uint64
-    // moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
     for !quit {
-        moveCounter += 1
         if game.Camera.GetZoom() > 0.9 {
             overworld.Counter += 1
         }
@@ -307,55 +304,17 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
         x, y := inputmanager.MousePosition()
 
-        /*
-        if moveCounter % 5 == 0 && (moveCamera.X != game.Camera.GetX() || moveCamera.Y != game.Camera.GetY()) {
-            if moveCamera.X < game.Camera.GetX() {
-                game.Camera.Move(-1, 0)
-            } else if moveCamera.X > game.Camera.GetX() {
-                game.Camera.Move(1, 0)
-            }
-
-            if moveCamera.Y < game.Camera.GetY() {
-                game.Camera.Move(0, -1)
-            } else if moveCamera.Y > game.Camera.GetY() {
-                game.Camera.Move(0, 1)
-            }
-
-            / *
-            overworld.CameraX = float64(game.Camera.GetX())
-            overworld.CameraY = float64(game.Camera.GetY())
-            * /
-        }
-        */
-
         // within the viewable area
         if x < 240 && y > 18 {
-            newX, newY := game.ScreenToTile(float64(x), float64(y))
-            /*
-            newX := game.cameraX + realX
-            newY := game.cameraY + realY
-            */
-            // newPoint := image.Pt(newX, newY)
-
+            tileX, tileY := game.ScreenToTile(float64(x), float64(y))
+            
             // right click should move the camera
             rightClick := inputmanager.RightClick()
             if rightClick /*|| zoomed */ {
-                /*
-                moveCamera = newPoint.Add(image.Pt(-5, -5))
-                if moveCamera.Y < 0 {
-                    moveCamera.Y = 0
-                }
-
-                if moveCamera.Y >= game.CurrentMap().Height() - 11 {
-                    moveCamera.Y = game.CurrentMap().Height() - 11
-                }
-                */
-                game.doMoveCamera(yield, newX, newY)
+                game.doMoveCamera(yield, tileX, tileY)
             }
 
             if inputmanager.LeftClick() {
-                tileX, tileY := newX, newY
-
                 switch locationType {
                     case LocationTypeAny: return tileX, tileY, false
                     case LocationTypeFriendlyCity:

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -169,8 +169,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     whiteFont := makeWhiteFont(fonts)
 
     overworld := Overworld{
-        CameraX: float64(game.Camera.GetX()),
-        CameraY: float64(game.Camera.GetY()),
+        Camera: game.Camera,
         Counter: game.Counter,
         Map: game.CurrentMap(),
         Cities: cities,
@@ -181,7 +180,6 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
         Fog: fog,
         ShowAnimation: game.State == GameStateUnitMoving,
         FogBlack: game.GetFogImage(),
-        Zoom: game.GetZoom(),
     }
 
     cancelBackground, _ := game.ImageCache.GetImage("main.lbx", 47, 0)
@@ -281,7 +279,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     })
 
     game.Drawer = func(screen *ebiten.Image, game *Game){
-        overworld.Zoom = game.GetAnimatedZoom()
+        overworld.Camera = game.Camera
         overworld.DrawOverworld(screen, ebiten.GeoM{})
 
         var miniGeom ebiten.GeoM
@@ -299,7 +297,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
     for !quit {
         moveCounter += 1
-        if game.GetZoom() > 0.9 {
+        if game.Camera.GetZoom() > 0.9 {
             overworld.Counter += 1
         }
 
@@ -322,8 +320,10 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                 game.Camera.Move(0, 1)
             }
 
+            /*
             overworld.CameraX = float64(game.Camera.GetX())
             overworld.CameraY = float64(game.Camera.GetY())
+            */
         }
 
         // within the viewable area

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2472,7 +2472,7 @@ func (game *Game) ScreenToTile(inX float64, inY float64) (int, int) {
     tileX /= float64(tileWidth)
     tileY /= float64(tileHeight)
 
-    log.Printf("relative tile %v, %v camera %v, %v", tileX, tileY, game.Camera.GetX(), game.Camera.GetY())
+    // log.Printf("relative tile %v, %v camera %v, %v", tileX, tileY, game.Camera.GetX(), game.Camera.GetY())
 
     // return int(tileX + float64(game.Camera.GetX())), int(tileY + float64(game.Camera.GetY()))
     return int(tileX), int(tileY)
@@ -4777,18 +4777,10 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
         return checkFog(x - 1, y + 1)
     }
 
-    /*
-    screenToTile := func(x int, y int) (int, int) {
-        ax, ay := geom.Apply(float64(x), float64(y))
-        return int(ax/float64(tileWidth)), int(ay/float64(tileHeight))
-    }
-    */
-
-    // minX, minY := screenToTile(0, 0)
     minX := int(overworld.Camera.GetZoomedX() - 1)
     minY := int(overworld.Camera.GetZoomedY() - 1)
-    maxX := minX + int(12/overworld.Camera.GetZoom() + 2)
-    maxY := minY + int(12/overworld.Camera.GetZoom() + 2)
+    maxX := minX + int(12/overworld.Camera.GetZoom() + 3)
+    maxY := minY + int(12/overworld.Camera.GetZoom() + 3)
 
     // log.Printf("fog min %v, %v max %v, %v", minX, minY, maxX, maxY)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4789,23 +4789,13 @@ func (overworld *Overworld) DrawMinimap(screen *ebiten.Image){
 }
 
 func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM){
-
-    // log.Printf("Overworld camera %v, %v", overworld.CameraX, overworld.CameraY)
-
-    /*
-    deltaX := overworld.CameraX - float64(int(overworld.CameraX))
-    deltaY := overworld.CameraY - float64(int(overworld.CameraY))
-    */
-
     tileWidth := overworld.Map.TileWidth()
     tileHeight := overworld.Map.TileHeight()
 
-    // geom.Translate((1-deltaX) * float64(tileWidth), (1-deltaY) * float64(tileHeight))
     geom.Translate(-overworld.Camera.GetZoomedX() * float64(tileWidth), -overworld.Camera.GetZoomedY() * float64(tileHeight))
     geom.Scale(overworld.Camera.GetAnimatedZoom(), overworld.Camera.GetAnimatedZoom())
-    // geom.Translate(0, 18)
 
-    overworld.Map.DrawLayer1(int(overworld.Camera.GetZoomedX()), int(overworld.Camera.GetZoomedY()), overworld.Counter / 8, overworld.ImageCache, screen, geom)
+    overworld.Map.DrawLayer1(overworld.Camera, overworld.Counter / 8, overworld.ImageCache, screen, geom)
 
     convertTileCoordinates := func(x int, y int) (int, int) {
         outX := x * tileWidth
@@ -4982,10 +4972,6 @@ func (game *Game) DrawGame(screen *ebiten.Image){
 
     overworld := Overworld{
         Camera: game.Camera,
-        /*
-        CameraX: game.Camera.GetOffsetX() - 6.0 / game.GetAnimatedZoom(),
-        CameraY: game.Camera.GetOffsetY() - 5.5 / game.GetAnimatedZoom(),
-        */
         Counter: useCounter,
         Map: game.CurrentMap(),
         Cities: cities,

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4624,50 +4624,52 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
             options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
             options.GeoM.Concat(geom)
 
-            if tileX >= 0 && tileY >= 0 && tileX < len(fog) && tileY < len(fog[tileX]) && fog[tileX][tileY] {
-                n := fogN(tileX, tileY)
-                e := fogE(tileX, tileY)
-                s := fogS(tileX, tileY)
-                w := fogW(tileX, tileY)
-                ne := fogNE(tileX, tileY)
-                se := fogSE(tileX, tileY)
-                nw := fogNW(tileX, tileY)
-                sw := fogSW(tileX, tileY)
+            if tileX >= 0 && tileY >= 0 && tileX < len(fog) && tileY < len(fog[tileX]) {
+                if fog[tileX][tileY] {
+                    n := fogN(tileX, tileY)
+                    e := fogE(tileX, tileY)
+                    s := fogS(tileX, tileY)
+                    w := fogW(tileX, tileY)
+                    ne := fogNE(tileX, tileY)
+                    se := fogSE(tileX, tileY)
+                    nw := fogNW(tileX, tileY)
+                    sw := fogSW(tileX, tileY)
 
-                if n && e {
-                    screen.DrawImage(FogEdge_N_E, &options)
-                } else if n {
-                    screen.DrawImage(FogEdge_N, &options)
-                } else if e {
-                    screen.DrawImage(FogEdge_E, &options)
-                } else if ne {
-                    screen.DrawImage(FogCorner_NE, &options)
-                }
+                    if n && e {
+                        screen.DrawImage(FogEdge_N_E, &options)
+                    } else if n {
+                        screen.DrawImage(FogEdge_N, &options)
+                    } else if e {
+                        screen.DrawImage(FogEdge_E, &options)
+                    } else if ne {
+                        screen.DrawImage(FogCorner_NE, &options)
+                    }
 
-                if s && e {
-                    screen.DrawImage(FogEdge_S_E, &options)
-                } else if s {
-                    screen.DrawImage(FogEdge_S, &options)
-                } else if se {
-                    screen.DrawImage(FogCorner_SE, &options)
-                }
+                    if s && e {
+                        screen.DrawImage(FogEdge_S_E, &options)
+                    } else if s {
+                        screen.DrawImage(FogEdge_S, &options)
+                    } else if se {
+                        screen.DrawImage(FogCorner_SE, &options)
+                    }
 
-                if n && w {
-                    screen.DrawImage(FogEdge_N_W, &options)
-                } else if w {
-                    screen.DrawImage(FogEdge_W, &options)
-                } else if nw {
-                    screen.DrawImage(FogCorner_NW, &options)
-                }
+                    if n && w {
+                        screen.DrawImage(FogEdge_N_W, &options)
+                    } else if w {
+                        screen.DrawImage(FogEdge_W, &options)
+                    } else if nw {
+                        screen.DrawImage(FogCorner_NW, &options)
+                    }
 
-                if s && w {
-                    screen.DrawImage(FogEdge_S_W, &options)
-                } else if sw {
-                    screen.DrawImage(FogCorner_SW, &options)
-                }
-            } else {
-                if overworld.FogBlack != nil {
-                    screen.DrawImage(overworld.FogBlack, &options)
+                    if s && w {
+                        screen.DrawImage(FogEdge_S_W, &options)
+                    } else if sw {
+                        screen.DrawImage(FogCorner_SW, &options)
+                    }
+                } else {
+                    if overworld.FogBlack != nil {
+                        screen.DrawImage(overworld.FogBlack, &options)
+                    }
                 }
             }
         }
@@ -4699,6 +4701,9 @@ func (overworld *Overworld) DrawMinimap(screen *ebiten.Image){
 }
 
 func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM){
+
+    screen.Fill(color.RGBA{R: 32, G: 32, B: 32, A: 0xff})
+
     tileWidth := overworld.Map.TileWidth()
     tileHeight := overworld.Map.TileHeight()
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2913,7 +2913,7 @@ func (game *Game) doCityScreen(yield coroutine.YieldFunc, city *citylib.City, pl
     mapUse := game.GetMap(city.Plane)
 
     overworld := Overworld{
-        Camera: camera.MakeCameraAt(city.X+4, city.Y+3),
+        Camera: camera.MakeCameraAt(city.X, city.Y).UpdateSize(4, 4),
         Counter: 0,
         Map: mapUse,
         Cities: cities,

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2425,9 +2425,24 @@ func (game *Game) doInputZoom(yield coroutine.YieldFunc) bool {
 }
 
 func (game *Game) doMoveCamera(yield coroutine.YieldFunc, x int, y int) {
+    camera := game.Camera
+
+    camera.Center(x, y)
+    for camera.GetZoomedY() < 0 {
+        y += 1
+        camera.Center(x, y)
+    }
+
+    for camera.GetZoomedMaxY() >= float64(game.CurrentMap().Height()) {
+        y -= 1
+        camera.Center(x, y)
+    }
+
+    /*
     if y < 0 {
         y = 0
     }
+    */
 
     if y > game.CurrentMap().Height() {
         y = game.CurrentMap().Height()
@@ -2441,10 +2456,10 @@ func (game *Game) doMoveCamera(yield coroutine.YieldFunc, x int, y int) {
     angle_cos := math.Cos(angle)
     angle_sin := math.Sin(angle)
 
-    speed := 10
+    steps := 10
 
-    for i := range speed {
-        value := float64(i) / float64(speed) * math.Pi / 2
+    for i := range steps {
+        value := float64(i) / float64(steps) * math.Pi / 2
         magnitude := length * math.Sin(value)
         game.Camera.SetOffset(angle_cos * magnitude, angle_sin * magnitude)
         yield()

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4155,8 +4155,10 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
     tileWidth := overworld.Map.TileWidth()
     tileHeight := overworld.Map.TileHeight()
 
+    /*
     tilesPerRow := overworld.Map.TilesPerRow(screen.Bounds().Dx())
     tilesPerColumn := overworld.Map.TilesPerColumn(screen.Bounds().Dy())
+    */
     var options ebiten.DrawImageOptions
 
     fog := overworld.Fog
@@ -4203,14 +4205,28 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
     }
 
 
-    for x := 0; x < tilesPerRow; x++ {
-        for y := 0; y < tilesPerColumn; y++ {
+    x_loop:
+    for x := 0; x < overworld.Map.Width(); x++ {
+
+        y_loop:
+        for y := 0; y < overworld.Map.Height(); y++ {
 
             tileX := overworld.Map.WrapX(x + overworld.CameraX)
             tileY := y + overworld.CameraY
 
-            options.GeoM = geom
+            options.GeoM.Reset()
+            // options.GeoM = geom
             options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
+            options.GeoM.Concat(geom)
+
+            posX, posY := options.GeoM.Apply(0, 0)
+            if int(posX) > screen.Bounds().Max.X {
+                break x_loop
+            }
+
+            if int(posY) > screen.Bounds().Max.Y {
+                break y_loop
+            }
 
             if tileX >= 0 && tileY >= 0 && tileX < len(fog) && tileY < len(fog[tileX]) && fog[tileX][tileY] {
                 n := fogN(tileX, tileY)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -268,8 +268,8 @@ func (game *Game) MakeFog() [][]bool {
 }
 
 func (game *Game) CenterCamera(x int, y int){
-    game.cameraX = x - int(5.0 / (float64(game.OverlandZoom) / ZoomStep))
-    game.cameraY = y - int(5.0 / (float64(game.OverlandZoom) / ZoomStep))
+    game.cameraX = x - int(5.0 / game.GetZoom())
+    game.cameraY = y - int(5.0 / game.GetZoom())
 
     /*
     if game.cameraX < 0 {
@@ -2237,8 +2237,8 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
         // can only click into the area not hidden by the hud
         if mouseX < 240 && mouseY > 18 {
             // log.Printf("Click at %v, %v", mouseX, mouseY)
-            tileX := game.CurrentMap().WrapX(game.cameraX + int(float64(mouseX) / float64(mapUse.TileWidth()) / (float64(game.OverlandZoom) / float64(ZoomStep))))
-            tileY := game.cameraY + int(float64(mouseY) / float64(mapUse.TileHeight()) / (float64(game.OverlandZoom) / float64(ZoomStep)))
+            tileX := game.CurrentMap().WrapX(game.cameraX + int(float64(mouseX) / float64(mapUse.TileWidth()) / game.GetZoom()))
+            tileY := game.cameraY + int(float64(mouseY) / float64(mapUse.TileHeight()) / game.GetZoom())
 
             game.CenterCamera(tileX, tileY)
 
@@ -2444,6 +2444,7 @@ func (game *Game) doCityScreen(yield coroutine.YieldFunc, city *citylib.City, pl
         Fog: fog,
         ShowAnimation: false,
         FogBlack: game.GetFogImage(),
+        Zoom: 1,
     }
 
     oldDrawer := game.Drawer
@@ -2459,6 +2460,10 @@ func (game *Game) doCityScreen(yield coroutine.YieldFunc, city *citylib.City, pl
     }
 
     game.Drawer = oldDrawer
+}
+
+func (game *Game) GetZoom() float64 {
+    return float64(game.OverlandZoom) / float64(ZoomStep)
 }
 
 func (game *Game) confirmMagicNodeEncounter(yield coroutine.YieldFunc, node *maplib.ExtraMagicNode) bool {
@@ -4435,7 +4440,7 @@ func (game *Game) DrawGame(screen *ebiten.Image){
         Fog: fog,
         ShowAnimation: game.State == GameStateUnitMoving,
         FogBlack: game.GetFogImage(),
-        Zoom: float64(game.OverlandZoom) / float64(ZoomStep),
+        Zoom: game.GetZoom(),
     }
 
     overworld.DrawOverworld(screen, ebiten.GeoM{})

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1389,8 +1389,8 @@ func (game *Game) showMovement(yield coroutine.YieldFunc, oldX int, oldY int, st
     tileHeight := float64(game.CurrentMap().TileHeight())
 
     convertTileCoordinates := func(x float64, y float64) (float64, float64) {
-        outX := (x - float64(game.cameraX)) * tileWidth
-        outY := (y - float64(game.cameraY)) * tileHeight
+        outX := (x) * tileWidth
+        outY := (y) * tileHeight
         return outX, outY
     }
 
@@ -1403,7 +1403,13 @@ func (game *Game) showMovement(yield coroutine.YieldFunc, oldX int, oldY int, st
 
     boot, _ := game.ImageCache.GetImage("compix.lbx", 72, 0)
 
-    zoom := game.GetZoom()
+    var geom ebiten.GeoM
+
+    cameraX := float64(game.cameraX) - 6.0 / game.GetAnimatedZoom()
+    cameraY := float64(game.cameraY) - 5.5 / game.GetAnimatedZoom()
+
+    geom.Translate(-cameraX * float64(tileWidth), -cameraY * float64(tileHeight))
+    geom.Scale(game.GetAnimatedZoom(), game.GetAnimatedZoom())
 
     game.Drawer = func (screen *ebiten.Image, game *Game){
         drawer(screen, game)
@@ -1415,7 +1421,7 @@ func (game *Game) showMovement(yield coroutine.YieldFunc, oldX int, oldY int, st
             options.GeoM.Translate(x, y)
             options.GeoM.Translate(float64(tileWidth) / 2, float64(tileHeight) / 2)
             options.GeoM.Translate(float64(boot.Bounds().Dx()) / -2, float64(boot.Bounds().Dy()) / -2)
-            options.GeoM.Scale(zoom, zoom)
+            options.GeoM.Concat(geom)
             screen.DrawImage(boot, &options)
         }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -168,7 +168,7 @@ const (
 )
 
 const ZoomMin = 3
-const ZoomMax = 20
+const ZoomMax = 10
 const ZoomDefault = 10
 const ZoomStep = 10
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -221,11 +221,6 @@ type Game struct {
     Players []*playerlib.Player
     CurrentPlayer int
 
-    /*
-    OverlandZoom int
-    AnimatedZoom float64
-    */
-
     Camera camera.Camera
 }
 
@@ -280,34 +275,6 @@ func (game *Game) MakeFog() [][]bool {
     }
 
     return fog
-}
-
-func (game *Game) CenterCamera2(x int, y int){
-    /*
-    game.cameraX = x - int(5.0 / game.GetZoom())
-    game.cameraY = y - int(5.0 / game.GetZoom())
-    */
-
-    /*
-    game.cameraX = x
-    game.cameraY = y
-    */
-
-    /*
-    if game.cameraX < 0 {
-        game.cameraX = 0
-    }
-    */
-
-    /*
-    if game.cameraY < 0 {
-        game.cameraY = 0
-    }
-
-    if game.cameraY >= game.CurrentMap().Height() - 11 {
-        game.cameraY = game.CurrentMap().Height() - 11
-    }
-    */
 }
 
 /* initial casting skill power is computed as follows:
@@ -2363,10 +2330,7 @@ func (game *Game) ScreenToTile(inX float64, inY float64) (int, int) {
     var geom ebiten.GeoM
 
     camera := game.Camera
-    // camera.Center(-6, 5)
 
-    // geom.Translate((1-deltaX) * float64(tileWidth), (1-deltaY) * float64(tileHeight))
-    // geom.Translate(-camera.GetZoomedX() * float64(tileWidth), -camera.GetZoomedY() * float64(tileHeight))
     /*
     geom.Translate(6, 5)
     geom.Scale(float64(tileWidth), float64(tileHeight))
@@ -2377,7 +2341,7 @@ func (game *Game) ScreenToTile(inX float64, inY float64) (int, int) {
     geom.Scale(camera.GetAnimatedZoom(), camera.GetAnimatedZoom())
 
     geom.Invert()
-    // tileX, tileY := geom.Apply(float64(inX)/float64(tileWidth) * camera.GetAnimatedZoom(), float64(inY)/float64(tileHeight) * camera.GetAnimatedZoom())
+
     tileX, tileY := geom.Apply(inX, inY)
 
     tileX /= float64(tileWidth)
@@ -2387,19 +2351,6 @@ func (game *Game) ScreenToTile(inX float64, inY float64) (int, int) {
 
     // return int(tileX + float64(game.Camera.GetX())), int(tileY + float64(game.Camera.GetY()))
     return int(tileX), int(tileY)
-
-    /*
-    realX := int(inX / float64(game.CurrentMap().TileWidth()) / game.Camera.GetZoom())
-    realY := int(inY / float64(game.CurrentMap().TileHeight()) / game.Camera.GetZoom())
-
-    // tileX := game.CurrentMap().WrapX(game.cameraX + realX - int(240 / float64(game.CurrentMap().TileWidth()) / game.GetZoom() / 2))
-    tileX := game.Camera.GetX() + realX - int(240 / float64(game.CurrentMap().TileWidth()) / game.Camera.GetZoom() / 2)
-    // tileY := game.Camera.GetY() + realY - int(math.Round(float64(data.ScreenHeight) / float64(game.CurrentMap().TileHeight()) / game.Camera.GetZoom() / 2))
-    // tileY := game.Camera.GetY() + realY - int(float64(data.ScreenHeight) / float64(game.CurrentMap().TileHeight()) / game.Camera.GetZoom() / 2)
-    tileY := game.Camera.GetY() + realY - int(float64(data.ScreenHeight) / float64(game.CurrentMap().TileHeight()) / game.Camera.GetZoom() / 2)
-
-    return tileX, tileY
-    */
 }
 
 func (game *Game) doInputZoom(yield coroutine.YieldFunc) bool {
@@ -2696,12 +2647,7 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
 
             // log.Printf("height %v tile height %v", data.ScreenHeight, game.CurrentMap().TileHeight())
 
-            /*
-            tileX := game.CurrentMap().WrapX(game.cameraX + realX - int(240 / float64(game.CurrentMap().TileWidth()) / game.GetZoom() / 2))
-            tileY := game.cameraY + realY - int(math.Round(float64(data.ScreenHeight) / float64(game.CurrentMap().TileHeight()) / game.GetZoom() / 2))
-            */
-
-            log.Printf("Click at %v, %v -> %v, %v", mouseX, mouseY, tileX, tileY)
+            // log.Printf("Click at %v, %v -> %v, %v", mouseX, mouseY, tileX, tileY)
 
             game.doMoveCamera(yield, tileX, tileY)
             tileX = game.CurrentMap().WrapX(tileX)
@@ -2759,19 +2705,6 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
     }
 }
 
-/*
-func (game *Game) UpdateZoom() {
-    epsilon := 0.1
-    if game.AnimatedZoom >= epsilon {
-        game.AnimatedZoom -= epsilon
-    } else if game.AnimatedZoom <= -epsilon {
-        game.AnimatedZoom += epsilon
-    } else {
-        game.AnimatedZoom = 0
-    }
-}
-*/
-
 func (game *Game) Update(yield coroutine.YieldFunc) GameState {
     game.Counter += 1
 
@@ -2780,8 +2713,6 @@ func (game *Game) Update(yield coroutine.YieldFunc) GameState {
         log.Printf("TPS: %v FPS: %v", ebiten.ActualTPS(), ebiten.ActualFPS())
     }
     */
-
-    // game.UpdateZoom()
 
     game.ProcessEvents(yield)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4882,7 +4882,7 @@ func (overworld *Overworld) ToCameraCoordinates(x int, y int) (int, int) {
 }
 
 func (overworld *Overworld) DrawMinimap(screen *ebiten.Image){
-    overworld.Map.DrawMinimap(screen, overworld.CitiesMiniMap, int(overworld.Camera.GetX() + 5), int(overworld.Camera.GetY() + 5), overworld.Camera.GetZoom(), overworld.Fog, overworld.Counter, true)
+    overworld.Map.DrawMinimap(screen, overworld.CitiesMiniMap, overworld.Camera.GetX(), overworld.Camera.GetY(), overworld.Camera.GetZoom(), overworld.Fog, overworld.Counter, true)
 }
 
 func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM){

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4970,13 +4970,16 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
             var options ebiten.DrawImageOptions
             // options.GeoM = geom
 
+            /*
             stackX := float64(overworld.Map.XDistance(overworld.Camera.GetX(), stack.X()) + overworld.Camera.GetX())
             stackY := float64(stack.Y())
+            */
+            stackX, stackY := overworld.ToCameraCoordinates(stack.X(), stack.Y())
 
             // log.Printf("World %v, %v -> camera %v, %v. Camera: %v, %v", stack.X(), stack.Y(), stackX, stackY, overworld.Camera.GetX(), overworld.Camera.GetY())
 
             // x, y := convertTileCoordinates(stackX, stackY)
-            x, y := stackX, stackY
+            x, y := float64(stackX), float64(stackY)
 
             // nx := overworld.Map.WrapX(x - overworld.Camera.GetX()) + overworld.Camera.GetX() + 6
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4460,10 +4460,15 @@ func (game *Game) DrawGame(screen *ebiten.Image){
         }
     }
 
+    useCounter := game.Counter
+    if game.GetZoom() < 0.9 {
+        useCounter = 1
+    }
+
     overworld := Overworld{
         CameraX: game.cameraX,
         CameraY: game.cameraY,
-        Counter: game.Counter,
+        Counter: useCounter,
         Map: game.CurrentMap(),
         Cities: cities,
         CitiesMiniMap: citiesMiniMap,

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -268,8 +268,8 @@ func (game *Game) MakeFog() [][]bool {
 }
 
 func (game *Game) CenterCamera(x int, y int){
-    game.cameraX = x - 5
-    game.cameraY = y - 5
+    game.cameraX = x - int(5.0 / (float64(game.OverlandZoom) / ZoomStep))
+    game.cameraY = y - int(5.0 / (float64(game.OverlandZoom) / ZoomStep))
 
     /*
     if game.cameraX < 0 {
@@ -702,7 +702,7 @@ func (game *Game) doCityListView(yield coroutine.YieldFunc) {
     }
 
     drawMinimap := func (screen *ebiten.Image, x int, y int, fog [][]bool, counter uint64){
-        game.CurrentMap().DrawMinimap(screen, citiesMiniMap, x, y, fog, counter, false)
+        game.CurrentMap().DrawMinimap(screen, citiesMiniMap, x, y, 1, fog, counter, false)
     }
 
     var showCity *citylib.City
@@ -749,7 +749,7 @@ func (game *Game) doArmyView(yield coroutine.YieldFunc) {
     }
 
     drawMinimap := func (screen *ebiten.Image, x int, y int, fog [][]bool, counter uint64){
-        game.CurrentMap().DrawMinimap(screen, citiesMiniMap, x, y, fog, counter, false)
+        game.CurrentMap().DrawMinimap(screen, citiesMiniMap, x, y, 1, fog, counter, false)
     }
 
     showVault := func(){
@@ -2237,8 +2237,8 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
         // can only click into the area not hidden by the hud
         if mouseX < 240 && mouseY > 18 {
             // log.Printf("Click at %v, %v", mouseX, mouseY)
-            tileX := game.CurrentMap().WrapX(game.cameraX + mouseX / mapUse.TileWidth())
-            tileY := game.cameraY + mouseY / mapUse.TileHeight()
+            tileX := game.CurrentMap().WrapX(game.cameraX + int(float64(mouseX) / float64(mapUse.TileWidth()) / (float64(game.OverlandZoom) / float64(ZoomStep))))
+            tileY := game.cameraY + int(float64(mouseY) / float64(mapUse.TileHeight()) / (float64(game.OverlandZoom) / float64(ZoomStep)))
 
             game.CenterCamera(tileX, tileY)
 
@@ -4276,7 +4276,7 @@ type Overworld struct {
 }
 
 func (overworld *Overworld) DrawMinimap(screen *ebiten.Image){
-    overworld.Map.DrawMinimap(screen, overworld.CitiesMiniMap, overworld.CameraX + 5, overworld.CameraY + 5, overworld.Fog, overworld.Counter, true)
+    overworld.Map.DrawMinimap(screen, overworld.CitiesMiniMap, overworld.CameraX + 5, overworld.CameraY + 5, overworld.Zoom, overworld.Fog, overworld.Counter, true)
 }
 
 func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM){

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -167,10 +167,10 @@ const (
     GameStateQuit
 )
 
-const ZoomMin = 1
-const ZoomMax = 200
-const ZoomDefault = 100
-const ZoomStep = 100
+const ZoomMin = 3
+const ZoomMax = 20
+const ZoomDefault = 10
+const ZoomStep = 10
 
 type Game struct {
     Cache *lbx.LbxCache
@@ -4280,6 +4280,9 @@ func (overworld *Overworld) DrawMinimap(screen *ebiten.Image){
 }
 
 func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM){
+
+    geom.Scale(overworld.Zoom, overworld.Zoom)
+
     overworld.Map.DrawLayer1(overworld.CameraX, overworld.CameraY, overworld.Counter / 8, overworld.ImageCache, screen, geom)
 
     tileWidth := overworld.Map.TileWidth()
@@ -4309,12 +4312,13 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
         if err == nil {
             var options ebiten.DrawImageOptions
             x, y := convertTileCoordinates(city.X, city.Y)
-            options.GeoM = geom
+            // options.GeoM = geom
             // draw the city in the center of the tile
             // first compute center of tile
             options.GeoM.Translate(float64(x + tileWidth / 2.0), float64(y + tileHeight / 2.0))
             // then move the city image so that the center of the image is at the center of the tile
             options.GeoM.Translate(float64(-cityPic.Bounds().Dx()) / 2.0, float64(-cityPic.Bounds().Dy()) / 2.0)
+            options.GeoM.Concat(geom)
             screen.DrawImage(cityPic, &options)
 
             /*
@@ -4344,9 +4348,10 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
 
         if doDraw {
             var options ebiten.DrawImageOptions
-            options.GeoM = geom
+            // options.GeoM = geom
             x, y := convertTileCoordinates(stack.X(), stack.Y())
             options.GeoM.Translate(float64(x) + stack.OffsetX() * float64(tileWidth), float64(y) + stack.OffsetY() * float64(tileHeight))
+            options.GeoM.Concat(geom)
 
             leader := stack.Leader()
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -229,6 +229,10 @@ func (camera *Camera) Move(dx int, dy int) {
 func (camera *Camera) Center(x int, y int) {
     camera.X = x
     camera.Y = y
+
+    if camera.Y < 0 {
+        camera.Y = 0
+    }
 }
 
 func MakeCamera() Camera {
@@ -2432,12 +2436,7 @@ func (game *Game) ScreenToTile(inX float64, inY float64) (int, int) {
 func (game *Game) doInputZoom(yield coroutine.YieldFunc) bool {
     inputLoop:
     for {
-        _, wheelY := ebiten.Wheel()
-        if wheelY > 0 {
-            wheelY = 1
-        } else if wheelY < 0 {
-            wheelY = -1
-        }
+        _, wheelY := inputmanager.Wheel()
 
         // zoomSpeed := 5
         zoomSpeed2 := 7
@@ -2504,6 +2503,14 @@ func (game *Game) doInputZoom(yield coroutine.YieldFunc) bool {
 }
 
 func (game *Game) doMoveCamera(yield coroutine.YieldFunc, x int, y int) {
+    if y < 0 {
+        y = 0
+    }
+
+    if y > game.CurrentMap().Height() {
+        y = game.CurrentMap().Height()
+    }
+
     dx := x - game.Camera.GetX()
     dy := y - game.Camera.GetY()
     length := math.Sqrt(float64(dx * dx + dy * dy))

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2046,11 +2046,7 @@ func (game *Game) RefreshUI() {
     }
 }
 
-func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Player) {
-    // log.Printf("Game.Update")
-    keys := make([]ebiten.Key, 0)
-    keys = inpututil.AppendJustPressedKeys(keys)
-
+func (game *Game) doInputZoom() {
     _, wheelY := ebiten.Wheel()
     if wheelY > 0 {
         wheelY = 1
@@ -2063,6 +2059,14 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
     } else if wheelY < 0 {
         game.OverlandZoom = max(game.OverlandZoom - 1, ZoomMin)
     }
+}
+
+func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Player) {
+    // log.Printf("Game.Update")
+    keys := make([]ebiten.Key, 0)
+    keys = inpututil.AppendJustPressedKeys(keys)
+
+    game.doInputZoom()
 
     if player.SelectedStack != nil {
         stack := player.SelectedStack

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2913,7 +2913,7 @@ func (game *Game) doCityScreen(yield coroutine.YieldFunc, city *citylib.City, pl
     mapUse := game.GetMap(city.Plane)
 
     overworld := Overworld{
-        Camera: camera.MakeCameraAt(city.X - 2, city.Y - 2),
+        Camera: camera.MakeCameraAt(city.X+4, city.Y+3),
         Counter: 0,
         Map: mapUse,
         Cities: cities,
@@ -4680,39 +4680,18 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
         return checkFog(x - 1, y + 1)
     }
 
-    minX := int(overworld.Camera.GetZoomedX() - 1)
-    minY := int(overworld.Camera.GetZoomedY() - 1)
-    maxX := minX + int(12/overworld.Camera.GetZoom() + 3)
-    maxY := minY + int(12/overworld.Camera.GetZoom() + 3)
+    minX, minY, maxX, maxY := overworld.Camera.GetTileBounds()
 
     // log.Printf("fog min %v, %v max %v, %v", minX, minY, maxX, maxY)
 
-    // x_loop:
     for x := minX; x < maxX; x++ {
-
-        //y_loop:
         for y := minY; y < maxY; y++ {
-
-            // tileX := overworld.Map.WrapX(x + int(overworld.Camera.GetX()))
-            // tileY := y + int(overworld.Camera.GetY())
             tileX := overworld.Map.WrapX(x)
             tileY := y
 
             options.GeoM.Reset()
-            // options.GeoM = geom
             options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
             options.GeoM.Concat(geom)
-
-            /*
-            posX, posY := options.GeoM.Apply(0, 0)
-            if int(posX) > screen.Bounds().Max.X {
-                break x_loop
-            }
-
-            if int(posY) > screen.Bounds().Max.Y {
-                break y_loop
-            }
-            */
 
             if tileX >= 0 && tileY >= 0 && tileX < len(fog) && tileY < len(fog[tileX]) && fog[tileX][tileY] {
                 n := fogN(tileX, tileY)

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -280,6 +280,8 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     })
 
     game.Drawer = func(screen *ebiten.Image, game *Game){
+        overworld.Zoom = game.GetAnimatedZoom()
+
         overworld.DrawOverworld(screen, ebiten.GeoM{})
 
         var miniGeom ebiten.GeoM
@@ -293,20 +295,21 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         ui.Draw(ui, screen)
     }
 
+    var moveCounter uint64
     moveCamera := image.Pt(game.cameraX, game.cameraY)
     for !quit {
+        moveCounter += 1
         if game.GetZoom() >= 0.9 {
             overworld.Counter += 1
         }
-        zoomed := game.doInputZoom()
-
-        overworld.Zoom = game.GetZoom()
+        zoomed := game.doInputZoom(yield)
+        _ = zoomed
 
         ui.StandardUpdate()
 
         x, y := inputmanager.MousePosition()
 
-        if overworld.Counter % 5 == 0 && (moveCamera.X != game.cameraX || moveCamera.Y != game.cameraY) {
+        if moveCounter % 5 == 0 && (moveCamera.X != game.cameraX || moveCamera.Y != game.cameraY) {
             if moveCamera.X < game.cameraX {
                 game.cameraX -= 1
             } else if moveCamera.X > game.cameraX {
@@ -333,7 +336,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
             // right click should move the camera
             rightClick := inputmanager.RightClick()
-            if rightClick || zoomed {
+            if rightClick /*|| zoomed*/ {
                 moveCamera = selectedPoint.Add(image.Pt(-5, -5))
                 if moveCamera.X < 0 {
                     moveCamera.X = 0

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -112,7 +112,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         Fog: fog,
         ShowAnimation: game.State == GameStateUnitMoving,
         FogBlack: game.GetFogImage(),
-        Zoom: float64(game.OverlandZoom) / float64(ZoomStep),
+        Zoom: game.GetZoom(),
     }
 
     selectedPoint := image.Pt(-1, -1)

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -298,7 +298,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         if game.GetZoom() >= 0.9 {
             overworld.Counter += 1
         }
-        game.doInputZoom()
+        zoomed := game.doInputZoom()
 
         overworld.Zoom = game.GetZoom()
 
@@ -333,7 +333,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
             // right click should move the camera
             rightClick := inputmanager.RightClick()
-            if rightClick {
+            if rightClick || zoomed {
                 moveCamera = selectedPoint.Add(image.Pt(-5, -5))
                 if moveCamera.X < 0 {
                     moveCamera.X = 0

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -323,8 +323,10 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
         // within the viewable area
         if x < 240 && y > 18 {
-            newX := game.cameraX + int(float64(x) / float64(game.CurrentMap().TileWidth()) / game.GetZoom())
-            newY := game.cameraY + int(float64(y) / float64(game.CurrentMap().TileHeight()) / game.GetZoom())
+            realX, realY := game.RealToTile(float64(x), float64(y))
+
+            newX := game.cameraX + realX
+            newY := game.cameraY + realY
             newPoint := image.Pt(newX, newY)
 
             // right click should move the camera

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -293,12 +293,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         ui.Draw(ui, screen)
     }
 
-    /*
-    var moveCounter uint64
-    moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
-    */
     for !quit {
-        // moveCounter += 1
         if game.Camera.GetZoom() >= 0.9 {
             overworld.Counter += 1
         }
@@ -309,53 +304,15 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
         x, y := inputmanager.MousePosition()
 
-        /*
-        if moveCounter % 5 == 0 && (moveCamera.X != game.Camera.GetX() || moveCamera.Y != game.Camera.GetY()) {
-            if moveCamera.X < game.Camera.GetX() {
-                game.Camera.Move(-1, 0)
-            } else if moveCamera.X > game.Camera.GetX() {
-                game.Camera.Move(1, 0)
-            }
-
-            if moveCamera.Y < game.Camera.GetY() {
-                game.Camera.Move(0, -1)
-            } else if moveCamera.Y > game.Camera.GetY() {
-                game.Camera.Move(0, 1)
-            }
-
-            / *
-            overworld.CameraX = float64(game.Camera.GetX())
-            overworld.CameraY = float64(game.Camera.GetY())
-            * /
-        }
-        */
-
         // within the viewable area
         if x < 240 && y > 18 {
             newX, newY := game.ScreenToTile(float64(x), float64(y))
-
-            /*
-            newX := game.cameraX + realX
-            newY := game.cameraY + realY
-            */
             newPoint := image.Pt(newX, newY)
 
             // right click should move the camera
             rightClick := inputmanager.RightClick()
             if rightClick /*|| zoomed*/ {
                 game.doMoveCamera(yield, newX, newY)
-                /*
-                moveCamera = selectedPoint.Add(image.Pt(-5, -5))
-                if moveCamera.X < 0 {
-                    moveCamera.X = 0
-                }
-                if moveCamera.Y < 0 {
-                    moveCamera.Y = 0
-                }
-                if moveCamera.Y >= game.CurrentMap().Height() - 11 {
-                    moveCamera.Y = game.CurrentMap().Height() - 11
-                }
-                */
             }
 
             if selectedPoint != newPoint {

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -295,7 +295,9 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
     moveCamera := image.Pt(game.cameraX, game.cameraY)
     for !quit {
-        overworld.Counter += 1
+        if game.GetZoom() >= 0.9 {
+            overworld.Counter += 1
+        }
         game.doInputZoom()
 
         overworld.Zoom = game.GetZoom()

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -101,8 +101,8 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     whiteFont := makeWhiteFont(fonts)
 
     overworld := Overworld{
-        CameraX: game.cameraX,
-        CameraY: game.cameraY,
+        CameraX: float64(game.cameraX),
+        CameraY: float64(game.cameraY),
         Counter: game.Counter,
         Map: game.CurrentMap(),
         Cities: cities,
@@ -322,16 +322,18 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                 game.cameraY += 1
             }
 
-            overworld.CameraX = game.cameraX
-            overworld.CameraY = game.cameraY
+            overworld.CameraX = float64(game.cameraX)
+            overworld.CameraY = float64(game.cameraY)
         }
 
         // within the viewable area
         if x < 240 && y > 18 {
-            realX, realY := game.RealToTile(float64(x), float64(y))
+            newX, newY := game.ScreenToTile(float64(x), float64(y))
 
+            /*
             newX := game.cameraX + realX
             newY := game.cameraY + realY
+            */
             newPoint := image.Pt(newX, newY)
 
             // right click should move the camera

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -296,6 +296,9 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     moveCamera := image.Pt(game.cameraX, game.cameraY)
     for !quit {
         overworld.Counter += 1
+        game.doInputZoom()
+
+        overworld.Zoom = game.GetZoom()
 
         ui.StandardUpdate()
 
@@ -320,8 +323,8 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
         // within the viewable area
         if x < 240 && y > 18 {
-            newX := game.cameraX + x / game.CurrentMap().TileWidth()
-            newY := game.cameraY + y / game.CurrentMap().TileHeight()
+            newX := game.cameraX + int(float64(x) / float64(game.CurrentMap().TileWidth()) / game.GetZoom())
+            newY := game.cameraY + int(float64(y) / float64(game.CurrentMap().TileHeight()) / game.GetZoom())
             newPoint := image.Pt(newX, newY)
 
             // right click should move the camera

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -293,10 +293,12 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         ui.Draw(ui, screen)
     }
 
+    /*
     var moveCounter uint64
     moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
+    */
     for !quit {
-        moveCounter += 1
+        // moveCounter += 1
         if game.Camera.GetZoom() >= 0.9 {
             overworld.Counter += 1
         }
@@ -307,6 +309,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
         x, y := inputmanager.MousePosition()
 
+        /*
         if moveCounter % 5 == 0 && (moveCamera.X != game.Camera.GetX() || moveCamera.Y != game.Camera.GetY()) {
             if moveCamera.X < game.Camera.GetX() {
                 game.Camera.Move(-1, 0)
@@ -320,11 +323,12 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                 game.Camera.Move(0, 1)
             }
 
-            /*
+            / *
             overworld.CameraX = float64(game.Camera.GetX())
             overworld.CameraY = float64(game.Camera.GetY())
-            */
+            * /
         }
+        */
 
         // within the viewable area
         if x < 240 && y > 18 {
@@ -339,6 +343,8 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
             // right click should move the camera
             rightClick := inputmanager.RightClick()
             if rightClick /*|| zoomed*/ {
+                game.doMoveCamera(yield, newX, newY)
+                /*
                 moveCamera = selectedPoint.Add(image.Pt(-5, -5))
                 if moveCamera.X < 0 {
                     moveCamera.X = 0
@@ -349,6 +355,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                 if moveCamera.Y >= game.CurrentMap().Height() - 11 {
                     moveCamera.Y = game.CurrentMap().Height() - 11
                 }
+                */
             }
 
             if selectedPoint != newPoint {

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -112,6 +112,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         Fog: fog,
         ShowAnimation: game.State == GameStateUnitMoving,
         FogBlack: game.GetFogImage(),
+        Zoom: float64(game.OverlandZoom) / float64(ZoomStep),
     }
 
     selectedPoint := image.Pt(-1, -1)

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -101,8 +101,8 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     whiteFont := makeWhiteFont(fonts)
 
     overworld := Overworld{
-        CameraX: float64(game.cameraX),
-        CameraY: float64(game.cameraY),
+        CameraX: float64(game.Camera.GetX()),
+        CameraY: float64(game.Camera.GetY()),
         Counter: game.Counter,
         Map: game.CurrentMap(),
         Cities: cities,
@@ -296,7 +296,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     }
 
     var moveCounter uint64
-    moveCamera := image.Pt(game.cameraX, game.cameraY)
+    moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
     for !quit {
         moveCounter += 1
         if game.GetZoom() >= 0.9 {
@@ -309,21 +309,21 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
         x, y := inputmanager.MousePosition()
 
-        if moveCounter % 5 == 0 && (moveCamera.X != game.cameraX || moveCamera.Y != game.cameraY) {
-            if moveCamera.X < game.cameraX {
-                game.cameraX -= 1
-            } else if moveCamera.X > game.cameraX {
-                game.cameraX += 1
+        if moveCounter % 5 == 0 && (moveCamera.X != game.Camera.GetX() || moveCamera.Y != game.Camera.GetY()) {
+            if moveCamera.X < game.Camera.GetX() {
+                game.Camera.Move(-1, 0)
+            } else if moveCamera.X > game.Camera.GetX() {
+                game.Camera.Move(1, 0)
             }
 
-            if moveCamera.Y < game.cameraY {
-                game.cameraY -= 1
-            } else if moveCamera.Y > game.cameraY {
-                game.cameraY += 1
+            if moveCamera.Y < game.Camera.GetY() {
+                game.Camera.Move(0, -1)
+            } else if moveCamera.Y > game.Camera.GetY() {
+                game.Camera.Move(0, 1)
             }
 
-            overworld.CameraX = float64(game.cameraX)
-            overworld.CameraY = float64(game.cameraY)
+            overworld.CameraX = float64(game.Camera.GetX())
+            overworld.CameraY = float64(game.Camera.GetY())
         }
 
         // within the viewable area

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -101,8 +101,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     whiteFont := makeWhiteFont(fonts)
 
     overworld := Overworld{
-        CameraX: float64(game.Camera.GetX()),
-        CameraY: float64(game.Camera.GetY()),
+        Camera: game.Camera,
         Counter: game.Counter,
         Map: game.CurrentMap(),
         Cities: cities,
@@ -112,7 +111,6 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         Fog: fog,
         ShowAnimation: game.State == GameStateUnitMoving,
         FogBlack: game.GetFogImage(),
-        Zoom: game.GetZoom(),
     }
 
     selectedPoint := image.Pt(-1, -1)
@@ -280,7 +278,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     })
 
     game.Drawer = func(screen *ebiten.Image, game *Game){
-        overworld.Zoom = game.GetAnimatedZoom()
+        overworld.Camera = game.Camera
 
         overworld.DrawOverworld(screen, ebiten.GeoM{})
 
@@ -299,7 +297,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     moveCamera := image.Pt(game.Camera.GetX(), game.Camera.GetY())
     for !quit {
         moveCounter += 1
-        if game.GetZoom() >= 0.9 {
+        if game.Camera.GetZoom() >= 0.9 {
             overworld.Counter += 1
         }
         zoomed := game.doInputZoom(yield)
@@ -322,8 +320,10 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                 game.Camera.Move(0, 1)
             }
 
+            /*
             overworld.CameraX = float64(game.Camera.GetX())
             overworld.CameraY = float64(game.Camera.GetY())
+            */
         }
 
         // within the viewable area

--- a/game/magic/inputmanager/input.go
+++ b/game/magic/inputmanager/input.go
@@ -119,3 +119,22 @@ func MousePosition() (int, int) {
 
     return theInputManager.mouseX, theInputManager.mouseY
 }
+
+// return normalized wheel values, which are always -1,0,1 for both x and y, no matter how far the wheel has moved
+func Wheel() (float64, float64) {
+    x, y := ebiten.Wheel()
+    if x > 0 {
+        x = 1
+    }
+    if x < 0 {
+        x = -1
+    }
+    if y > 0 {
+        y = 1
+    }
+    if y < 0 {
+        y = -1
+    }
+
+    return x, y
+}

--- a/game/magic/inputmanager/input.go
+++ b/game/magic/inputmanager/input.go
@@ -124,16 +124,16 @@ func MousePosition() (int, int) {
 func Wheel() (float64, float64) {
     x, y := ebiten.Wheel()
     if x > 0 {
-        x = 1
+        x = min(x, 1)
     }
     if x < 0 {
-        x = -1
+        x = max(x, -1)
     }
     if y > 0 {
-        y = 1
+        y = min(y, 1)
     }
     if y < 0 {
-        y = -1
+        y = max(y, -1)
     }
 
     return x, y

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -185,7 +185,7 @@ func runGameInstance(yield coroutine.YieldFunc, magic *MagicGame, settings setup
 
     game.Events <- gamelib.StartingCityEvent(introCity)
 
-    game.CenterCamera(cityX, cityY)
+    game.Camera.Center(cityX, cityY)
 
     game.DoNextTurn()
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -702,14 +702,18 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
     tileWidth := mapObject.TileWidth()
     tileHeight := mapObject.TileHeight()
 
+    /*
     tilesPerRow := mapObject.TilesPerRow(screen.Bounds().Dx())
     tilesPerColumn := mapObject.TilesPerColumn(screen.Bounds().Dy())
+    */
 
     var options ebiten.DrawImageOptions
 
     // draw all tiles first
-    for x := 0; x < tilesPerRow * 2; x++ {
-        for y := 0; y < tilesPerColumn * 2; y++ {
+    x_loop:
+    for x := 0; x < mapObject.Map.Columns(); x++ {
+        y_loop:
+        for y := 0; y < mapObject.Map.Rows(); y++ {
             tileX := mapObject.WrapX(cameraX + x)
             tileY := cameraY + y
 
@@ -727,6 +731,15 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
                 // options.GeoM.Reset()
                 options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
                 options.GeoM.Concat(geom)
+
+                screenX, screenY := options.GeoM.Apply(0, 0)
+                if screenX > float64(screen.Bounds().Dx()) {
+                    break x_loop
+                }
+                if screenY > float64(screen.Bounds().Dy()) {
+                    break y_loop
+                }
+
                 screen.DrawImage(tileImage, &options)
 
                 extra, ok := mapObject.ExtraMap[image.Pt(tileX, tileY)]

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -711,11 +711,15 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
 
     // draw all tiles first
     x_loop:
-    for x := 0; x < mapObject.Map.Columns(); x++ {
+    for x := -mapObject.Map.Columns(); x < mapObject.Map.Columns() * 2; x++ {
         y_loop:
         for y := 0; y < mapObject.Map.Rows(); y++ {
+            /*
             tileX := mapObject.WrapX(cameraX + x)
             tileY := cameraY + y
+            */
+            tileX := mapObject.WrapX(x)
+            tileY := y
 
             // for debugging
             // util.DrawRect(screen, image.Rect(x * tileWidth, y * tileHeight, (x + 1) * tileWidth, (y + 1) * tileHeight), color.RGBA{R: 255, G: 0, B: 0, A: 255})
@@ -782,8 +786,8 @@ func (mapObject *Map) DrawLayer2(cameraX int, cameraY int, animationCounter uint
                 break y_loop
             }
 
-            tileX := mapObject.WrapX(cameraX + x)
-            tileY := cameraY + y
+            tileX := mapObject.WrapX(x)
+            tileY := y
 
             if tileX < 0 || tileX >= mapObject.Map.Columns() || tileY < 0 || tileY >= mapObject.Map.Rows() {
                 continue

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -11,6 +11,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    cameralib "github.com/kazzmir/master-of-magic/game/magic/camera"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
@@ -733,7 +734,7 @@ func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, ce
 }
 
 // draw base map tiles, in general stuff that should go under cities/units
-func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint64, imageCache *util.ImageCache, screen *ebiten.Image, geom ebiten.GeoM){
+func (mapObject *Map) DrawLayer1(camera cameralib.Camera, animationCounter uint64, imageCache *util.ImageCache, screen *ebiten.Image, geom ebiten.GeoM){
     tileWidth := mapObject.TileWidth()
     tileHeight := mapObject.TileHeight()
 
@@ -744,11 +745,16 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
 
     var options ebiten.DrawImageOptions
 
+    minX := int(camera.GetZoomedX() - 1)
+    minY := int(camera.GetZoomedY() - 1)
+    maxX := minX + int(12/camera.GetZoom() + 3)
+    maxY := minY + int(12/camera.GetZoom() + 3)
+
     // draw all tiles first
-    x_loop:
-    for x := -mapObject.Map.Columns(); x < mapObject.Map.Columns() * 2; x++ {
-        y_loop:
-        for y := 0; y < mapObject.Map.Rows(); y++ {
+    // x_loop:
+    for x := minX; x < maxX; x++ {
+        // y_loop:
+        for y := minY; y < maxY; y++ {
             /*
             tileX := mapObject.WrapX(cameraX + x)
             tileY := cameraY + y
@@ -771,6 +777,7 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
                 options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
                 options.GeoM.Concat(geom)
 
+                /*
                 screenX, screenY := options.GeoM.Apply(0, 0)
                 if screenX > float64(screen.Bounds().Max.X) {
                     break x_loop
@@ -778,6 +785,7 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
                 if screenY > float64(screen.Bounds().Max.Y) {
                     break y_loop
                 }
+                */
 
                 screen.DrawImage(tileImage, &options)
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -733,10 +733,10 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
                 options.GeoM.Concat(geom)
 
                 screenX, screenY := options.GeoM.Apply(0, 0)
-                if screenX > float64(screen.Bounds().Dx()) {
+                if screenX > float64(screen.Bounds().Max.X) {
                     break x_loop
                 }
-                if screenY > float64(screen.Bounds().Dy()) {
+                if screenY > float64(screen.Bounds().Max.Y) {
                     break y_loop
                 }
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -567,7 +567,7 @@ func bannerColor(banner data.BannerType) color.RGBA {
     return color.RGBA{R: 0, G: 0, B: 0, A: 255}
 }
 
-func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, centerX int, centerY int, fog [][]bool, counter uint64, crosshairs bool){
+func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, centerX int, centerY int, zoom float64, fog [][]bool, counter uint64, crosshairs bool){
     if len(mapObject.miniMapPixels) != screen.Bounds().Dx() * screen.Bounds().Dy() * 4 {
         mapObject.miniMapPixels = make([]byte, screen.Bounds().Dx() * screen.Bounds().Dy() * 4)
     }
@@ -657,7 +657,7 @@ func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, ce
         }
         cursorColor := util.PremultiplyAlpha(color.RGBA{R: 255, G: 255, B: byte(cursorColorBlue), A: 180})
 
-        cursorRadius := 5
+        cursorRadius := int(5.0 / zoom)
         x1 := centerX - cursorRadius - cameraX
         y1 := centerY - cursorRadius - cameraY
         x2 := centerX + cursorRadius - cameraX

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -745,20 +745,11 @@ func (mapObject *Map) DrawLayer1(camera cameralib.Camera, animationCounter uint6
 
     var options ebiten.DrawImageOptions
 
-    minX := int(camera.GetZoomedX() - 1)
-    minY := int(camera.GetZoomedY() - 1)
-    maxX := minX + int(12/camera.GetZoom() + 3)
-    maxY := minY + int(12/camera.GetZoom() + 3)
+    minX, minY, maxX, maxY := camera.GetTileBounds()
 
     // draw all tiles first
-    // x_loop:
     for x := minX; x < maxX; x++ {
-        // y_loop:
         for y := minY; y < maxY; y++ {
-            /*
-            tileX := mapObject.WrapX(cameraX + x)
-            tileY := cameraY + y
-            */
             tileX := mapObject.WrapX(x)
             tileY := y
 
@@ -776,16 +767,6 @@ func (mapObject *Map) DrawLayer1(camera cameralib.Camera, animationCounter uint6
                 // options.GeoM.Reset()
                 options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
                 options.GeoM.Concat(geom)
-
-                /*
-                screenX, screenY := options.GeoM.Apply(0, 0)
-                if screenX > float64(screen.Bounds().Max.X) {
-                    break x_loop
-                }
-                if screenY > float64(screen.Bounds().Max.Y) {
-                    break y_loop
-                }
-                */
 
                 screen.DrawImage(tileImage, &options)
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -483,6 +483,41 @@ func (mapObject *Map) WrapX(x int) int {
     return x % mapObject.Map.Columns()
 }
 
+// return the shortest x distance between two points, taking into account the map wrapping
+// result: WrapX(x1 + distance) = x2
+func (mapObject *Map) XDistance(x1 int, x2 int) int {
+    abs := func(x int) int {
+        if x < 0 {
+            return -x
+        }
+
+        return x
+    }
+
+    value := x2 - x1
+
+    /*
+    absValue := value
+    if absValue < 0 {
+        absValue = -absValue
+    }
+    */
+
+    // cross over map boundary from x1 towards x2
+    value2 := (mapObject.Map.Columns() - x1) + x2
+
+    // cross over map boundary from x2 towards x1
+    value3 := -x1 - (mapObject.Map.Columns() - x2)
+
+    if abs(value) < abs(value2) && abs(value) < abs(value3) {
+        return value
+    } else if abs(value2) < abs(value3) && abs(value2) < abs(value) {
+        return value2
+    } else {
+        return value3
+    }
+}
+
 func (mapObject *Map) GetTile(tileX int, tileY int) FullTile {
     tileX = mapObject.WrapX(tileX)
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -758,14 +758,29 @@ func (mapObject *Map) DrawLayer2(cameraX int, cameraY int, animationCounter uint
     tileWidth := mapObject.TileWidth()
     tileHeight := mapObject.TileHeight()
 
+    /*
     tilesPerRow := mapObject.TilesPerRow(screen.Bounds().Dx())
     tilesPerColumn := mapObject.TilesPerColumn(screen.Bounds().Dy())
+    */
 
     var options ebiten.DrawImageOptions
 
     // then draw all extra nodes on top
-    for x := 0; x < tilesPerRow; x++ {
-        for y := 0; y < tilesPerColumn; y++ {
+    x_loop:
+    for x := 0; x < mapObject.Map.Columns(); x++ {
+        y_loop:
+        for y := 0; y < mapObject.Map.Rows(); y++ {
+            options.GeoM.Reset()
+            options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
+            options.GeoM.Concat(geom)
+
+            posX, posY := options.GeoM.Apply(0, 0)
+            if int(posX) > screen.Bounds().Max.X {
+                break x_loop
+            }
+            if int(posY) > screen.Bounds().Max.Y {
+                break y_loop
+            }
 
             tileX := mapObject.WrapX(cameraX + x)
             tileY := cameraY + y
@@ -776,8 +791,6 @@ func (mapObject *Map) DrawLayer2(cameraX int, cameraY int, animationCounter uint
 
             extra, ok := mapObject.ExtraMap[image.Pt(tileX, tileY)]
             if ok {
-                options.GeoM = geom
-                options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
                 extra.DrawLayer2(screen, imageCache, &options, animationCounter, tileWidth, tileHeight)
             }
         }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -708,8 +708,8 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
     var options ebiten.DrawImageOptions
 
     // draw all tiles first
-    for x := 0; x < tilesPerRow; x++ {
-        for y := 0; y < tilesPerColumn; y++ {
+    for x := 0; x < tilesPerRow * 2; x++ {
+        for y := 0; y < tilesPerColumn * 2; y++ {
             tileX := mapObject.WrapX(cameraX + x)
             tileY := cameraY + y
 
@@ -722,9 +722,11 @@ func (mapObject *Map) DrawLayer1(cameraX int, cameraY int, animationCounter uint
 
             tileImage, err := mapObject.GetTileImage(tileX, tileY, animationCounter)
             if err == nil {
-                options.GeoM = geom
+                options.GeoM.Reset()
+                // options.GeoM = geom
                 // options.GeoM.Reset()
                 options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
+                options.GeoM.Concat(geom)
                 screen.DrawImage(tileImage, &options)
 
                 extra, ok := mapObject.ExtraMap[image.Pt(tileX, tileY)]

--- a/game/magic/maplib/map_test.go
+++ b/game/magic/maplib/map_test.go
@@ -1,0 +1,33 @@
+package maplib
+
+import (
+    "testing"
+    "github.com/kazzmir/master-of-magic/game/magic/terrain"
+)
+
+func TestMap(t *testing.T) {
+    rawMap := terrain.MakeMap(10, 10)
+    xmap := Map{
+        Map: rawMap,
+    }
+
+    type Test struct {
+        x1, x2, distance int
+    }
+
+    tests := []Test{
+        {3,2,-1},
+        {3,0,-3},
+        {2,3,1},
+        {3,2,-1},
+        {9,0,1},
+        {0,9,-1},
+    }
+
+    for _, test := range tests {
+        distance := xmap.Distance(test.x1, test.x2)
+        if distance != test.distance {
+            t.Errorf("Distance from %d to %d is %d, expected %d", test.x1, test.x2, distance, test.distance)
+        }
+    }
+}

--- a/game/magic/maplib/map_test.go
+++ b/game/magic/maplib/map_test.go
@@ -25,7 +25,7 @@ func TestMap(t *testing.T) {
     }
 
     for _, test := range tests {
-        distance := xmap.Distance(test.x1, test.x2)
+        distance := xmap.XDistance(test.x1, test.x2)
         if distance != test.distance {
             t.Errorf("Distance from %d to %d is %d, expected %d", test.x1, test.x2, distance, test.distance)
         }

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -9,6 +9,7 @@ import (
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
     "github.com/kazzmir/master-of-magic/game/magic/cityview"
+    "github.com/kazzmir/master-of-magic/game/magic/camera"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/terrain"
@@ -138,7 +139,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 
     engine.CityScreen.Draw(screen, func (where *ebiten.Image, geom ebiten.GeoM, counter uint64) {
         overworld := game.Overworld{
-            Camera: game.MakeCameraAt(cameraX, cameraY),
+            Camera: camera.MakeCameraAt(cameraX, cameraY),
             Map: engine.Map,
             Cities: []*citylib.City{engine.CityScreen.City},
             Stacks: []*playerlib.UnitStack{},

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -138,8 +138,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 
     engine.CityScreen.Draw(screen, func (where *ebiten.Image, geom ebiten.GeoM, counter uint64) {
         overworld := game.Overworld{
-            CameraX: float64(cameraX),
-            CameraY: float64(cameraY),
+            Camera: game.MakeCameraAt(cameraX, cameraY),
             Map: engine.Map,
             Cities: []*citylib.City{engine.CityScreen.City},
             Stacks: []*playerlib.UnitStack{},
@@ -149,7 +148,6 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
             Fog: nil,
             ShowAnimation: false,
             FogBlack: nil,
-            Zoom: 1,
         }
 
         overworld.DrawOverworld(where, geom)

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -134,8 +134,8 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 
     engine.CityScreen.Draw(screen, func (where *ebiten.Image, geom ebiten.GeoM, counter uint64) {
         overworld := game.Overworld{
-            CameraX: cameraX,
-            CameraY: cameraY,
+            CameraX: float64(cameraX),
+            CameraY: float64(cameraY),
             Map: engine.Map,
             Cities: []*citylib.City{engine.CityScreen.City},
             Stacks: []*playerlib.UnitStack{},

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -145,6 +145,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
             Fog: nil,
             ShowAnimation: false,
             FogBlack: nil,
+            Zoom: 1,
         }
 
         overworld.DrawOverworld(where, geom)

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -2163,7 +2163,7 @@ func createScenario26(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     x, y := game.FindValidCityLocation()
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     player := game.AddPlayer(wizard, true)
     player.Gold = 15772

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -90,7 +90,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
 
     // game.Map.Map.Terrain[3][6] = terrain.TileNatureForest.Index
 
-    player.LiftFog(x, y, 3, data.PlaneArcanus)
+    player.LiftFog(x, y, 30, data.PlaneArcanus)
 
     drake := player.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, nil))
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -212,6 +212,9 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
     player := game.AddPlayer(wizard, true)
 
     x, y := game.FindValidCityLocation()
+    y = 0
+
+    log.Printf("City at %v, %v", x, y)
 
     introCity := citylib.MakeCity("Test City", x, y, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap())
     introCity.Population = 6000

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -121,7 +121,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     enemy1.AddUnit(units.MakeOverworldUnitFromUnit(units.Warlocks, x + 2, y + 2, data.PlaneArcanus, enemy1.Wizard.Banner, nil))
     enemy1.AddUnit(units.MakeOverworldUnitFromUnit(units.HighMenBowmen, x + 2, y + 2, data.PlaneArcanus, enemy1.Wizard.Banner, nil))
 
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     return game
 }
@@ -247,7 +247,7 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
 
     player.LiftFog(x, y, 2, data.PlaneArcanus)
 
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     return game
 }
@@ -315,7 +315,7 @@ func createScenario4(cache *lbx.LbxCache) *gamelib.Game {
 
     player.LiftFog(x, y, 2, data.PlaneArcanus)
 
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     introCity.Buildings.Insert(buildinglib.BuildingSmithy)
 
@@ -380,7 +380,7 @@ func createScenario5(cache *lbx.LbxCache) *gamelib.Game {
 
     _ = introCity
 
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     game.Events <- &gamelib.GameEventScroll{
         Title: "CITY GROWTH",
@@ -470,7 +470,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
 
     player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     return game
 }
@@ -1056,7 +1056,7 @@ func createScenario14(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 50
 
     player.LiftFog(x, y, 4, data.PlaneArcanus)
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     /*
     game.Events <- &gamelib.GameEventLearnedSpell{
@@ -1521,7 +1521,7 @@ func createScenario19(cache *lbx.LbxCache) *gamelib.Game {
     // game.Map.Map.Terrain[3][6] = terrain.TileNatureForest.Index
 
     player.LiftFog(x, y, 3, data.PlaneArcanus)
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     enemy1 := game.AddPlayer(setup.WizardCustom{
         Name: "dingus",
@@ -2047,7 +2047,7 @@ func createScenario24(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 26
 
     player.LiftFog(x, y, 3, data.PlaneArcanus)
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     enemy1 := game.AddPlayer(setup.WizardCustom{
         Name: "dingus",
@@ -2096,7 +2096,7 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     x, y := game.FindValidCityLocation()
-    game.CenterCamera(x, y)
+    game.Camera.Center(x, y)
 
     player := game.AddPlayer(wizard, true)
     player.Gold = 15772

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -213,8 +213,6 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y := game.FindValidCityLocation()
 
-    log.Printf("City at %v, %v", x, y)
-
     introCity := citylib.MakeCity("Test City", x, y, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap())
     introCity.Population = 6000
     introCity.Plane = data.PlaneArcanus

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -212,7 +212,6 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
     player := game.AddPlayer(wizard, true)
 
     x, y := game.FindValidCityLocation()
-    y = 0
 
     log.Printf("City at %v, %v", x, y)
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -70,6 +70,11 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y := game.FindValidCityLocation()
 
+    /*
+    x = 20
+    y = 20
+    */
+
     city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap())
     city.Population = 16190
     city.Plane = data.PlaneArcanus
@@ -89,6 +94,8 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 26
 
     // game.Map.Map.Terrain[3][6] = terrain.TileNatureForest.Index
+
+    // log.Printf("City at %v, %v", x, y)
 
     player.LiftFog(x, y, 30, data.PlaneArcanus)
 


### PR DESCRIPTION
Allow the overworld to be zoomed in/out so the user can see more of the map. Moving between coordinates on the map is also done smoothly.

![image](https://github.com/user-attachments/assets/e3ff9b89-286c-496d-b8ea-ac14c43dd933)
