### PR TITLE
Limit movement icon

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1426,6 +1426,8 @@ func (game *Game) showMovement(yield coroutine.YieldFunc, oldX int, oldY int, st
     game.Drawer = func (screen *ebiten.Image, game *Game){
         drawer(screen, game)
 
+        overworldScreen := screen.SubImage(image.Rect(0, 18, 240, data.ScreenHeight)).(*ebiten.Image)
+
         // draw boot images on the map that show where the unit is moving to
         for _, point := range stack.CurrentPath {
             var options ebiten.DrawImageOptions
@@ -1434,7 +1436,7 @@ func (game *Game) showMovement(yield coroutine.YieldFunc, oldX int, oldY int, st
             options.GeoM.Translate(float64(tileWidth) / 2, float64(tileHeight) / 2)
             options.GeoM.Translate(float64(boot.Bounds().Dx()) / -2, float64(boot.Bounds().Dy()) / -2)
             options.GeoM.Concat(geom)
-            screen.DrawImage(boot, &options)
+            overworldScreen.DrawImage(boot, &options)
         }
 
     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1560,6 +1560,16 @@ func (game *Game) FindPath(oldX int, oldY int, newX int, newY int, stack *player
             }
         }
 
+        // same logic as magic nodes
+        lair := useMap.GetLair(x2, y2)
+        if lair != nil {
+            if !tileEqual(image.Pt(x2, y2), image.Pt(newX, newY)) {
+                if !lair.Empty {
+                    return pathfinding.Infinity
+                }
+            }
+        }
+
         tileFrom := useMap.GetTile(x1, y1)
         tileTo := useMap.GetTile(x2, y2)
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -111,6 +111,7 @@ func randomEncounterType() EncounterType {
 type ExtraEncounter struct {
     Type EncounterType
     Units []units.Unit
+    Empty bool
 }
 
 // choices is a map from a name to the chance of choosing that name, where all the int values should add up to 100

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1831,6 +1831,7 @@ func createScenario22(cache *lbx.LbxCache) *gamelib.Game {
     player.LiftFog(x, y, 3, data.PlaneArcanus)
 
     drake := player.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, nil))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, nil))
 
     for i := 0; i < 1; i++ {
         fireElemental := player.AddUnit(units.MakeOverworldUnitFromUnit(units.FireElemental, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, nil))


### PR DESCRIPTION
1. limit drawing the overworld to a subimage of the screen so that icons/tiles don't accidentally get drawn onto the UI part
2. ignore pathfinding through lair/caves, and also set a lair/cave to empty if the monsters are defeated