### PR TITLE
Add merchant event

### DIFF
--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -125,6 +125,11 @@ type Power struct {
     Spell spellbook.Spell
 }
 
+type Requirement struct {
+    MagicType data.MagicType
+    Amount int
+}
+
 type Artifact struct {
     Type ArtifactType
     Image int
@@ -132,6 +137,7 @@ type Artifact struct {
     Cost int
     Powers []Power
     Abilities []data.Ability
+    Requirements []Requirement
 }
 
 func (artifact *Artifact) HasAbility(ability data.AbilityType) bool {
@@ -369,8 +375,6 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
         if !exists {
             return nil, fmt.Errorf("Invalid slot type %v", slotValue)
         }
-
-        // TODO: use this somehow? seems unnecessary
         _ = slot
 
         // Type
@@ -486,29 +490,45 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
         }
 
         // Requirements
-        _, err = lbx.ReadByte(reader) // TODO: natureRanksNeeded
+        var requirements []Requirement
+        natureRanksNeeded, err := lbx.ReadByte(reader)
         if err != nil {
             return nil, fmt.Errorf("read error: %v", err)
         }
+        if natureRanksNeeded != 0 {
+            requirements = append(requirements, Requirement{MagicType: data.NatureMagic, Amount: int(natureRanksNeeded)})
+        }
 
-        _, err = lbx.ReadByte(reader) // TODO: sorceryRanksNeeded
+        sorceryRanksNeeded, err := lbx.ReadByte(reader)
         if err != nil {
             return nil, fmt.Errorf("read error: %v", err)
         }
+        if sorceryRanksNeeded != 0 {
+            requirements = append(requirements, Requirement{MagicType: data.SorceryMagic, Amount: int(sorceryRanksNeeded)})
+        }
 
-        _, err = lbx.ReadByte(reader) // TODO: chaosRanksNeeded
+        chaosRanksNeeded, err := lbx.ReadByte(reader)
         if err != nil {
             return nil, fmt.Errorf("read error: %v", err)
         }
+        if chaosRanksNeeded != 0 {
+            requirements = append(requirements, Requirement{MagicType: data.ChaosMagic, Amount: int(chaosRanksNeeded)})
+        }
 
-        _, err = lbx.ReadByte(reader) // TODO: lifeRanksNeeded
+        lifeRanksNeeded, err := lbx.ReadByte(reader)
         if err != nil {
             return nil, fmt.Errorf("read error: %v", err)
         }
+        if lifeRanksNeeded != 0 {
+            requirements = append(requirements, Requirement{MagicType: data.LifeMagic, Amount: int(lifeRanksNeeded)})
+        }
 
-        _, err = lbx.ReadByte(reader) // TODO: deathRanksNeeded
+        deathRanksNeeded, err := lbx.ReadByte(reader)
         if err != nil {
             return nil, fmt.Errorf("read error: %v", err)
+        }
+        if deathRanksNeeded != 0 {
+            requirements = append(requirements, Requirement{MagicType: data.DeathMagic, Amount: int(deathRanksNeeded)})
         }
 
         // The last byte seems to be some sort of flag
@@ -521,10 +541,10 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
             Name: string(name),
             Image: int(image),
             Cost: int(cost),
-            // Slot: slot,
             Type: artifactType,
             Powers: powers,
             Abilities: abilities,
+            Requirements: requirements,
         }
         out = append(out, artifact)
     }

--- a/game/magic/artifact/view.go
+++ b/game/magic/artifact/view.go
@@ -1,14 +1,13 @@
-package artifactview
+package artifact
 
 import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/artifact"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
 
