### PR TITLE
shader: fix edge glow shader corner evaluation

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,6 +13,7 @@
 * overworld: zoom in/out
 * combat: town damage, destroy buildings/people after a battle
 * combat: implement flying fortress
+* add edge glow to enchanted items
 
 9/22/2024 * city view: separate surplus food/gold from subsistence food/gold
 9/22/2024 * overworld path finding to point on map

--- a/game/magic/shaders/edge-glow.kage
+++ b/game/magic/shaders/edge-glow.kage
@@ -23,7 +23,7 @@ func nearbyAlpha(src vec2) float {
     right := imageSrc0At(src + vec2(1, 0))
     up_left := imageSrc0At(src - vec2(1, 1))
     up := imageSrc0At(src - vec2(0, 1))
-    up_right := imageSrc0At(src + vec2(1, 1))
+    up_right := imageSrc0At(src + vec2(1, -1))
     down_left := imageSrc0At(src + vec2(-1, 1))
     down := imageSrc0At(src + vec2(0, 1))
     down_right := imageSrc0At(src + vec2(1, 1))


### PR DESCRIPTION
Just a small bug in the edge glow shader.

Before:
<img width="68" alt="Bildschirmfoto 2025-01-04 um 12 20 31" src="https://github.com/user-attachments/assets/03aab938-141b-4469-bfa3-379f72f22466" />

After:
<img width="64" alt="Bildschirmfoto 2025-01-04 um 12 20 28" src="https://github.com/user-attachments/assets/6504a13f-f0ef-40d6-aaf7-2440dbde37c6" />
