### PR TITLE
Add hire mercenaries event

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1919,6 +1919,10 @@ func (game *Game) doHireHero(yield coroutine.YieldFunc, cost int, hero *herolib.
 /* show the hire mercenaries popup, and if the user clicks 'hire' then add the units to the player's list of units
  */
 func (game *Game) doHireMercenaries(yield coroutine.YieldFunc, cost int, units []*units.OverworldUnit, player *playerlib.Player) {
+    if len(units) < 1 {
+        return
+    }
+
     quit := false
 
     result := func(hired bool) {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1818,14 +1818,14 @@ func (game *Game) doHireHero(yield coroutine.YieldFunc, cost int, hero *herolib.
     }
 
     // unit type
-    playerActiveOnArcanus := false
-    playerActiveOnMyrror := false
+    presentOnArcanus := false
+    presentOnMyrror := false
     for _, city := range player.Cities {
         if city.Plane == data.PlaneArcanus {
-            playerActiveOnArcanus = true
+            presentOnArcanus = true
         }
         if city.Plane == data.PlaneMyrror {
-            playerActiveOnMyrror = true
+            presentOnMyrror = true
         }
     }
 
@@ -1843,24 +1843,24 @@ func (game *Game) doHireHero(yield coroutine.YieldFunc, cost int, hero *herolib.
             continue
         }
 
-        isFromKnownPlane := false
-        if playerActiveOnArcanus {
+        isFromPresentPlane := false
+        if presentOnArcanus {
             for _, race := range data.ArcanianRaces() {
                 if unit.Race == race {
-                    isFromKnownPlane = true
+                    isFromPresentPlane = true
                     break
                 }
             }
         }
-        if !isFromKnownPlane && playerActiveOnMyrror {
+        if !isFromPresentPlane && presentOnMyrror {
             for _, race := range data.MyrranRaces() {
                 if unit.Race == race {
-                    isFromKnownPlane = true
+                    isFromPresentPlane = true
                     break
                 }
             }
         }
-        if !isFromKnownPlane {
+        if !isFromPresentPlane {
             continue
         }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1894,7 +1894,7 @@ func (game *Game) doHireHero(yield coroutine.YieldFunc, cost int, hero *herolib.
     }
 
     // cost
-    cost := unit.ProductionCost * (level + 3) / 2
+    cost := count * unit.ProductionCost * (level + 3) / 2
     if player.Wizard.AbilityEnabled(setup.AbilityCharismatic) {
         cost /= 2
     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -92,6 +92,12 @@ type GameEventHireHero struct {
     Cost int
 }
 
+type GameEventHireMercenaries struct {
+    Units []*units.OverworldUnit
+    Player *playerlib.Player
+    Cost int
+}
+
 type GameEventVault struct {
     CreatedArtifact *artifact.Artifact
 }
@@ -1778,7 +1784,155 @@ func (game *Game) doHireHero(yield coroutine.YieldFunc, cost int, hero *herolib.
         }
     }
 
-    game.HudUI.AddElements(MakeHireScreenUI(game.Cache, game.HudUI, hero, cost, result))
+    game.HudUI.AddElements(MakeHireHeroScreenUI(game.Cache, game.HudUI, hero, cost, result))
+
+    for !quit {
+        game.Counter += 1
+        game.HudUI.StandardUpdate()
+        yield()
+    }
+}
+
+/* random chance to create a hire mercenaries event
+ */
+ func (game *Game) maybeHireMercenaries(player *playerlib.Player) {
+    if game.TurnNumber <= 30 {
+        return
+    }
+
+    fortressCity := player.FindFortressCity()
+    if fortressCity == nil {
+        return  // player is being banished
+    }
+
+    // chance to create an event
+    chance := 1 + player.Fame / 20
+    if player.Wizard.AbilityEnabled(setup.AbilityFamous) {
+        chance *= 2
+    }
+    if chance > 10 {
+        chance = 10
+    }
+    if rand.N(100) >= 10 {
+        return
+    }
+
+    // unit type
+    playerActiveOnArcanus := false
+    playerActiveOnMyrror := false
+    for _, city := range player.Cities {
+        if city.Plane == data.PlaneArcanus {
+            playerActiveOnArcanus = true
+        }
+        if city.Plane == data.PlaneMyrror {
+            playerActiveOnMyrror = true
+        }
+    }
+
+    var unitCandidates []*units.Unit
+    for _, unit := range units.AllUnits {
+        if unit.Race == data.RaceFantastic || unit.Race == data.RaceHero {
+            continue
+        }
+
+        if unit.IsSettlers() {
+            continue
+        }
+
+        if unit.Name == "Trireme" || unit.Name == "Galley" || unit.Name == "Warship" {
+            continue
+        }
+
+        isFromKnownPlane := false
+        if playerActiveOnArcanus {
+            for _, race := range data.ArcanianRaces() {
+                if unit.Race == race {
+                    isFromKnownPlane = true
+                    break
+                }
+            }
+        }
+        if !isFromKnownPlane && playerActiveOnMyrror {
+            for _, race := range data.MyrranRaces() {
+                if unit.Race == race {
+                    isFromKnownPlane = true
+                    break
+                }
+            }
+        }
+        if !isFromKnownPlane {
+            continue
+        }
+
+        unitCandidates = append(unitCandidates, &unit)
+    }
+    if len(unitCandidates) == 0 {
+        return
+    }
+
+    unit := unitCandidates[rand.IntN(len(unitCandidates))]
+
+    // number of units
+    count := 1
+    countRoll := rand.N(100) + player.Fame
+    switch {
+        case countRoll > 90: count = 3
+        case countRoll > 60: count = 2
+    }
+
+    // experience
+    level := 1
+    experience := 20
+    experienceRoll := rand.N(100) + player.Fame
+    switch {
+        case experienceRoll > 90:
+            level = 3
+            experience = 120
+        case experienceRoll > 60:
+            level = 2
+            experience = 60
+    }
+
+    // cost
+    cost := unit.ProductionCost * (level + 3) / 2
+    if player.Wizard.AbilityEnabled(setup.AbilityCharismatic) {
+        cost /= 2
+    }
+    if player.Gold < cost {
+        return
+    }
+
+    // create units
+    var overworldUnits []*units.OverworldUnit
+    for i := 0; i < count; i++ {
+        overworldUnit := units.MakeOverworldUnitFromUnit(*unit, fortressCity.X, fortressCity.Y, fortressCity.Plane, player.Wizard.Banner, player.MakeExperienceInfo())
+        overworldUnit.Experience = experience
+        overworldUnits = append(overworldUnits, overworldUnit)
+    }
+
+    select {
+        case game.Events <- &GameEventHireMercenaries{Cost: cost, Units: overworldUnits, Player: player}:
+        default:
+    }
+}
+
+/* show the hire mercenaries popup, and if the user clicks 'hire' then add the units to the player's list of units
+ */
+func (game *Game) doHireMercenaries(yield coroutine.YieldFunc, cost int, units []*units.OverworldUnit, player *playerlib.Player) {
+    quit := false
+
+    result := func(hired bool) {
+        quit = true
+        if hired {
+            for _, unit := range units {
+                player.AddUnit(unit)
+            }
+            player.Gold -= cost
+            game.RefreshUI()
+        }
+    }
+
+    game.HudUI.AddElements(MakeHireMercenariesScreenUI(game.Cache, game.HudUI, units[0], len(units), cost, result))
 
     for !quit {
         game.Counter += 1
@@ -1865,6 +2019,11 @@ func (game *Game) ProcessEvents(yield coroutine.YieldFunc) {
                         hire := event.(*GameEventHireHero)
                         if hire.Player.Human {
                             game.doHireHero(yield, hire.Cost, hire.Hero, hire.Player)
+                        }
+                    case *GameEventHireMercenaries:
+                        hire := event.(*GameEventHireMercenaries)
+                        if hire.Player.Human {
+                            game.doHireMercenaries(yield, hire.Cost, hire.Units, hire.Player)
                         }
                     case *GameEventNextTurn:
                         game.doNextTurn(yield)
@@ -4068,6 +4227,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
     }
 
     game.maybeHireHero(player)
+    game.maybeHireMercenaries(player)
 
     // game.CenterCamera(player.Cities[0].X, player.Cities[0].Y)
     game.DoNextUnit(player)

--- a/game/magic/game/mercenaries.go
+++ b/game/magic/game/mercenaries.go
@@ -1,21 +1,21 @@
 package game
 
 import (
-    "log"
     "fmt"
     "image/color"
+    "log"
 
-    "github.com/kazzmir/master-of-magic/lib/font"
-    "github.com/kazzmir/master-of-magic/lib/lbx"
+    uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
+    "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
-    uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
+    "github.com/kazzmir/master-of-magic/lib/font"
+    "github.com/kazzmir/master-of-magic/lib/lbx"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
 
-func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero, goldToHire int, action func(bool)) []*uilib.UIElement {
+func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.OverworldUnit, count int, goldToHire int, action func(bool)) []*uilib.UIElement {
     fontLbx, err := cache.GetLbxFile("fonts.lbx")
     if err != nil {
         log.Printf("Unable to read fonts.lbx: %v", err)
@@ -78,36 +78,24 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             options.ColorScale.ScaleAlpha(getAlpha())
             screen.DrawImage(background, &options)
 
-            options.GeoM.Translate(9, 7)
-            portraitLbx, portraitIndex := hero.GetPortraitLbxInfo()
-            portrait, err := imageCache.GetImage(portraitLbx, portraitIndex, 0)
-            if err == nil {
-                screen.DrawImage(portrait, &options)
-            }
-
-            // unitview.RenderCombatImage(screen, &imageCache, &hero.Unit.Unit, options)
+            options.GeoM.Translate(24, 28)
+            unitview.RenderCombatImage(screen, &imageCache, unit, options, 0)
 
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
             options.GeoM.Translate(31, 6)
             options.GeoM.Translate(51, 7)
-
-            unitview.RenderUnitInfoNormal(screen, &imageCache, hero, hero.GetTitle(), "", descriptionFont, smallFont, options)
+            unitview.RenderUnitInfoNormal(screen, &imageCache, unit, "", unit.Unit.Race.String(), descriptionFont, smallFont, options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
             options.GeoM.Translate(31, 6)
             options.GeoM.Translate(10, 50)
-            unitview.RenderUnitInfoStats(screen, &imageCache, hero, 15, descriptionFont, smallFont, options)
-
-            /*
-            options.GeoM.Translate(0, 60)
-            unitview.RenderUnitAbilities(screen, &imageCache, hero, mediumFont, options, true, 0)
-            */
+            unitview.RenderUnitInfoStats(screen, &imageCache, unit, 15, descriptionFont, smallFont, options)
         },
     })
 
-    elements = append(elements, unitview.MakeUnitAbilitiesElements(&imageCache, hero, mediumFont, 40, 124, 1, &getAlpha, true)...)
+    elements = append(elements, unitview.MakeUnitAbilitiesElements(&imageCache, unit, mediumFont, 40, 124, 1, &getAlpha, false)...)
 
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
@@ -122,7 +110,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
     })
 
     buttonBackgrounds, _ := imageCache.GetImages("backgrnd.lbx", 24)
-    // hire button
+
     hireRect := util.ImageRect(257, 149 + int(yTop), buttonBackgrounds[0])
     hireIndex := 0
     elements = append(elements, &uilib.UIElement{
@@ -130,22 +118,6 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
         Rect: hireRect,
         LeftClick: func(this *uilib.UIElement){
             hireIndex = 1
-
-            /*
-            var confirmElements []*uilib.UIElement
-
-            yes := func(){
-                ui.RemoveElements(elements)
-                // FIXME: disband unit
-            }
-
-            no := func(){
-            }
-
-            confirmElements = uilib.MakeConfirmDialogWithLayer(ui, cache, &imageCache, 2, fmt.Sprintf("Do you wish to disband the unit of %v?", unit.Unit.Name), yes, no)
-
-            ui.AddElements(confirmElements)
-            */
         },
         LeftClickRelease: func(this *uilib.UIElement){
             hireIndex = 0
@@ -204,7 +176,11 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             options.ColorScale.ScaleAlpha(getAlpha())
             screen.DrawImage(banner, &options)
 
-            okDismissFont.PrintCenter(screen, 135, 6, 1, options.ColorScale, fmt.Sprintf("Hero for Hire: %v gold", goldToHire))
+            message := fmt.Sprintf("Mercenaries for Hire: %v gold", goldToHire)
+            if count > 1 {
+                message = fmt.Sprintf("%v Mercenaries for Hire: %v gold", count, goldToHire)
+            }
+            okDismissFont.PrintCenter(screen, 135, 6, 1, options.ColorScale, message)
         },
     })
 

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -280,20 +280,9 @@ type Hero struct {
     Equipment [3]*artifact.Artifact
 }
 
-type noInfo struct {
-}
-
-func (noInfo *noInfo) HasWarlord() bool {
-    return false
-}
-
-func (noInfo *noInfo) Crusade() bool {
-    return false
-}
-
 func MakeHeroSimple(heroType HeroType) *Hero {
     unit := units.MakeOverworldUnit(heroType.GetUnit())
-    unit.ExperienceInfo = &noInfo{}
+    unit.ExperienceInfo = &units.NoExperienceInfo{}
     return MakeHero(unit, heroType, heroType.DefaultName())
 }
 
@@ -809,7 +798,7 @@ func (hero *Hero) SetExperienceInfo(info units.ExperienceInfo) {
 }
 
 func (hero *Hero) ResetOwner() {
-    hero.SetExperienceInfo(&noInfo{})
+    hero.SetExperienceInfo(&units.NoExperienceInfo{})
 }
 
 // force hero to go up one level

--- a/game/magic/units/experience.go
+++ b/game/magic/units/experience.go
@@ -5,6 +5,17 @@ type ExperienceInfo interface {
     Crusade() bool
 }
 
+type NoExperienceInfo struct {
+}
+
+func (noInfo *NoExperienceInfo) HasWarlord() bool {
+    return false
+}
+
+func (noInfo *NoExperienceInfo) Crusade() bool {
+    return false
+}
+
 type ExperienceData interface {
     ToInt() int
     Name() string

--- a/game/magic/unitview/ui.go
+++ b/game/magic/unitview/ui.go
@@ -152,7 +152,7 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
             options.GeoM.Translate(31, 6)
             options.GeoM.Translate(51, 6)
 
-            RenderUnitInfoNormal(screen, &imageCache, unit, unit.GetTitle(), descriptionFont, smallFont, options)
+            RenderUnitInfoNormal(screen, &imageCache, unit, unit.GetTitle(), "", descriptionFont, smallFont, options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(31, 6)

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -68,11 +68,16 @@ func renderUpkeep(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitVi
     renderIcons(unitCostMana, smallMana, bigMana)
 }
 
-func RenderUnitInfoNormal(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitView, extraTitle string, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions) {
+func RenderUnitInfoNormal(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitView, extraTitle string, namePrefix string, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions) {
     x, y := defaultOptions.GeoM.Apply(0, 0)
 
+    name := unit.GetName()
+    if namePrefix != "" {
+        name = fmt.Sprintf("%v %v", namePrefix, name)
+    }
+
     if extraTitle != "" {
-        descriptionFont.Print(screen, x, y, 1, defaultOptions.ColorScale, unit.GetName())
+        descriptionFont.Print(screen, x, y, 1, defaultOptions.ColorScale, name)
         y += float64(descriptionFont.Height())
         defaultOptions.GeoM.Translate(0, float64(descriptionFont.Height()))
         descriptionFont.Print(screen, x, y, 1, defaultOptions.ColorScale, "The " + extraTitle)
@@ -80,7 +85,7 @@ func RenderUnitInfoNormal(screen *ebiten.Image, imageCache *util.ImageCache, uni
         y += float64(descriptionFont.Height())
         defaultOptions.GeoM.Translate(0, float64(descriptionFont.Height()))
     } else {
-        descriptionFont.Print(screen, x, y+2, 1, defaultOptions.ColorScale, unit.GetName())
+        descriptionFont.Print(screen, x, y+2, 1, defaultOptions.ColorScale, name)
         y += 17
         defaultOptions.GeoM.Translate(0, 16)
     }

--- a/test/hire-hero/main.go
+++ b/test/hire-hero/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+    "log"
+    "image/color"
+    "strconv"
+    "os"
+
+    "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/game/magic/hero"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/units"
+    gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
+    uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
+
+    "github.com/hajimehoshi/ebiten/v2"
+    "github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+type Engine struct {
+    LbxCache *lbx.LbxCache
+    UI *uilib.UI
+}
+
+func NewEngine(scenario int) (*Engine, error) {
+    cache := lbx.AutoCache()
+
+    ui := &uilib.UI{
+        Draw: func(ui *uilib.UI, screen *ebiten.Image){
+
+        ui.IterateElementsByLayer(func (element *uilib.UIElement){
+            if element.Draw != nil {
+                element.Draw(element, screen)
+            }
+        })
+
+        },
+    }
+    ui.SetElementsFromArray(nil)
+
+    rakir := hero.MakeHero(&units.OverworldUnit{
+                Unit: units.HeroRakir,
+            }, hero.HeroRakir, "Rakir")
+
+    ui.AddElements(gamelib.MakeHireHeroScreenUI(cache, ui, rakir, 100, func (hired bool){
+        log.Printf("hired %v", hired)
+    }))
+
+    return &Engine{
+        LbxCache: cache,
+        UI: ui,
+    }, nil
+}
+
+func (engine *Engine) Update() error {
+
+    keys := make([]ebiten.Key, 0)
+    keys = inpututil.AppendJustPressedKeys(keys)
+
+    for _, key := range keys {
+        if key == ebiten.KeyEscape || key == ebiten.KeyCapsLock {
+            return ebiten.Termination
+        }
+    }
+
+    engine.UI.StandardUpdate()
+
+    return nil
+}
+
+func (engine *Engine) Draw(screen *ebiten.Image) {
+    screen.Fill(color.RGBA{R: 0, G: 150, B: 150, A: 0xff})
+
+    engine.UI.Draw(engine.UI, screen)
+}
+
+func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
+    return data.ScreenWidth, data.ScreenHeight
+}
+
+func main(){
+    log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
+
+    monitorWidth, _ := ebiten.Monitor().Size()
+    size := monitorWidth / 390
+
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
+    ebiten.SetWindowTitle("summon unit")
+    ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
+
+    scenario := 1
+
+    if len(os.Args) >= 2 {
+        x, err := strconv.Atoi(os.Args[1])
+        if err != nil {
+            log.Fatalf("Error with scenario: %v", err)
+        }
+
+        scenario = x
+    }
+
+    engine, err := NewEngine(scenario)
+
+    if err != nil {
+        log.Printf("Error: unable to load engine: %v", err)
+        return
+    }
+
+    err = ebiten.RunGame(engine)
+    if err != nil {
+        log.Printf("Error: %v", err)
+    }
+}

--- a/test/hire-mercenaries/main.go
+++ b/test/hire-mercenaries/main.go
@@ -7,7 +7,6 @@ import (
     "os"
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
-    "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
@@ -38,11 +37,10 @@ func NewEngine(scenario int) (*Engine, error) {
     }
     ui.SetElementsFromArray(nil)
 
-    rakir := hero.MakeHero(&units.OverworldUnit{
-                Unit: units.HeroRakir,
-            }, hero.HeroRakir, "Rakir")
+    unit := units.MakeOverworldUnitFromUnit(units.HalflingSpearmen, 0, 0, data.PlaneArcanus, data.BannerGreen, &units.NoExperienceInfo{})
+    unit.Experience = 60
 
-    ui.AddElements(gamelib.MakeHireScreenUI(cache, ui, rakir, 100, func (hired bool){
+    ui.AddElements(gamelib.MakeHireMercenariesScreenUI(cache, ui, unit, 2, 100, func (hired bool){
         log.Printf("hired %v", hired)
     }))
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1964,6 +1964,79 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// hire mercenaries
+func createScenario24(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 24")
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerBlue,
+        Race: data.RaceTroll,
+        Abilities: []setup.WizardAbility{
+            setup.AbilityAlchemy,
+            setup.AbilitySageMaster,
+        },
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.LifeMagic,
+                Count: 3,
+            },
+            data.WizardBook{
+                Magic: data.SorceryMagic,
+                Count: 8,
+            },
+        },
+    }
+
+    game := gamelib.MakeGame(cache, setup.NewGameSettings{})
+
+    game.Plane = data.PlaneArcanus
+
+    player := game.AddPlayer(wizard, true)
+
+    x, y := game.FindValidCityLocation()
+
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap())
+    city.Population = 6190
+    city.Plane = data.PlaneArcanus
+    city.Banner = wizard.Banner
+    city.Buildings.Insert(buildinglib.BuildingFortress)
+    city.ProducingBuilding = buildinglib.BuildingGranary
+    city.ProducingUnit = units.UnitNone
+    city.Race = wizard.Race
+    city.Farmers = 5
+    city.Workers = 1
+    city.Wall = false
+
+    city.ResetCitizens(nil)
+
+    player.AddCity(city)
+
+    player.Gold = 15772
+    player.Mana = 26
+
+    player.LiftFog(x, y, 3, data.PlaneArcanus)
+    game.CenterCamera(x, y)
+
+    enemy1 := game.AddPlayer(setup.WizardCustom{
+        Name: "dingus",
+        Banner: data.BannerRed,
+    }, false)
+
+    enemy1.AddUnit(units.MakeOverworldUnitFromUnit(units.Warlocks, x + 1, y + 1, data.PlaneArcanus, enemy1.Wizard.Banner, nil))
+    enemy1.AddUnit(units.MakeOverworldUnitFromUnit(units.HighMenBowmen, x + 1, y + 1, data.PlaneArcanus, enemy1.Wizard.Banner, nil))
+
+    game.Events <- &gamelib.GameEventHireMercenaries{
+        Player: player,
+        Units: []*units.OverworldUnit{
+            units.MakeOverworldUnitFromUnit(units.BarbarianSpearmen, x, y, data.PlaneArcanus, player.Wizard.Banner, nil),
+            units.MakeOverworldUnitFromUnit(units.BarbarianSpearmen, x, y, data.PlaneArcanus, player.Wizard.Banner, nil),
+        },
+        Cost: 200,
+    }
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -1993,6 +2066,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 21: game = createScenario21(cache)
         case 22: game = createScenario22(cache)
         case 23: game = createScenario23(cache)
+        case 24: game = createScenario24(cache)
         default: game = createScenario1(cache)
     }
 


### PR DESCRIPTION
This PR adds the hire mercanries event:

<img width="956" alt="Bildschirmfoto 2025-01-03 um 06 08 27" src="https://github.com/user-attachments/assets/f9ec8acb-20f7-40b7-837c-a1727552a8d2" />

Event generation is following the description [in the wiki](https://masterofmagic.fandom.com/wiki/Mercenaries):
- does not trigger if
  - early in the game
  - the player is being banished (no fortress city)
- generates the event with a chance of `max(10, 1 + fame / 20)`%
- selects a random unit from all units except
  - fantastic or hero
  - settlers
  - ships
  - races from an absent plane
- select a random number of units between 1 and 3
- selects random experience points of 20 (level 1) / 60 (level2) / 120 (level 3)
- costs `#units * production cost * (level + 3) / 2 [* 0.5 if charismatic]`
- puts the units in the fortress city if hired

Random unit selection is done slighty different: It first selects a list of possible candidates to choose from instead of trying 20 times randomly a unit from all units and fail if the unit does not match the criteria.

Presence on a plane is also done slighty simpler: Presence is given only if a player has a city on a plane instead of a city or unit or tower of wizardry.