### PR TITLE
create artifact: pass in runemaster retort for cost adjustment

### DIFF
--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -312,7 +312,7 @@ func getName(artifact *Artifact, customName string) string {
     return prefix + base + postfix
 }
 
-func calculateCost(artifact *Artifact, costs map[Power]int, artificer bool) int {
+func calculateCost(artifact *Artifact, costs map[Power]int, artificer bool, runemaster bool) int {
     base := 0
     switch artifact.Type {
         case ArtifactTypeSword: base = 100
@@ -344,13 +344,20 @@ func calculateCost(artifact *Artifact, costs map[Power]int, artificer bool) int 
 
     cost := base + powerCost + spellCost
 
+    reduction := 0.0
+
     if artificer {
-        cost /= 2
+        reduction += 0.5
     }
-    return cost
+
+    if runemaster {
+        reduction += 0.25
+    }
+
+    return int(float64(cost) - float64(cost) * reduction)
 }
 
-func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, nameFont *font.Font, powerFont *font.Font, picLow int, picHigh int, powerGroups [][]Power, costs map[Power]int, artifact *Artifact, customName *string, selectCount *int, artificer bool) []*uilib.UIElement {
+func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, nameFont *font.Font, powerFont *font.Font, picLow int, picHigh int, powerGroups [][]Power, costs map[Power]int, artifact *Artifact, customName *string, selectCount *int, artificer bool, runemaster bool) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
     // image
@@ -533,7 +540,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                             *selectCount -= 1
                             artifact.RemovePower(power)
                             artifact.Name = getName(artifact, *customName)
-                            artifact.Cost = calculateCost(artifact, costs, artificer)
+                            artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                             lastPower = nil
                         } else {
                             // something was already selected in this group, so the count doesn't change
@@ -541,7 +548,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                             artifact.RemovePower(*lastPower)
                             artifact.AddPower(power)
                             artifact.Name = getName(artifact, *customName)
-                            artifact.Cost = calculateCost(artifact, costs, artificer)
+                            artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                             lastPower = &power
                         }
                     } else {
@@ -550,7 +557,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                             groupSelect = i
                             artifact.AddPower(power)
                             artifact.Name = getName(artifact, *customName)
-                            artifact.Cost = calculateCost(artifact, costs, artificer)
+                            artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                             lastPower = &power
                         } else {
                             ui.AddElement(uilib.MakeErrorElement(ui, cache, imageCache, "Only four powers may be enchanted into an item", func(){}))
@@ -584,7 +591,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
     return elements
 }
 
-func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, artifact *Artifact, customName *string, powerFont *font.Font, powers []Power, compatibilities map[Power]set.Set[ArtifactType], costs map[Power]int, selectCount *int, magicLevel MagicLevel, artificer bool) []*uilib.UIElement {
+func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, artifact *Artifact, customName *string, powerFont *font.Font, powers []Power, compatibilities map[Power]set.Set[ArtifactType], costs map[Power]int, selectCount *int, magicLevel MagicLevel, artificer bool, runemaster bool) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
     var group1 []Power
@@ -651,7 +658,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                                     *selectCount -= 1
                                     artifact.RemovePower(power)
                                     artifact.Name = getName(artifact, *customName)