-func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact artifact.Artifact, font *font.Font, options ebiten.DrawImageOptions) {
+func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact Artifact, font *font.Font, options ebiten.DrawImageOptions) {
     itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
     screen.DrawImage(itemBackground, &options)
 

--- a/game/magic/artifactview/view.go
+++ b/game/magic/artifactview/view.go
@@ -10,7 +10,6 @@ import (
 
 func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact artifact.Artifact, font *font.Font, options ebiten.DrawImageOptions) {
     itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
-    // options.GeoM.Translate(14, 65)
     screen.DrawImage(itemBackground, &options)
 
     itemImage, _ := imageCache.GetImage("items.lbx", artifact.Image, 0)

--- a/game/magic/artifactview/view.go
+++ b/game/magic/artifactview/view.go
@@ -1,0 +1,35 @@
+package artifactview
+
+import (
+    "github.com/kazzmir/master-of-magic/lib/font"
+    "github.com/kazzmir/master-of-magic/game/magic/util"
+    "github.com/kazzmir/master-of-magic/game/magic/artifact"
+
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact artifact.Artifact, font *font.Font, options ebiten.DrawImageOptions) {
+    itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
+    // options.GeoM.Translate(14, 65)
+    screen.DrawImage(itemBackground, &options)
+
+    itemImage, _ := imageCache.GetImage("items.lbx", artifact.Image, 0)
+    options.GeoM.Translate(10, 8)
+    screen.DrawImage(itemImage, &options)
+
+    x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X) + 3, 4)
+    font.Print(screen, x, y, 1, options.ColorScale, artifact.Name)
+
+    dot, _ := imageCache.GetImage("itemisc.lbx", 26, 0)
+    savedGeom := options.GeoM
+    for i, power := range artifact.Powers {
+        options.GeoM = savedGeom
+        options.GeoM.Translate(3, 26)
+        options.GeoM.Translate(float64(i / 2 * 80), float64(i % 2 * 13))
+
+        screen.DrawImage(dot, &options)
+
+        x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1), 0)
+        font.Print(screen, x, y, 1, options.ColorScale, power.Name)
+    }
+}

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1986,7 +1986,16 @@ func (game *Game) doHireMercenaries(yield coroutine.YieldFunc, cost int, units [
 
     var artifactCandidates []*artifact.Artifact
     for _, artifact := range game.ArtifactPool {
-        // TODO: Check requirements (merchant has level 12 in all realms)
+        requirementsMet := true
+        for _, requirement := range artifact.Requirements {
+            if requirement.Amount > 12 {
+                requirementsMet = false
+                break
+            }
+        }
+        if !requirementsMet {
+            continue
+        }
 
         artifactCandidates = append(artifactCandidates, artifact)
     }
@@ -4325,6 +4334,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
 
     game.maybeHireHero(player)
     game.maybeHireMercenaries(player)
+    game.maybeBuyFromMerchant(player)
 
     // game.CenterCamera(player.Cities[0].X, player.Cities[0].Y)
     game.DoNextUnit(player)

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -9,13 +9,12 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
-    "github.com/kazzmir/master-of-magic/game/magic/artifactview"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
 
-func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifact *artifact.Artifact, goldToBuy int, action func(bool)) []*uilib.UIElement {
+func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *artifact.Artifact, goldToBuy int, action func(bool)) []*uilib.UIElement {
     fontLbx, err := cache.GetLbxFile("fonts.lbx")
     if err != nil {
         log.Printf("Unable to read fonts.lbx: %v", err)
@@ -75,7 +74,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifact *artifact.
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             colorScale := ebiten.ColorScale{}
             colorScale.ScaleAlpha(getAlpha())
-            text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifact.Name, goldToBuy)
+            text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifactToBuy.Name, goldToBuy)
             lightFont.PrintWrap(screen, 56, 8, 180, 1, colorScale, text)
         },
     })
@@ -86,7 +85,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifact *artifact.
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
             options.GeoM.Translate(14, 65)
-            artifactview.RenderArtifactBox(screen, &imageCache, *artifact, darkFont, options)
+            artifact.RenderArtifactBox(screen, &imageCache, *artifactToBuy, darkFont, options)
         },
     })
 

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -74,6 +74,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifact *artifact.
         Layer: 1,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             colorScale := ebiten.ColorScale{}
