### PR TITLE
Add hero level up message

### DIFF
--- a/TODO
+++ b/TODO
@@ -14,6 +14,7 @@
 * combat: town damage, destroy buildings/people after a battle
 * combat: implement flying fortress
 * add edge glow to enchanted items
+* hero: ability progress (https://masterofmagic.fandom.com/wiki/Experience_Level#Ability_Improvement_Tables_-_Heroes)
 
 9/22/2024 * city view: separate surplus food/gold from subsistence food/gold
 9/22/2024 * overworld path finding to point on map

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2111,14 +2111,17 @@ func (game *Game) doNextTurn(yield coroutine.YieldFunc) {
 }
 
 func (game *Game) AddExperience(player *playerlib.Player, unit units.StackUnit, amount int) {
-    if unit.IsHero() {
-        level_before := units.GetHeroExperienceLevel(unit.GetExperience(), player.Wizard.AbilityEnabled(setup.AbilityWarlord), player.GlobalEnchantments.Contains(data.EnchantmentCrusade))
+    if player.Human && unit.IsHero() {
+        warlord := player.Wizard.AbilityEnabled(setup.AbilityWarlord)
+        crusade := player.GlobalEnchantments.Contains(data.EnchantmentCrusade)
+
+        level_before := units.GetHeroExperienceLevel(unit.GetExperience(), warlord, crusade)
 
         unit.AddExperience(amount)
 
-        level_after := units.GetHeroExperienceLevel(unit.GetExperience(), player.Wizard.AbilityEnabled(setup.AbilityWarlord), player.GlobalEnchantments.Contains(data.EnchantmentCrusade))
+        level_after := units.GetHeroExperienceLevel(unit.GetExperience(), warlord, crusade)
 
-        if player.Human && (level_before != level_after) {
+        if level_before != level_after {
             hero := unit.(*herolib.Hero)
             game.Events <- &GameEventHeroLevelUp{
                 Hero: hero,

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2118,7 +2118,7 @@ func (game *Game) AddExperience(player *playerlib.Player, unit units.StackUnit, 
 
         level_after := units.GetHeroExperienceLevel(unit.GetExperience(), player.Wizard.AbilityEnabled(setup.AbilityWarlord), player.GlobalEnchantments.Contains(data.EnchantmentCrusade))
 
-        if level_before != level_after {
+        if player.Human && (level_before != level_after) {
             hero := unit.(*herolib.Hero)
             game.Events <- &GameEventHeroLevelUp{
                 Hero: hero,

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -285,14 +285,8 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
         // text
         titleFont.Print(screen, left + 48, top + 10, 1, options.ColorScale, fmt.Sprintf("%v has made a level.", hero.Name))
 
-        // stats improvements
-        // FIXME: use logic from hero.GetBaseHitPoints
-        // FIXME: use logic from hero.GetBaseResistance
-        // FIXME: use logic from hero.GetBaseMeleeAttackPower() or hero.GetBaseRangedAttackPower()
-        // FIXME: use logic from hero.GetBaseDefense()
-        // FIXME: define hero.GetBaseImprovements
-        stats := []string{"+1 Hit Points", "+1 Resistance", "+1 Attack", "+1 Defense"}
-        for index, stat := range stats {
+        // stats progression
+        for index, progression := range hero.GetBaseProgression() {
             xOffset := 95 * float64(index / 2)
             yOffset := 10 * float64(index % 2)
 
@@ -300,7 +294,7 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
             options.GeoM.Translate(left + 48 + xOffset, top + 25 + yOffset)
             screen.DrawImage(dot, &options)
 
-            smallFont.Print(screen, left + 55 + xOffset, top + 24 + yOffset, 1, options.ColorScale, stat)
+            smallFont.Print(screen, left + 55 + xOffset, top + 24 + yOffset, 1, options.ColorScale, progression)
         }
 
         // level

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -3,16 +3,20 @@ package game
 import (
     "log"
     "fmt"
+    "image"
     "image/color"
 
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/coroutine"
+    "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
     "github.com/hajimehoshi/ebiten/v2"
+    "github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
 func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero, goldToHire int, action func(bool)) []*uilib.UIElement {
@@ -209,4 +213,131 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
     })
 
     return elements
+}
+
+func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.Hero) {
+    fontLbx, err := game.Cache.GetLbxFile("fonts.lbx")
+    if err != nil {
+        log.Printf("Unable to read fonts.lbx: %v", err)
+        return
+    }
+
+    fonts, err := font.ReadFonts(fontLbx, 0)
+    if err != nil {
+        log.Printf("Unable to read fonts from fonts.lbx: %v", err)
+        return
+    }
+
+    yellowGradient := color.Palette{
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        color.RGBA{R: 0x0, G: 0x0, B: 0x0, A: 0},
+        color.RGBA{R: 0xed, G: 0xa4, B: 0x00, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xbc, B: 0x00, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xd6, B: 0x11, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0, A: 0xff},
+    }
+
+    top := float64(40)
+    left := float64(30)
+    height := 70 // TODO: include height from ability improvements
+
+    titleFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowGradient)
+    smallFont := font.MakeOptimizedFontWithPalette(fonts[2], yellowGradient)
+
+    backgroundTop, _ := game.ImageCache.GetImage("reload.lbx", 23, 0)
+    backgroundTop = backgroundTop.SubImage(image.Rect(0, 0, backgroundTop.Bounds().Dx(), height)).(*ebiten.Image)
+
+    backgroundBottom, _ := game.ImageCache.GetImage("reload.lbx", 24, 0)
+
+    portraitLbx, portraitIndex := hero.GetPortraitLbxInfo()
+    portrait, err := game.ImageCache.GetImage(portraitLbx, portraitIndex, 0)
+
+    dot, _ := game.ImageCache.GetImage("itemisc.lbx", 26, 0)
+
+    drawer := game.Drawer
+    defer func(){
+        game.Drawer = drawer
+    }()
+
+    getAlpha := util.MakeFadeIn(7, &game.Counter)
+
+    game.Drawer = func (screen *ebiten.Image, game *Game){
+        drawer(screen, game)
+
+        var options ebiten.DrawImageOptions
+
+        // background
+        options.GeoM.Translate(left, top)
+        options.ColorScale.ScaleAlpha(getAlpha())
+        screen.DrawImage(backgroundTop, &options)
+
+        options.GeoM.Reset()
+        options.GeoM.Translate(left, top + float64(height))
+        screen.DrawImage(backgroundBottom, &options)
+
+        // portrait
+        options.GeoM.Reset()
+        options.GeoM.Translate(left + 10, top + 10)
+        screen.DrawImage(portrait, &options)
+
+        // text
+        titleFont.Print(screen, left + 48, top + 10, 1, options.ColorScale, fmt.Sprintf("%v has made a level.", hero.Name))
+
+        // stats improvements
+        // FIXME: use logic from hero.GetBaseHitPoints
+        // FIXME: use logic from hero.GetBaseResistance
+        // FIXME: use logic from hero.GetBaseMeleeAttackPower() or hero.GetBaseRangedAttackPower()
+        // FIXME: use logic from hero.GetBaseDefense()
+        // FIXME: define hero.GetBaseImprovements
+        stats := []string{"+1 Hit Points", "+1 Resistance", "+1 Attack", "+1 Defense"}
+        for index, stat := range stats {
+            xOffset := 95 * float64(index / 2)
+            yOffset := 10 * float64(index % 2)
+
+            options.GeoM.Reset()
+            options.GeoM.Translate(left + 48 + xOffset, top + 25 + yOffset)
+            screen.DrawImage(dot, &options)
+
+            smallFont.Print(screen, left + 55 + xOffset, top + 24 + yOffset, 1, options.ColorScale, stat)
+        }
+
+        // level
+        options.GeoM.Reset()
+        options.GeoM.Translate(left + 10, top + 50)
+        unitview.RenderExperienceBadge(screen, &game.ImageCache, hero, smallFont, options, false)
+
+        // TODO: render ability improvements
+    }
+
+    quit := false
+
+    // absorb clicks and key presses
+    yield()
+
+    // fade in
+    getAlpha = util.MakeFadeIn(7, &game.Counter)
+    for i := 0; i < 7; i++ {
+        game.Counter += 1
+        yield()
+    }
+
+
+    for !quit {
+        game.Counter += 1
+
+        if inputmanager.LeftClick() || inpututil.IsKeyJustPressed(ebiten.KeySpace) || inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
+            quit = true
+        }
+
+        yield()
+    }
+
+    // fade out
+    getAlpha = util.MakeFadeOut(7, &game.Counter)
+    for i := 0; i < 7; i++ {
+        game.Counter += 1
+        yield()
+    }
 }

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -972,8 +972,6 @@ func (hero *Hero) GetBaseHitPoints() int {
 }
 
 func (hero *Hero) getBaseHitPointsProgression(level units.HeroExperienceLevel) int {
-    // FIXME: shouldn't this be 10% starting from captain?
-    //        see https://masterofmagic.fandom.com/wiki/Experience_Level#Attribute_Improvement_Table_-_Heroes
     switch level {
         case units.ExperienceHero: return 0
         case units.ExperienceMyrmidon: return 1

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -551,7 +551,9 @@ func (hero *Hero) GetMaxHealth() int {
 }
 
 func (hero *Hero) AddExperience(amount int) {
-    hero.Unit.AddExperience(amount)
+    if hero.Status != StatusDead {
+        hero.Unit.AddExperience(amount)
+    }
 }
 
 func (hero *Hero) GetExperience() int {
@@ -827,22 +829,23 @@ func (hero *Hero) GainLevel(maxLevel units.HeroExperienceLevel) {
 }
 
 func (hero *Hero) GetBaseMeleeAttackPower() int {
-    base := hero.Unit.GetBaseMeleeAttackPower()
-
     level := hero.GetExperienceLevel()
-    switch level {
-        case units.ExperienceHero:
-        case units.ExperienceMyrmidon: base += 1
-        case units.ExperienceCaptain: base += 2
-        case units.ExperienceCommander: base += 3
-        case units.ExperienceChampionHero: base += 4
-        case units.ExperienceLord: base += 5
-        case units.ExperienceGrandLord: base += 6
-        case units.ExperienceSuperHero: base += 7
-        case units.ExperienceDemiGod: base += 8
-    }
+    return hero.Unit.GetBaseMeleeAttackPower() + hero.getBaseMeleeAttackPowerProgression(level)
+}
 
-    return base
+func (hero *Hero) getBaseMeleeAttackPowerProgression(level units.HeroExperienceLevel) int {
+    switch level {
+        case units.ExperienceHero: return 0
+        case units.ExperienceMyrmidon: return 1
+        case units.ExperienceCaptain: return 2
+        case units.ExperienceCommander: return 3
+        case units.ExperienceChampionHero: return 4
+        case units.ExperienceLord: return 5
+        case units.ExperienceGrandLord: return 6
+        case units.ExperienceSuperHero: return 7
+        case units.ExperienceDemiGod: return 8
+    }
+    return 0
 }
 
 func (hero *Hero) GetMeleeAttackPower() int {
@@ -858,25 +861,23 @@ func (hero *Hero) GetMeleeAttackPower() int {
 }
 
 func (hero *Hero) GetBaseRangedAttackPower() int {
-    base := hero.Unit.GetBaseRangedAttackPower()
-    if base == 0 {
-        return 0
-    }
-
     level := hero.GetExperienceLevel()
-    switch level {
-        case units.ExperienceHero:
-        case units.ExperienceMyrmidon: base += 1
-        case units.ExperienceCaptain: base += 2
-        case units.ExperienceCommander: base += 3
-        case units.ExperienceChampionHero: base += 4
-        case units.ExperienceLord: base += 5
-        case units.ExperienceGrandLord: base += 6
-        case units.ExperienceSuperHero: base += 7
-        case units.ExperienceDemiGod: base += 8
-    }
+    return hero.Unit.GetBaseRangedAttackPower() + hero.getBaseRangedAttackPowerProgression(level)
+}
 
-    return base
+func (hero *Hero) getBaseRangedAttackPowerProgression(level units.HeroExperienceLevel) int {
+    switch level {
+        case units.ExperienceHero: return 0
+        case units.ExperienceMyrmidon: return 1
+        case units.ExperienceCaptain: return 2
+        case units.ExperienceCommander: return 3
+        case units.ExperienceChampionHero: return 4
+        case units.ExperienceLord: return 5
+        case units.ExperienceGrandLord: return 6
+        case units.ExperienceSuperHero: return 7
+        case units.ExperienceDemiGod: return 8
+    }
+    return 0
 }
 
 func (hero *Hero) GetRangedAttackPower() int {
@@ -896,22 +897,23 @@ func (hero *Hero) GetRangedAttackPower() int {
 }
 
 func (hero *Hero) GetBaseDefense() int {
-    base := hero.Unit.GetBaseDefense()
-
     level := hero.GetExperienceLevel()
-    switch level {
-        case units.ExperienceHero:
-        case units.ExperienceMyrmidon: base += 1
-        case units.ExperienceCaptain: base += 1
-        case units.ExperienceCommander: base += 2
-        case units.ExperienceChampionHero: base += 2
-        case units.ExperienceLord: base += 3
-        case units.ExperienceGrandLord: base += 3
-        case units.ExperienceSuperHero: base += 4
-        case units.ExperienceDemiGod: base += 4
-    }
+    return hero.Unit.GetBaseDefense() + hero.getBaseDefenseProgression(level)
+}
 
-    return base
+func (hero *Hero) getBaseDefenseProgression(level units.HeroExperienceLevel) int {
+    switch level {
+        case units.ExperienceHero: return 0
+        case units.ExperienceMyrmidon: return 1
+        case units.ExperienceCaptain: return 1
+        case units.ExperienceCommander: return 2
+        case units.ExperienceChampionHero: return 2
+        case units.ExperienceLord: return 3
+        case units.ExperienceGrandLord: return 3
+        case units.ExperienceSuperHero: return 4
+        case units.ExperienceDemiGod: return 4
+    }
+    return 0
 }
 
 func (hero *Hero) GetDefense() int {
@@ -927,22 +929,23 @@ func (hero *Hero) GetDefense() int {
 }
 
 func (hero *Hero) GetBaseResistance() int {
-    base := hero.Unit.GetBaseResistance()
-
     level := hero.GetExperienceLevel()
-    switch level {
-        case units.ExperienceHero:
-        case units.ExperienceMyrmidon: base += 1
-        case units.ExperienceCaptain: base += 2
-        case units.ExperienceCommander: base += 3
-        case units.ExperienceChampionHero: base += 4
-        case units.ExperienceLord: base += 5
-        case units.ExperienceGrandLord: base += 6
-        case units.ExperienceSuperHero: base += 7
-        case units.ExperienceDemiGod: base += 8
-    }
+    return hero.Unit.GetBaseResistance() + hero.getBaseResistanceProgression(level)
+}
 
-    return base
+func (hero *Hero) getBaseResistanceProgression(level units.HeroExperienceLevel) int {
+    switch level {
+        case units.ExperienceHero: return 0
+        case units.ExperienceMyrmidon: return 1
+        case units.ExperienceCaptain: return 2
+        case units.ExperienceCommander: return 3
+        case units.ExperienceChampionHero: return 4
+        case units.ExperienceLord: return 5
+        case units.ExperienceGrandLord: return 6
+        case units.ExperienceSuperHero: return 7
+        case units.ExperienceDemiGod: return 8
+    }
+    return 0
 }
 
 func (hero *Hero) GetResistance() int {
@@ -964,23 +967,57 @@ func (hero *Hero) GetHitPoints() int {
 }
 
 func (hero *Hero) GetBaseHitPoints() int {
-    base := hero.Unit.GetBaseHitPoints()
+    level := hero.GetExperienceLevel()
+    return hero.Unit.GetBaseHitPoints() + hero.getBaseHitPointsProgression(level)
+}
+
+func (hero *Hero) getBaseHitPointsProgression(level units.HeroExperienceLevel) int {
+    // FIXME: shouldn't this be 10% starting from captain?
+    //        see https://masterofmagic.fandom.com/wiki/Experience_Level#Attribute_Improvement_Table_-_Heroes
+    switch level {
+        case units.ExperienceHero: return 0
+        case units.ExperienceMyrmidon: return 1
+        case units.ExperienceCaptain: return 2
+        case units.ExperienceCommander: return 3
+        case units.ExperienceChampionHero: return 4
+        case units.ExperienceLord: return 5
+        case units.ExperienceGrandLord: return 6
+        case units.ExperienceSuperHero: return 7
+        case units.ExperienceDemiGod: return 8
+    }
+    return 0
+}
+
+func (hero *Hero) GetBaseProgression() []string {
+    var improvements []string;
 
     level := hero.GetExperienceLevel()
-    // FIXME: shouldn't this be 10% starting from captain? see https://masterofmagic.fandom.com/wiki/Experience_Level#Attribute_Improvement_Table_-_Heroes
-    switch level {
-        case units.ExperienceHero:
-        case units.ExperienceMyrmidon: base += 1
-        case units.ExperienceCaptain: base += 2
-        case units.ExperienceCommander: base += 3
-        case units.ExperienceChampionHero: base += 4
-        case units.ExperienceLord: base += 5
-        case units.ExperienceGrandLord: base += 6
-        case units.ExperienceSuperHero: base += 7
-        case units.ExperienceDemiGod: base += 8
+    if level <= units.ExperienceHero {
+        return improvements
     }
 
-    return base
+    hitPoints := hero.getBaseHitPointsProgression(level) - hero.getBaseHitPointsProgression(level - 1)
+    if hitPoints > 0 {
+        improvements = append(improvements, fmt.Sprintf("+%v Hit Points", hitPoints))
+    }
+
+    resistance := hero.getBaseResistanceProgression(level) - hero.getBaseResistanceProgression(level - 1)
+    if resistance > 0 {
+        improvements = append(improvements, fmt.Sprintf("+%v Resistance", resistance))
+    }
+
+    meleeAttack := hero.getBaseMeleeAttackPowerProgression(level) - hero.getBaseMeleeAttackPowerProgression(level - 1)
+    rangedAttack := hero.getBaseRangedAttackPowerProgression(level) - hero.getBaseRangedAttackPowerProgression(level - 1)
+    if meleeAttack > 0 || rangedAttack > 0{
+        improvements = append(improvements, fmt.Sprintf("+%v Attack", min(meleeAttack, rangedAttack)))
+    }
+
+    defense := hero.getBaseDefenseProgression(level) - hero.getBaseDefenseProgression(level - 1)
+    if defense > 0 {
+        improvements = append(improvements, fmt.Sprintf("+%v Defense", defense))
+    }
+
+    return improvements
 }
 
 func (hero *Hero) GetAbilities() []data.Ability {

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -967,6 +967,7 @@ func (hero *Hero) GetBaseHitPoints() int {
     base := hero.Unit.GetBaseHitPoints()
 
     level := hero.GetExperienceLevel()
+    // FIXME: shouldn't this be 10% starting from captain? see https://masterofmagic.fandom.com/wiki/Experience_Level#Attribute_Improvement_Table_-_Heroes
     switch level {
         case units.ExperienceHero:
         case units.ExperienceMyrmidon: base += 1

--- a/game/magic/hero/hero_test.go
+++ b/game/magic/hero/hero_test.go
@@ -4,6 +4,7 @@ import (
     "testing"
     "math"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/units"
 )
 
 func floatEqual(a, b float32) bool {
@@ -72,4 +73,13 @@ func TestHero(test *testing.T){
         test.Errorf("Theria should have 5 Caster ability")
     }
 
+    if len(theria.GetBaseProgression()) != 0 {
+        test.Errorf("There should be no progression yet")
+    }
+
+    theria.GainLevel(units.ExperienceMyrmidon)
+
+    if len(theria.GetBaseProgression()) != 4 {
+        test.Errorf("There should be progression yet")
+    }
 }

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -243,19 +243,27 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
     showNIcons(healthIcon, unit.GetBaseHitPoints(), healthIconGold, unit.GetHitPoints() - unit.GetBaseHitPoints(), x, y)
 }
 
+func RenderExperienceBadge(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitView, font *font.Font, defaultOptions ebiten.DrawImageOptions, showExperience bool) (float64) {
+    data := unit.GetExperienceData()
+    experienceIndex := 102 + data.ToInt()
+    pic, _ := imageCache.GetImage("special.lbx", experienceIndex, 0)
+    screen.DrawImage(pic, &defaultOptions)
+    x, y := defaultOptions.GeoM.Apply(0, 0)
+    text := data.Name()
+    if showExperience {
+        text = fmt.Sprintf("%v (%v ep)", data.Name(), unit.GetExperience())
+    }
+    font.Print(screen, x + float64(pic.Bounds().Dx() + 2), float64(y) + 5, 1, defaultOptions.ColorScale, text)
+    return float64(pic.Bounds().Dy() + 1)
+}
+
 func renderUnitAbilities(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitView, mediumFont *font.Font, defaultOptions ebiten.DrawImageOptions, pureAbilities bool, page uint32) {
     var renders []func() float64
 
     if !pureAbilities {
         // experience badge
         renders = append(renders, func() float64 {
-            data := unit.GetExperienceData()
-            experienceIndex := 102 + data.ToInt()
-            pic, _ := imageCache.GetImage("special.lbx", experienceIndex, 0)
-            screen.DrawImage(pic, &defaultOptions)
-            x, y := defaultOptions.GeoM.Apply(0, 0)
-            mediumFont.Print(screen, x + float64(pic.Bounds().Dx() + 2), float64(y) + 5, 1, defaultOptions.ColorScale, fmt.Sprintf("%v (%v ep)", data.Name(), unit.GetExperience()))
-            return float64(pic.Bounds().Dy() + 1)
+            return RenderExperienceBadge(screen, imageCache, unit, mediumFont, defaultOptions, true)
         })
 
         artifacts := slices.Clone(unit.GetArtifacts())

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -2129,6 +2129,70 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// hero level up
+func createScenario26(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 26")
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerBlue,
+        Race: data.RaceTroll,
+        Abilities: []setup.WizardAbility{
+            setup.AbilityAlchemy,
+            setup.AbilitySageMaster,
+        },
+        Books: []data.WizardBook{
+            {
+                Magic: data.LifeMagic,
+                Count: 3,
+            },
+            {
+                Magic: data.SorceryMagic,
+                Count: 8,
+            },
+        },
+    }
+
+    game := gamelib.MakeGame(cache, setup.NewGameSettings{})
+    game.Plane = data.PlaneArcanus
+
+    x, y := game.FindValidCityLocation()
+    game.CenterCamera(x, y)
+
+    player := game.AddPlayer(wizard, true)
+    player.Gold = 15772
+    player.Mana = 26
+    player.LiftFog(x, y, 3, data.PlaneArcanus)
+
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap())
+    city.Population = 6190
+    city.Plane = data.PlaneArcanus
+    city.Banner = wizard.Banner
+    city.Buildings.Insert(buildinglib.BuildingFortress)
+    city.ProducingBuilding = buildinglib.BuildingGranary
+    city.ProducingUnit = units.UnitNone
+    city.Race = wizard.Race
+    city.Farmers = 5
+    city.Workers = 1
+    city.Wall = false
+    city.ResetCitizens(nil)
+    player.AddCity(city)
+
+    gunther := hero.MakeHero(units.MakeOverworldUnit(units.HeroGunther), hero.HeroGunther, "Gunther")
+    reywind := hero.MakeHero(units.MakeOverworldUnit(units.HeroReywind), hero.HeroReywind, "Reywind")
+    player.AddHero(gunther)
+    player.AddHero(reywind)
+    gunther.AddExperience(19)
+    reywind.AddExperience(58)
+
+    enemy := game.AddPlayer(setup.WizardCustom{
+        Name: "dingus",
+        Banner: data.BannerRed,
+    }, false)
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.KlackonSpearmen, x + 1, y + 1, data.PlaneArcanus, enemy.Wizard.Banner, nil))
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -2160,6 +2224,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 23: game = createScenario23(cache)
         case 24: game = createScenario24(cache)
         case 25: game = createScenario25(cache)
+        case 26: game = createScenario26(cache)
         default: game = createScenario1(cache)
     }
 


### PR DESCRIPTION
Adds the hero level up popup:

<img width="825" alt="Bildschirmfoto 2025-01-05 um 11 35 58" src="https://github.com/user-attachments/assets/f384edef-6c53-48ad-85c4-23bc22dd858d" />

The overworld scenario 26 contains two heros:
- Gunther will gain the next level at the start of the turn
- Raywind will gain the next level if combat against the spearman is won

Does not render the ability improvements (they seem not to be implemented yet).