-                                    artifact.Cost = calculateCost(artifact, costs, artificer)
+                                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                                     lastPower = nil
                                 } else {
                                     // something was already selected in this group, so the count doesn't change
@@ -659,7 +666,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                                     artifact.RemovePower(*lastPower)
                                     artifact.AddPower(power)
                                     artifact.Name = getName(artifact, *customName)
-                                    artifact.Cost = calculateCost(artifact, costs, artificer)
+                                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                                     lastPower = &power
                                 }
                             } else {
@@ -668,7 +675,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                                     groupSelect = i
                                     artifact.AddPower(power)
                                     artifact.Name = getName(artifact, *customName)
-                                    artifact.Cost = calculateCost(artifact, costs, artificer)
+                                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                                     lastPower = &power
                                 } else {
                                     ui.AddElement(uilib.MakeErrorElement(ui, cache, imageCache, "Only four powers may be enchanted into an item", func(){}))
@@ -680,7 +687,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                             if selected[i] {
                                 artifact.RemovePower(power)
                                 artifact.Name = getName(artifact, *customName)
-                                artifact.Cost = calculateCost(artifact, costs, artificer)
+                                artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                                 selected[i] = false
                                 *selectCount -= 1
                             } else if *selectCount < 4 {
@@ -689,7 +696,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
 
                                 artifact.AddPower(power)
                                 artifact.Name = getName(artifact, *customName)
-                                artifact.Cost = calculateCost(artifact, costs, artificer)
+                                artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
                             } else {
                                 ui.AddElement(uilib.MakeErrorElement(ui, cache, imageCache, "Only four powers may be enchanted into an item", func(){}))
                             }
@@ -874,7 +881,7 @@ func makeFonts(cache *lbx.LbxCache) (*font.Font, *font.Font, *font.Font) {
 /* returns the artifact that was created and true,
  * otherwise false for cancelled
  */
-func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, creationType CreationScreen, magicLevel MagicLevel, artificer bool, draw *func(*ebiten.Image)) (*Artifact, bool) {
+func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, creationType CreationScreen, magicLevel MagicLevel, artificer bool, runemaster bool, draw *func(*ebiten.Image)) (*Artifact, bool) {
     powerFont, powerFontWhite, nameFont := makeFonts(cache)
 
     imageCache := util.MakeImageCache(cache)
@@ -914,8 +921,8 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
         artifact.Type = artifactType
         groups := groupPowers(powers, costs, compatibilities, artifactType, creationType)
         selectCount := 0
-        elements := makePowersFull(ui, cache, &imageCache, nameFont, powerFont, picLow, picHigh, groups, costs, &artifact, &customName, &selectCount, artificer)
-        abilityElements := makeAbilityElements(ui, cache, &imageCache, &artifact, &customName, powerFont, powers, compatibilities, costs, &selectCount, magicLevel, artificer)
+        elements := makePowersFull(ui, cache, &imageCache, nameFont, powerFont, picLow, picHigh, groups, costs, &artifact, &customName, &selectCount, artificer, runemaster)
+        abilityElements := makeAbilityElements(ui, cache, &imageCache, &artifact, &customName, powerFont, powers, compatibilities, costs, &selectCount, magicLevel, artificer, runemaster)
         return PowerArtifact{
             Elements: elements,
             AbilityElements: abilityElements,
@@ -949,7 +956,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
         ui.AddElements(powers[index].AbilityElements)
         currentArtifact = powers[index].Artifact
         currentArtifact.Name = getName(currentArtifact, customName)
-        currentArtifact.Cost = calculateCost(currentArtifact, costs, artificer)
+        currentArtifact.Cost = calculateCost(currentArtifact, costs, artificer, runemaster)
     }
 
     var selectedButton *uilib.UIElement

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3715,6 +3715,9 @@ func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerl
 
             castingCost := spell.Cost(true)
 
+            // FIXME: if the player has runemaster and the spell is arcane, then apply a -25% reduction. Don't apply
+            // to create artifact or enchant item because the reduction has already been applied
+
             if castingCost <= player.Mana && castingCost <= player.RemainingCastingSkill {
                 player.Mana -= castingCost
                 player.RemainingCastingSkill -= castingCost

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3702,7 +3702,7 @@ func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerl
                     case "Enchant Item": creation = artifact.CreationEnchantItem
                 }
 
-                created, cancel := artifact.ShowCreateArtifactScreen(yield, game.Cache, creation, &player.Wizard, player.Wizard.AbilityEnabled(setup.AbilityArtificer), &drawFunc)
+                created, cancel := artifact.ShowCreateArtifactScreen(yield, game.Cache, creation, &player.Wizard, player.Wizard.AbilityEnabled(setup.AbilityArtificer), player.Wizard.AbilityEnabled(setup.AbilityRunemaster), &drawFunc)
                 if cancel {
                     return
                 }

--- a/test/artifact/main.go
+++ b/test/artifact/main.go
@@ -22,6 +22,9 @@ type Engine struct {
     Drawer func(*ebiten.Image)
     Cache *lbx.LbxCache
     Coroutine *coroutine.Coroutine
+
+    Artificer bool
+    Runemaster bool
 }
 
 type Books struct {
@@ -44,7 +47,7 @@ func NewEngine() (*Engine, error) {
     }
 
     run := func(yield coroutine.YieldFunc) error {
-        create, cancel := artifact.ShowCreateArtifactScreen(yield, engine.Cache, artifact.CreationCreateArtifact, &Books{}, false, &engine.Drawer)
+        create, cancel := artifact.ShowCreateArtifactScreen(yield, engine.Cache, artifact.CreationCreateArtifact, &Books{}, engine.Artificer, engine.Runemaster, &engine.Drawer)
         if !cancel {
             log.Printf("Create artifact: %+v", create)
         } else {

--- a/test/artifact/main.go
+++ b/test/artifact/main.go
@@ -79,10 +79,12 @@ func (engine *Engine) Update() error {
                 engine.Artificer = !engine.Artificer
                 engine.ShowUpdate = 60
                 engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
+                log.Printf("Artificer %v Runemaster %v", engine.Artificer, engine.Runemaster)
             case ebiten.KeyF2:
                 engine.Runemaster = !engine.Runemaster
                 engine.ShowUpdate = 60
                 engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
+                log.Printf("Artificer %v Runemaster %v", engine.Artificer, engine.Runemaster)
         }
     }
 

--- a/test/artifact/main.go
+++ b/test/artifact/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
     "log"
+    "fmt"
 
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
@@ -11,6 +12,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/coroutine"
 
     "github.com/hajimehoshi/ebiten/v2"
+    "github.com/hajimehoshi/ebiten/v2/ebitenutil"
     "github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
@@ -25,6 +27,7 @@ type Engine struct {
 
     Artificer bool
     Runemaster bool
+    ShowUpdate int
 }
 
 type Books struct {
@@ -46,7 +49,13 @@ func NewEngine() (*Engine, error) {
         Drawer: func(*ebiten.Image){},
     }
 
-    run := func(yield coroutine.YieldFunc) error {
+    engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
+
+    return engine, nil
+}
+
+func (engine *Engine) ArtifactRoutine() func (coroutine.YieldFunc) error {
+    return func(yield coroutine.YieldFunc) error {
         create, cancel := artifact.ShowCreateArtifactScreen(yield, engine.Cache, artifact.CreationCreateArtifact, &Books{}, engine.Artificer, engine.Runemaster, &engine.Drawer)
         if !cancel {
             log.Printf("Create artifact: %+v", create)
@@ -55,10 +64,6 @@ func NewEngine() (*Engine, error) {
         }
         return nil
     }
-
-    engine.Coroutine = coroutine.MakeCoroutine(run)
-
-    return engine, nil
 }
 
 func (engine *Engine) Update() error {
@@ -68,9 +73,21 @@ func (engine *Engine) Update() error {
     keys = inpututil.AppendJustPressedKeys(keys)
 
     for _, key := range keys {
-        if key == ebiten.KeyEscape || key == ebiten.KeyCapsLock {
-            return ebiten.Termination
+        switch key {
+            case ebiten.KeyEscape, ebiten.KeyCapsLock: return ebiten.Termination
+            case ebiten.KeyF1:
+                engine.Artificer = !engine.Artificer
+                engine.ShowUpdate = 60
+                engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
+            case ebiten.KeyF2:
+                engine.Runemaster = !engine.Runemaster
+                engine.ShowUpdate = 60
+                engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
         }
+    }
+
+    if engine.ShowUpdate > 0 {
+        engine.ShowUpdate -= 1
     }
 
     if engine.Coroutine.Run() != nil {
@@ -82,6 +99,10 @@ func (engine *Engine) Update() error {
 
 func (engine *Engine) Draw(screen *ebiten.Image){
     engine.Drawer(screen)
+
+    if engine.ShowUpdate > 0 {
+        ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Artificer %v Runemaster %v", engine.Artificer, engine.Runemaster), 0, 0)
+    }
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {


### PR DESCRIPTION
The create artifact screen should take the runemaster retort into account when showing the cost to the user. This fixes #207.

The test/artifact program allows you to toggle artificer and runemaster using the f1/f2 keys.