### PR TITLE
lbxdump: dump terrain tiles by index

### DIFF
--- a/util/lbxdump/main.go
+++ b/util/lbxdump/main.go
@@ -16,6 +16,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/terrain"
 )
 
 func dumpLbx(reader io.ReadSeeker, lbxName string, onlyIndex int, rawDump bool) error {
@@ -32,26 +33,25 @@ func dumpLbx(reader io.ReadSeeker, lbxName string, onlyIndex int, rawDump bool) 
     os.Mkdir(dir, 0755)
 
     if lbxName == "terrain.lbx" && !rawDump {
-        index := 0
-        images, err := file.ReadTerrainImages(index)
+        terrainData, err := terrain.ReadTerrainData(&file)
         if err != nil {
             return err
         }
 
-        // fmt.Printf("Loaded %v images\n", len(images))
-        for i, image := range images {
-            func (){
-                name := filepath.Join(dir, fmt.Sprintf("image_%v_%v.png", index, i))
-                out, err := os.Create(name)
-                if err != nil {
-                    fmt.Printf("Error creating image file: %v\n", err)
-                    return
-                }
-                defer out.Close()
+        for i, tile := range terrainData.Tiles {
+            for j, image := range tile.Images {
+                func (){
+                    name := filepath.Join(dir, fmt.Sprintf("image_%04d_0x%03x_%v.png", i, i, j))
+                    out, err := os.Create(name)
+                    if err != nil {
+                        fmt.Printf("Error creating image file: %v\n", err)
+                        return
+                    }
+                    defer out.Close()
 
-                png.Encode(out, image)
-                // fmt.Printf("Saved image %v to %v\n", i, name)
-            }()
+                    png.Encode(out, image)
+                }()
+            }
         }
     } else if lbxName == "fonts.lbx" && !rawDump {
         fonts, err := font.ReadFonts(&file, 0)


### PR DESCRIPTION
Currently, finding the correct terrain image for a tile is challenging because images from an animation group increment the counter in the filename.

Using `ReadTerrainData` allows the dumped files to be named separately by their index and animation index (although dumping now relies on the tile definitions in terrain and not only on the file itself anymore).

I suggest showing both the index in decimal (4 digits) as hex. This way the files are ordered nicely and the image for a tile index can be found easily.

Example: `image_0201_0x0c9_0`

