### PR TITLE
units: allow user to modify path after movement, add G icon

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2506,7 +2506,7 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
         oldX := stack.X()
         oldY := stack.Y()
 
-        if len(stack.CurrentPath) == 0 {
+        if len(stack.CurrentPath) == 0 || stack.OutOfMoves() {
 
             dx := 0
             dy := 0
@@ -2558,6 +2558,13 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
                         } else {
                             stack.CurrentPath = path
                         }
+                    }
+                } else {
+                    path := game.FindPath(oldX, oldY, newX, newY, stack, player.GetFog(game.Plane))
+                    if path == nil {
+                        game.blinkRed(yield)
+                    } else {
+                        stack.CurrentPath = path
                     }
                 }
             }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4803,7 +4803,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
         location := image.Point{stack.X(), stack.Y()}
         _, hasCity := cityPositions[location]
 
-        if stack == overworld.SelectedStack && (overworld.ShowAnimation || overworld.Counter / 55 % 2 == 0) {
+        if stack == overworld.SelectedStack && (stack.OutOfMoves() || (overworld.ShowAnimation || overworld.Counter / 55 % 2 == 0)) {
             doDraw = true
         } else if stack == overworld.MovingStack {
             doDraw = true
@@ -4847,6 +4847,19 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
                 if enchantment != data.UnitEnchantmentNone {
                     x, y := options.GeoM.Apply(0, 0)
                     util.DrawOutline(screen, overworld.ImageCache, pic, x, y, overworld.Counter/10, enchantment.Color())
+                }
+            }
+
+            if stack == overworld.SelectedStack {
+                boot, _ := overworld.ImageCache.GetImage("compix.lbx", 72, 0)
+                for _, point := range stack.CurrentPath {
+                    var options ebiten.DrawImageOptions
+                    x, y := convertTileCoordinates(overworld.ToCameraCoordinates(point.X, point.Y))
+                    options.GeoM.Translate(float64(x), float64(y))
+                    options.GeoM.Translate(float64(tileWidth) / 2, float64(tileHeight) / 2)
+                    options.GeoM.Translate(float64(boot.Bounds().Dx()) / -2, float64(boot.Bounds().Dy()) / -2)
+                    options.GeoM.Concat(geom)
+                    screen.DrawImage(boot, &options)
                 }
             }
         }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -508,6 +508,7 @@ func MakeGame(lbxCache *lbx.LbxCache, settings setup.NewGameSettings) *Game {
 
     whitePalette := color.Palette{
         color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
         color.White, color.White, color.White, color.White,
     }
 
@@ -3928,6 +3929,12 @@ func (game *Game) MakeHudUI() *uilib.UI {
 
                     if weapon != nil {
                         screen.DrawImage(weapon, &weaponOptions)
+                    }
+
+                    // draw a G on the unit if they are moving
+                    if len(stack.CurrentPath) != 0 {
+                        x, y := options.GeoM.Apply(1, 1)
+                        game.WhiteFont.Print(screen, x, y, 1, options.ColorScale, "G")
                     }
                 },
             })

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2555,17 +2555,24 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
                 if len(activeUnits) > 0 {
                     if newY > 0 && newY < mapUse.Height() {
 
+                        var inactiveStack *playerlib.UnitStack
+
                         inactiveUnits := stack.InactiveUnits()
                         if len(inactiveUnits) > 0 {
                             stack.RemoveUnits(inactiveUnits)
-                            player.AddStack(playerlib.MakeUnitStackFromUnits(inactiveUnits))
+                            inactiveStack = player.AddStack(playerlib.MakeUnitStackFromUnits(inactiveUnits))
                             game.RefreshUI()
                         }
 
                         path := game.FindPath(oldX, oldY, newX, newY, stack, player.GetFog(game.Plane))
                         if path == nil {
                             game.blinkRed(yield)
+                            player.MergeStacks(stack, inactiveStack)
                         } else {
+                            // FIXME: i'm not sure this can ever occur in practice
+                            if inactiveStack != nil {
+                                inactiveStack.CurrentPath = stack.CurrentPath
+                            }
                             stack.CurrentPath = path
                         }
                     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4803,7 +4803,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
         location := image.Point{stack.X(), stack.Y()}
         _, hasCity := cityPositions[location]
 
-        if stack == overworld.SelectedStack && (stack.OutOfMoves() || (overworld.ShowAnimation || overworld.Counter / 55 % 2 == 0)) {
+        if stack == overworld.SelectedStack && (overworld.ShowAnimation || overworld.Counter / 55 % 2 == 0) {
             doDraw = true
         } else if stack == overworld.MovingStack {
             doDraw = true
@@ -4850,17 +4850,18 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
                 }
             }
 
-            if stack == overworld.SelectedStack {
-                boot, _ := overworld.ImageCache.GetImage("compix.lbx", 72, 0)
-                for _, point := range stack.CurrentPath {
-                    var options ebiten.DrawImageOptions
-                    x, y := convertTileCoordinates(overworld.ToCameraCoordinates(point.X, point.Y))
-                    options.GeoM.Translate(float64(x), float64(y))
-                    options.GeoM.Translate(float64(tileWidth) / 2, float64(tileHeight) / 2)
-                    options.GeoM.Translate(float64(boot.Bounds().Dx()) / -2, float64(boot.Bounds().Dy()) / -2)
-                    options.GeoM.Concat(geom)
-                    screen.DrawImage(boot, &options)
-                }
+        }
+
+        if stack == overworld.SelectedStack {
+            boot, _ := overworld.ImageCache.GetImage("compix.lbx", 72, 0)
+            for _, point := range stack.CurrentPath {
+                var options ebiten.DrawImageOptions
+                x, y := convertTileCoordinates(overworld.ToCameraCoordinates(point.X, point.Y))
+                options.GeoM.Translate(float64(x), float64(y))
+                options.GeoM.Translate(float64(tileWidth) / 2, float64(tileHeight) / 2)
+                options.GeoM.Translate(float64(boot.Bounds().Dx()) / -2, float64(boot.Bounds().Dy()) / -2)
+                options.GeoM.Concat(geom)
+                screen.DrawImage(boot, &options)
             }
         }
     }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -601,8 +601,9 @@ func (player *Player) RemoveCity(city *citylib.City) {
     })
 }
 
-func (player *Player) AddStack(stack *UnitStack){
+func (player *Player) AddStack(stack *UnitStack) *UnitStack {
     player.Stacks = append(player.Stacks, stack)
+    return stack
 }
 
 func (player *Player) AddUnit(unit units.StackUnit) units.StackUnit {

--- a/game/magic/player/stack.go
+++ b/game/magic/player/stack.go
@@ -190,7 +190,7 @@ func (stack *UnitStack) Move(dx int, dy int, cost fraction.Fraction){
 // true if no unit has any moves left
 func (stack *UnitStack) OutOfMoves() bool {
     for _, unit := range stack.units {
-        if unit.GetMovesLeft().GreaterThan(fraction.Zero()) {
+        if !unit.GetPatrol() && unit.GetMovesLeft().GreaterThan(fraction.Zero()) {
             return false
         }
     }


### PR DESCRIPTION
Show a G icon in the UI for a stack of units that are moving.

![image](https://github.com/user-attachments/assets/c52f9279-13d2-402c-bd72-c5ffea6bac31)

Also allow to change the path of a unit that has already exhausted its moves.