+            colorScale.ScaleAlpha(getAlpha())
             text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifact.Name, goldToBuy)
             lightFont.PrintWrap(screen, 56, 8, 180, 1, colorScale, text)
         },

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -1,0 +1,150 @@
+package game
+
+import (
+    "log"
+    "fmt"
+    "image/color"
+
+    "github.com/kazzmir/master-of-magic/lib/font"
+    "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/game/magic/util"
+    "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/artifactview"
+    uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
+
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifact *artifact.Artifact, goldToBuy int, action func(bool)) []*uilib.UIElement {
+    fontLbx, err := cache.GetLbxFile("fonts.lbx")
+    if err != nil {
+        log.Printf("Unable to read fonts.lbx: %v", err)
+        return nil
+    }
+
+    fonts, err := font.ReadFonts(fontLbx, 0)
+    if err != nil {
+        log.Printf("Unable to read fonts from fonts.lbx: %v", err)
+        return nil
+    }
+
+    imageCache := util.MakeImageCache(cache)
+
+    lightPalette := color.Palette{
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        color.RGBA{R: 0x0, G: 0x0, B: 0x0, A: 0},
+        color.RGBA{R: 0xed, G: 0xa4, B: 0x00, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xbc, B: 0x00, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xd6, B: 0x11, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0, A: 0xff},
+    }
+    darkPalette := color.Palette{
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        util.Lighten(color.RGBA{R: 0xc7, G: 0x82, B: 0x1b, A: 0xff}, 0),
+        util.Lighten(color.RGBA{R: 0xc7, G: 0x82, B: 0x1b, A: 0xff}, 20),
+        util.Lighten(color.RGBA{R: 0xc7, G: 0x82, B: 0x1b, A: 0xff}, 50),
+        util.Lighten(color.RGBA{R: 0xc7, G: 0x82, B: 0x1b, A: 0xff}, 80),
+        color.RGBA{R: 0xc7, G: 0x82, B: 0x1b, A: 0xff},
+        color.RGBA{R: 0xc7, G: 0x82, B: 0x1b, A: 0xff},
+    }
+
+    lightFont := font.MakeOptimizedFontWithPalette(fonts[4], lightPalette)
+    darkFont := font.MakeOptimizedFontWithPalette(fonts[4], darkPalette)
+
+    var elements []*uilib.UIElement
+
+    const fadeSpeed = 7
+
+    getAlpha := ui.MakeFadeIn(fadeSpeed)
+
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            background, _ := imageCache.GetImage("hire.lbx", 2, 0)
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(getAlpha())
+            screen.DrawImage(background, &options)
+        },
+    })
+
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            colorScale := ebiten.ColorScale{}
+            text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifact.Name, goldToBuy)
+            lightFont.PrintWrap(screen, 56, 8, 180, 1, colorScale, text)
+        },
+    })
+
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(getAlpha())
+            options.GeoM.Translate(14, 65)
+            artifactview.RenderArtifactBox(screen, &imageCache, *artifact, darkFont, options)
+        },
+    })
+
+    buttonBackgrounds, _ := imageCache.GetImages("backgrnd.lbx", 24)
+    buyRect := util.ImageRect(252, 121, buttonBackgrounds[0])
+    buyIndex := 0
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Rect: buyRect,
+        LeftClick: func(this *uilib.UIElement){
+            buyIndex = 1
+        },
+        LeftClickRelease: func(this *uilib.UIElement){
+            buyIndex = 0
+            getAlpha = ui.MakeFadeOut(fadeSpeed)
+            ui.AddDelay(fadeSpeed, func(){
+                ui.RemoveElements(elements)
+                action(true)
+            })
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(float64(buyRect.Min.X), float64(buyRect.Min.Y))
+            options.ColorScale.ScaleAlpha(getAlpha())
+            screen.DrawImage(buttonBackgrounds[buyIndex], &options)
+
+            x := float64(buyRect.Min.X + buyRect.Max.X) / 2
+            y := float64(buyRect.Min.Y + buyRect.Max.Y) / 2
+            lightFont.PrintCenter(screen, x, y - 5, 1, options.ColorScale, "Buy")
+        },
+    })
+
+    rejectRect := util.ImageRect(252, 140, buttonBackgrounds[0])
+    rejectIndex := 0
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Rect: rejectRect,
+        LeftClick: func(this *uilib.UIElement){
+            rejectIndex = 1
+        },
+        LeftClickRelease: func(this *uilib.UIElement){
+            getAlpha = ui.MakeFadeOut(fadeSpeed)
+
+            ui.AddDelay(fadeSpeed, func(){
+                ui.RemoveElements(elements)
+                action(false)
+            })
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(float64(rejectRect.Min.X), float64(rejectRect.Min.Y))
+            options.ColorScale.ScaleAlpha(getAlpha())
+            screen.DrawImage(buttonBackgrounds[rejectIndex], &options)
+
+            x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
+            y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
+            lightFont.PrintCenter(screen, x, y - 5, 1, options.ColorScale, "Reject")
+        },
+    })
+
+    return elements
+}

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -65,6 +65,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
             background, _ := imageCache.GetImage("hire.lbx", 2, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
+            options.GeoM.Translate(4, 15)
             screen.DrawImage(background, &options)
         },
     })
@@ -75,7 +76,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
             colorScale := ebiten.ColorScale{}
             colorScale.ScaleAlpha(getAlpha())
             text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifactToBuy.Name, goldToBuy)
-            lightFont.PrintWrap(screen, 56, 8, 180, 1, colorScale, text)
+            lightFont.PrintWrap(screen, 60, 23, 180, 1, colorScale, text)
         },
     })
 
