### PR TITLE
map: make random terrain placement appear less arbitrary

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -609,7 +609,7 @@ func (game *Game) FindValidCityLocation() (int, int) {
             x := continent[index].X
             y := continent[index].Y
 
-            if y > 3 && y < mapUse.Map.Columns() - 3 && mapUse.Map.Terrain[x][y] == terrain.TileLand.Index(mapUse.Plane) {
+            if y > 3 && y < mapUse.Map.Columns() - 3 && terrain.GetTile(mapUse.Map.Terrain[x][y]).IsLand() {
                 return x, y
             }
         }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -599,7 +599,7 @@ func (game *Game) NearCity(point image.Point, squares int) bool {
 
 func (game *Game) FindValidCityLocation() (int, int) {
     mapUse := game.CurrentMap()
-    continents := mapUse.Map.FindContinents(mapUse.Plane)
+    continents := mapUse.Map.FindContinents()
 
     for i := 0; i < 10; i++ {
         continentIndex := rand.IntN(len(continents))
@@ -620,7 +620,7 @@ func (game *Game) FindValidCityLocation() (int, int) {
 
 func (game *Game) FindValidCityLocationOnContinent(x int, y int) (int, int) {
     mapUse := game.CurrentMap()
-    continents := mapUse.Map.FindContinents(mapUse.Plane)
+    continents := mapUse.Map.FindContinents()
 
     for _, continent := range continents {
         if continent.Contains(image.Pt(x, y)) {

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -60,7 +60,7 @@ func (map_ *Map) FloodWalk(x int, y int, f FloodFunc){
     walk(x, y)
 }
 
-func (map_ *Map) FindContinents(plane data.Plane) []Continent {
+func (map_ *Map) FindContinents() []Continent {
 
     seen := makeCells(map_.Rows(), map_.Columns())
 
@@ -334,7 +334,7 @@ func GenerateLandCellularAutomata(rows int, columns int, data *TerrainData, plan
 // put down other tiles like forests, mountains, special nodes, etc
 func (map_ *Map) PlaceRandomTerrainTiles(plane data.Plane){
 
-    continents := map_.FindContinents(plane)
+    continents := map_.FindContinents()
 
     randomGrasslands := func(y int) int {
         choices := []int{
@@ -409,7 +409,7 @@ func (map_ *Map) PlaceRandomTerrainTiles(plane data.Plane){
 
 // remove land masses that contain less squares than 'area'
 func (map_ *Map) RemoveSmallIslands(area int, plane data.Plane){
-    continents := map_.FindContinents(plane)
+    continents := map_.FindContinents()
 
     for _, continent := range continents {
         if continent.Size() < area {

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -93,7 +93,7 @@ func (map_ *Map) FindContinents(plane data.Plane) []Continent {
                     ny := y + dy
 
                     if nx >= 0 && nx < columns && ny >= 0 && ny < rows {
-                        if map_.Terrain[nx][ny] == TileLand.Index(plane) {
+                        if GetTile(map_.Terrain[nx][ny]).IsLand() {
                             *continent = append(*continent, image.Pt(nx, ny))
                             // searchTiles(nx, ny, continent)
                             search = append(search, image.Pt(nx, ny))
@@ -108,7 +108,7 @@ func (map_ *Map) FindContinents(plane data.Plane) []Continent {
 
     for x := 0; x < map_.Columns(); x++ {
         for y := 0; y < map_.Rows(); y++ {
-            if map_.Terrain[x][y] == TileLand.Index(plane) && seen[x][y] == false {
+            if GetTile(map_.Terrain[x][y]).IsLand() && seen[x][y] == false {
                 var continent Continent
                 continent = append(continent, image.Pt(x, y))
                 searchTiles(x, y, &continent)

--- a/game/magic/terrain/terrain.go
+++ b/game/magic/terrain/terrain.go
@@ -504,7 +504,7 @@ func expand4(value uint8) uint8 {
     return v1 | v2 | v3 | v4
 }
 
-func getTile(index int) Tile {
+func GetTile(index int) Tile {
     if index >= MyrrorStart {
         index -= MyrrorStart
     }
@@ -1557,7 +1557,7 @@ func ReadTerrainData(lbxFile *lbx.LbxFile) (*TerrainData, error) {
         tiles = append(tiles, TerrainTile{
             ImageIndex: index,
             TileIndex: tileIndex,
-            Tile: getTile(tileIndex),
+            Tile: GetTile(tileIndex),
             Images: tileImages,
         })
 


### PR DESCRIPTION
Make the random terrain placement a bit less arbitrary looking by:
- placing tundra only near the poles
- placing desert only near the center
- use some weights
- generate a bit less land in general
- generate a bit less land at the poles

<img width="563" alt="Bildschirmfoto 2025-01-14 um 21 09 20" src="https://github.com/user-attachments/assets/580cce2f-bb7d-4025-87ba-a93bc39014c1" />
