### PR TITLE
pathfinding: take map wrapping into account

### DIFF
--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -1177,7 +1177,7 @@ func (model *CombatModel) computePath(x1 int, y1 int, x2 int, y2 int, canTravers
         return out
     }
 
-    return pathfinding.FindPath(image.Pt(x1, y1), image.Pt(x2, y2), 50, tileCost, neighbors)
+    return pathfinding.FindPath(image.Pt(x1, y1), image.Pt(x2, y2), 50, tileCost, neighbors, pathfinding.PointEqual)
 }
 
 /* return a valid path that the given unit can take to reach tile position x, y

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1595,7 +1595,16 @@ func (game *Game) FindPath(oldX int, oldY int, newX int, newY int, stack *player
         return out
     }
 
-    path, ok := pathfinding.FindPath(image.Pt(oldX, oldY), image.Pt(newX, newY), 10000, tileCost, neighbors)
+    normalized := func (a image.Point) image.Point {
+        return image.Pt(useMap.WrapX(a.X), a.Y)
+    }
+
+    // check equality of two points taking wrapping into account
+    tileEqual := func (a image.Point, b image.Point) bool {
+        return normalized(a) == normalized(b)
+    }
+
+    path, ok := pathfinding.FindPath(image.Pt(oldX, oldY), image.Pt(newX, newY), 10000, tileCost, neighbors, tileEqual)
     if ok {
         return path[1:]
     }

--- a/game/magic/pathfinding/path_test.go
+++ b/game/magic/pathfinding/path_test.go
@@ -89,7 +89,7 @@ func TestPath1(test *testing.T){
     tileCost := makeTileCost(tiles)
     neighbors := makeNeighbors(tiles)
 
-    path, ok := FindPath(start, end, 10, tileCost, neighbors)
+    path, ok := FindPath(start, end, 10, tileCost, neighbors, PointEqual)
     if !ok {
         test.Errorf("unable to find path")
     }
@@ -102,7 +102,7 @@ func TestPath1(test *testing.T){
         test.Errorf("path not as expected: expected=%v actual=%v", expectedPath, path)
     }
 
-    path2, ok := FindPath(start, end, 3, tileCost, neighbors)
+    path2, ok := FindPath(start, end, 3, tileCost, neighbors, PointEqual)
     if ok {
         test.Errorf("expected no path, but found one: %v", path2)
     }
@@ -132,7 +132,7 @@ XXX3
     tileCost := makeTileCost(tiles)
     neighbors := makeNeighbors(tiles)
 
-    path, ok := FindPath(start, end, 12, tileCost, neighbors)
+    path, ok := FindPath(start, end, 12, tileCost, neighbors, PointEqual)
     if !ok {
         test.Errorf("unable to find path")
     }
@@ -162,7 +162,7 @@ XXXX
     tileCost := makeTileCost(tiles)
     neighbors := makeNeighbors(tiles)
 
-    _, ok := FindPath(start, end, Infinity, tileCost, neighbors)
+    _, ok := FindPath(start, end, Infinity, tileCost, neighbors, PointEqual)
     if ok {
         test.Errorf("able to find path through blocked map")
     }
@@ -188,7 +188,7 @@ func TestStress(test *testing.T){
     start := image.Pt(0, 0)
     end := image.Pt(99, 99)
 
-    _, ok := FindPath(start, end, 100000, makeTileCost(tiles), makeNeighbors(tiles))
+    _, ok := FindPath(start, end, 100000, makeTileCost(tiles), makeNeighbors(tiles), PointEqual)
     if !ok {
         test.Errorf("unable to find path")
     }
@@ -199,7 +199,7 @@ func TestStress(test *testing.T){
         if start.Eq(end) {
             continue
         }
-        _, ok := FindPath(start, end, 100000, makeTileCost(tiles), makeNeighbors(tiles))
+        _, ok := FindPath(start, end, 100000, makeTileCost(tiles), makeNeighbors(tiles), PointEqual)
         if !ok {
             test.Errorf("unable to find path")
         }
@@ -210,7 +210,7 @@ func BenchmarkLarge(bench *testing.B){
     tiles := makeRandomMap(100, 100, 10)
     bench.ResetTimer()
     for range bench.N {
-        FindPath(image.Pt(0, 0), image.Pt(99, 99), 100000, makeTileCost(tiles), makeNeighbors(tiles))
+        FindPath(image.Pt(0, 0), image.Pt(99, 99), 100000, makeTileCost(tiles), makeNeighbors(tiles), PointEqual)
     }
 }
 
@@ -218,6 +218,6 @@ func BenchmarkSmall(bench *testing.B){
     tiles := makeRandomMap(20, 20, 10)
     bench.ResetTimer()
     for range bench.N {
-        FindPath(image.Pt(0, 0), image.Pt(19, 19), 100000, makeTileCost(tiles), makeNeighbors(tiles))
+        FindPath(image.Pt(0, 0), image.Pt(19, 19), 100000, makeTileCost(tiles), makeNeighbors(tiles), PointEqual)
     }
 }

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -121,7 +121,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     enemy1.AddUnit(units.MakeOverworldUnitFromUnit(units.Warlocks, x + 2, y + 2, data.PlaneArcanus, enemy1.Wizard.Banner, nil))
     enemy1.AddUnit(units.MakeOverworldUnitFromUnit(units.HighMenBowmen, x + 2, y + 2, data.PlaneArcanus, enemy1.Wizard.Banner, nil))
 
-    game.Camera.Center(x, y)
+    game.Camera.Center(stack.X(), stack.Y())
 
     return game
 }


### PR DESCRIPTION
If the map is 50 tiles long then (49,0) should be 1 unit away from (0,0), so pathfinding has to take into account the fact that (50,0) is the same as (0,0).