@@ -84,13 +85,13 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(14, 65)
+            options.GeoM.Translate(18, 80)
             artifact.RenderArtifactBox(screen, &imageCache, *artifactToBuy, darkFont, options)
         },
     })
 
     buttonBackgrounds, _ := imageCache.GetImages("backgrnd.lbx", 24)
-    buyRect := util.ImageRect(252, 121, buttonBackgrounds[0])
+    buyRect := util.ImageRect(256, 136, buttonBackgrounds[0])
     buyIndex := 0
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
@@ -118,7 +119,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
         },
     })
 
-    rejectRect := util.ImageRect(252, 140, buttonBackgrounds[0])
+    rejectRect := util.ImageRect(256, 155, buttonBackgrounds[0])
     rejectIndex := 0
     elements = append(elements, &uilib.UIElement{
         Layer: 1,

--- a/game/magic/game/vault.go
+++ b/game/magic/game/vault.go
@@ -10,6 +10,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/artifactview"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     "github.com/kazzmir/master-of-magic/game/magic/magicview"
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
@@ -104,30 +105,8 @@ func (game *Game) showItemPopup(item *artifact.Artifact, cache *lbx.LbxCache, im
     drawer := func (screen *ebiten.Image){
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(getAlpha())
-        itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
-        options.GeoM.Translate(32, 48)
-        screen.DrawImage(itemBackground, &options)
-
-        itemImage, _ := imageCache.GetImage("items.lbx", item.Image, 0)
-        options.GeoM.Translate(10, 8)
-        screen.DrawImage(itemImage, &options)
-
-        x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X) + 3, 4)
-
-        vaultFonts.ItemName.Print(screen, x, y, 1, options.ColorScale, item.Name)
-
-        dot, _ := imageCache.GetImage("itemisc.lbx", 26, 0)
-        savedGeom := options.GeoM
-        for i, power := range item.Powers {
-            options.GeoM = savedGeom
-            options.GeoM.Translate(3, 26)
-            options.GeoM.Translate(float64(i / 2 * 80), float64(i % 2 * 13))
-
-            screen.DrawImage(dot, &options)
-
-            x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1), 0)
-            vaultFonts.PowerFont.Print(screen, x, y, 1, options.ColorScale, power.Name)
-        }
+        options.GeoM.Translate(48, 48)
+        artifactview.RenderArtifactBox(screen, imageCache, *item, vaultFonts.ItemName, options)
     }
 
     logic := func (yield coroutine.YieldFunc) {

--- a/game/magic/game/vault.go
+++ b/game/magic/game/vault.go
@@ -10,7 +10,6 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
-    "github.com/kazzmir/master-of-magic/game/magic/artifactview"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     "github.com/kazzmir/master-of-magic/game/magic/magicview"
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
@@ -106,7 +105,7 @@ func (game *Game) showItemPopup(item *artifact.Artifact, cache *lbx.LbxCache, im
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(getAlpha())
         options.GeoM.Translate(48, 48)
-        artifactview.RenderArtifactBox(screen, imageCache, *item, vaultFonts.ItemName, options)
+        artifact.RenderArtifactBox(screen, imageCache, *item, vaultFonts.ItemName, options)
     }
 
     logic := func (yield coroutine.YieldFunc) {

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -275,6 +275,9 @@ func renderUnitAbilities(screen *ebiten.Image, imageCache *util.ImageCache, unit
                         artifactPic, _ := imageCache.GetImage("items.lbx", artifacts[i].Image, 0)
                         screen.DrawImage(artifactPic, &defaultOptions)
 
+                        x, y := defaultOptions.GeoM.Apply(0, 0)
+                        mediumFont.Print(screen, x + float64(artifactPic.Bounds().Dx() + 2), float64(y) + 5, 1, defaultOptions.ColorScale, artifacts[i].Name)
+
                         artifacts = slices.Delete(artifacts, i, i+1)
                         return float64(artifactPic.Bounds().Dy() + 1)
                     }

--- a/test/merchant/main.go
+++ b/test/merchant/main.go
@@ -60,7 +60,7 @@ func NewEngine(scenario int) (*Engine, error) {
             {
                 Type: artifact.PowerTypeSpellSave,
                 Amount: 2,
-                Name: "+2 Spell Save",
+                Name: "-2 Spell Save",
             },
         },
         Cost: 250,

--- a/test/merchant/main.go
+++ b/test/merchant/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+    "log"
+    "image/color"
+    "strconv"
+    "os"
+
+    "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+    gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
+    uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
+
+    "github.com/hajimehoshi/ebiten/v2"
+    "github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+type Engine struct {
+    LbxCache *lbx.LbxCache
+    UI *uilib.UI
+}
+
+func NewEngine(scenario int) (*Engine, error) {
+    cache := lbx.AutoCache()
+
+    ui := &uilib.UI{
+        Draw: func(ui *uilib.UI, screen *ebiten.Image){
+
+        ui.IterateElementsByLayer(func (element *uilib.UIElement){
+            if element.Draw != nil {
+                element.Draw(element, screen)
+            }
+        })
+
+        },
+    }
+    ui.SetElementsFromArray(nil)
+
+    artifact := &artifact.Artifact{
+        Name: "Excalibur",
+        Image: 7,
+        Type: artifact.ArtifactTypeSword,
+        Powers: []artifact.Power{
+            {
+                Type: artifact.PowerTypeAttack,
+                Amount: 1,
+                Name: "+3 Attack",
+            },
+            {
+                Type: artifact.PowerTypeDefense,
+                Amount: 2,
+                Name: "+2 Defense",
+            },
+            {
+                Type: artifact.PowerTypeSpellSkill,
+                Amount: 2,
+                Name: "+2 Spell Skill",
+            },
+            {
+                Type: artifact.PowerTypeSpellSave,
+                Amount: 2,
+                Name: "+2 Spell Save",
+            },
+        },
+        Cost: 250,
+    }
+
+    ui.AddElements(gamelib.MakeMerchantScreenUI(cache, ui, artifact, 250, func (bought bool){
+        log.Printf("bought %v", bought)
+    }))
+
+    return &Engine{
+        LbxCache: cache,
+        UI: ui,
+    }, nil
+}
+
+func (engine *Engine) Update() error {
+
+    keys := make([]ebiten.Key, 0)
+    keys = inpututil.AppendJustPressedKeys(keys)
+
+    for _, key := range keys {
+        if key == ebiten.KeyEscape || key == ebiten.KeyCapsLock {
+            return ebiten.Termination
+        }
+    }
+
+    engine.UI.StandardUpdate()
+
+    return nil
+}
+
+func (engine *Engine) Draw(screen *ebiten.Image) {
+    screen.Fill(color.RGBA{R: 0, G: 150, B: 150, A: 0xff})
+
+    engine.UI.Draw(engine.UI, screen)
+}
+
+func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
+    return data.ScreenWidth, data.ScreenHeight
+}
+
+func main(){
+    log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
+
+    monitorWidth, _ := ebiten.Monitor().Size()
+    size := monitorWidth / 390
+
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
+    ebiten.SetWindowTitle("summon unit")
+    ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
+
+    scenario := 1
+
+    if len(os.Args) >= 2 {
+        x, err := strconv.Atoi(os.Args[1])
+        if err != nil {
+            log.Fatalf("Error with scenario: %v", err)
+        }
+
+        scenario = x
+    }
+
+    engine, err := NewEngine(scenario)
+
+    if err != nil {
+        log.Printf("Error: unable to load engine: %v", err)
+        return
+    }
+
+    err = ebiten.RunGame(engine)
+    if err != nil {
+        log.Printf("Error: %v", err)
+    }
+}

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -2062,6 +2062,100 @@ func createScenario24(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// merchant
+func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 25")
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerBlue,
+        Race: data.RaceTroll,
+        Abilities: []setup.WizardAbility{
+            setup.AbilityAlchemy,
+            setup.AbilitySageMaster,
+        },
+        Books: []data.WizardBook{
+            {
+                Magic: data.LifeMagic,
+                Count: 3,
+            },
+            {
+                Magic: data.SorceryMagic,
+                Count: 8,
+            },
+        },
+    }
+
+    game := gamelib.MakeGame(cache, setup.NewGameSettings{})
+    game.Plane = data.PlaneArcanus
+
+    x, y := game.FindValidCityLocation()
+    game.CenterCamera(x, y)
+
+    player := game.AddPlayer(wizard, true)
+    player.Gold = 15772
+    player.Mana = 26
+    player.LiftFog(x, y, 3, data.PlaneArcanus)
+
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap())
+    city.Population = 6190
+    city.Plane = data.PlaneArcanus
+    city.Banner = wizard.Banner
+    city.Buildings.Insert(buildinglib.BuildingFortress)
+    city.ProducingBuilding = buildinglib.BuildingGranary
+    city.ProducingUnit = units.UnitNone
+    city.Race = wizard.Race
+    city.Farmers = 5
+    city.Workers = 1
+    city.Wall = false
+    city.ResetCitizens(nil)
+    player.AddCity(city)
+
+    player.AddHero(hero.MakeHero(units.MakeOverworldUnit(units.HeroGunther), hero.HeroGunther, "Gunther"))
+
+    enemy := game.AddPlayer(setup.WizardCustom{
+        Name: "dingus",
+        Banner: data.BannerRed,
+    }, false)
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.KlackonSpearmen, x + 1, y + 1, data.PlaneArcanus, enemy.Wizard.Banner, nil))
+
+    artifact := &artifact.Artifact{
+        Name: "Excalibur",
+        Image: 7,
+        Type: artifact.ArtifactTypeSword,
+        Powers: []artifact.Power{
+            {
+                Type: artifact.PowerTypeAttack,
+                Amount: 1,
+                Name: "+3 Attack",
+            },
+            {
+                Type: artifact.PowerTypeDefense,
+                Amount: 2,
+                Name: "+2 Defense",
+            },
+            {
+                Type: artifact.PowerTypeSpellSkill,
+                Amount: 2,
+                Name: "+2 Spell Skill",
+            },
+            {
+                Type: artifact.PowerTypeSpellSave,
+                Amount: 2,
+                Name: "+2 Spell Save",
+            },
+        },
+        Cost: 250,
+    }
+
+    game.Events <- &gamelib.GameEventMerchant{
+        Player: player,
+        Artifact: artifact,
+        Cost: 1000,
+    }
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -2092,6 +2186,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 22: game = createScenario22(cache)
         case 23: game = createScenario23(cache)
         case 24: game = createScenario24(cache)
+        case 25: game = createScenario25(cache)
         default: game = createScenario1(cache)
     }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1328,11 +1328,7 @@ func createScenario17(cache *lbx.LbxCache) *gamelib.Game {
         Cost: 300,
     }
 
-    artifacts, err := artifact.ReadArtifacts(cache)
-    if err != nil {
-		log.Fatalf("Error reading artifacts")
-    }
-    player.VaultEquipment[1] = &artifacts[1]
+    player.VaultEquipment[1] = game.ArtifactPool["Pummel Mace"]
 
     testArtifact := artifact.Artifact{
         Name: "Sword",
@@ -2118,39 +2114,12 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     }, false)
     enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.KlackonSpearmen, x + 1, y + 1, data.PlaneArcanus, enemy.Wizard.Banner, nil))
 
-    artifact := &artifact.Artifact{
-        Name: "Excalibur",
-        Image: 7,
-        Type: artifact.ArtifactTypeSword,
-        Powers: []artifact.Power{
-            {
-                Type: artifact.PowerTypeAttack,
-                Amount: 1,
-                Name: "+3 Attack",
-            },
-            {
-                Type: artifact.PowerTypeDefense,
-                Amount: 2,
-                Name: "+2 Defense",
-            },
-            {
-                Type: artifact.PowerTypeSpellSkill,
-                Amount: 2,
-                Name: "+2 Spell Skill",
-            },
-            {
-                Type: artifact.PowerTypeSpellSave,
-                Amount: 2,
-                Name: "+2 Spell Save",
-            },
-        },
-        Cost: 250,
-    }
+    artifact := game.ArtifactPool["Pummel Mace"]
 
     game.Events <- &gamelib.GameEventMerchant{
         Player: player,
         Artifact: artifact,
-        Cost: 1000,
+        Cost: artifact.Cost,
     }
 
     return game


### PR DESCRIPTION
Adds the merchant event:

<img width="948" alt="Bildschirmfoto 2025-01-03 um 18 24 53" src="https://github.com/user-attachments/assets/70845c0b-0b24-4acb-8d73-9adac8b2366d" />

All predefined items are read from the `itemdata.lbx` and added to a pool, where they can be taken out by the merchant (or later for lair treasure).

Also adds requirements (number of books in certain magic types) to artifacts and reads them for the predefined items from `itemdata.lbx`

Event generations follows the description in the [wiki](https://masterofmagic.fandom.com/wiki/Merchant):
- generates the event with a chances of `max(10, 2 + player.Fame / 25 [*2 if famous])`
- cost is `artifactCost [/ 2 if charismatic]`
- an item is skipped, if the requirements are not met (the merchant has 12 books in every type of magic)

I further moved the part of drawing an artifact also used in the vault to a new `artifactview` folder.

@kazzmir What do you think?