### PR TITLE
combat: handle casting spells using charge powers

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1121,7 +1121,7 @@ func (combat *CombatScreen) InvokeSpell(player *playerlib.Player, spell spellboo
         case "Resist Elements":
             combat.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
                 combat.CreateResistElementsProjectile(target)
-                target.AddAbility(data.AbilityResistElements)
+                target.AddEnchantment(data.UnitEnchantmentResistElements)
                 successCallback()
             }, targetAny)
 

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -3010,7 +3010,7 @@ func (combat *CombatScreen) Draw(screen *ebiten.Image){
             */
 
             // _ = index
-            enchantment := util.First(unit.Unit.GetEnchantments(), data.UnitEnchantmentNone)
+            enchantment := util.First(unit.GetEnchantments(), data.UnitEnchantmentNone)
             RenderCombatUnit(screen, combatImages[index], unitOptions, unit.Figures(), enchantment, combat.Counter, &combat.ImageCache)
         }
     }

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1270,17 +1270,8 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                     uilib.Selection{
                         Name: combat.Model.SelectedUnit.Unit.GetName(),
                         Action: func(){
-                            unitSpells := combat.Model.SelectedUnit.Spells.Copy()
+                            unitSpells := combat.Model.SelectedUnit.Spells
                             caster := combat.Model.SelectedUnit
-
-                            /*
-                            for spell, charge := range caster.SpellCharges {
-                                if charge > 0 {
-                                    // FIXME: a hack here could be to set the casting skill to 0
-                                    unitSpells.AddSpell(spell)
-                                }
-                            }
-                            */
 
                             doCast := func(spell spellbook.Spell){
                                 charge, hasCharge := caster.SpellCharges[spell]
@@ -1323,7 +1314,6 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                             }
 
                             // what is casting skill based on for a unit?
-                            // FIXME: if the unit doesn't have enough casting skill but has a charge then use the charge
                             spellUI := spellbook.MakeSpellBookCastUI(ui, combat.Cache, unitSpells, caster.SpellCharges, int(caster.CastingSkill), spellbook.Spell{}, 0, false, func (spell spellbook.Spell, picked bool){
                                 if picked {
                                     doCast(spell)

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -750,12 +750,14 @@ func (unit *ArmyUnit) ApplyDamage(damage int, damageType units.Damage, armorPier
 
 func (unit *ArmyUnit) InitializeSpells(allSpells spellbook.Spells, player *playerlib.Player) {
     unit.CastingSkill = 0
+    unit.SpellCharges = make(map[spellbook.Spell]int)
     for _, ability := range unit.Unit.GetAbilities() {
         switch ability.Ability {
             case data.AbilityDoomBoltSpell:
                 doomBolt := allSpells.FindByName("Doom Bolt")
-                unit.Spells.AddSpell(doomBolt)
-                unit.CastingSkill += float32(doomBolt.CastCost)
+                unit.SpellCharges[doomBolt] = int(ability.Value)
+                // unit.Spells.AddSpell(doomBolt)
+                // unit.CastingSkill += float32(doomBolt.CastCost)
             case data.AbilityCaster:
                 unit.CastingSkill = ability.Value
         }

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -546,6 +546,10 @@ func (unit *ArmyUnit) CanFollowPath(path pathfinding.Path) bool {
     return true
 }
 
+func (unit *ArmyUnit) GetEnchantments() []data.UnitEnchantment {
+    return append(unit.Unit.GetEnchantments(), unit.Enchantments...)
+}
+
 func (unit *ArmyUnit) AddEnchantment(enchantment data.UnitEnchantment) {
     unit.Enchantments = append(unit.Enchantments, enchantment)
 }

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -509,8 +509,8 @@ type ArmyUnit struct {
 
     LastTurn int
 
-    // abilities applied to the unit during combat, usually by a spell
-    Abilities []data.AbilityType
+    // enchantments applied to the unit during combat, usually by a spell
+    Enchantments []data.UnitEnchantment
 
     // ugly to need this, but this caches paths computed for the unit
     Paths map[image.Point]pathfinding.Path
@@ -546,8 +546,8 @@ func (unit *ArmyUnit) CanFollowPath(path pathfinding.Path) bool {
     return true
 }
 
-func (unit *ArmyUnit) AddAbility(ability data.AbilityType) {
-    unit.Abilities = append(unit.Abilities, ability)
+func (unit *ArmyUnit) AddEnchantment(enchantment data.UnitEnchantment) {
+    unit.Enchantments = append(unit.Enchantments, enchantment)
 }
 
 func (unit *ArmyUnit) GetResistances(enchantments... data.UnitEnchantment) int {

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -478,6 +478,7 @@ type CombatUnit interface {
     IsUndead() bool
     GetRace() data.Race
     GetRealm() data.MagicType
+    GetSpellChargeSpells() map[spellbook.Spell]int
 }
 
 type ArmyUnit struct {
@@ -490,6 +491,7 @@ type ArmyUnit struct {
     MovesLeft fraction.Fraction
 
     Spells spellbook.Spells
+    SpellCharges map[spellbook.Spell]int
     CastingSkill float32
     Casted bool
 
@@ -762,6 +764,7 @@ func (unit *ArmyUnit) InitializeSpells(allSpells spellbook.Spells, player *playe
 
     if unit.Unit.IsHero() {
         unit.Spells.AddAllSpells(player.KnownSpells)
+        unit.SpellCharges = unit.Unit.GetSpellChargeSpells()
     }
 }
 

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -509,6 +509,9 @@ type ArmyUnit struct {
 
     LastTurn int
 
+    // abilities applied to the unit during combat, usually by a spell
+    Abilities []data.AbilityType
+
     // ugly to need this, but this caches paths computed for the unit
     Paths map[image.Point]pathfinding.Path
 }
@@ -543,6 +546,10 @@ func (unit *ArmyUnit) CanFollowPath(path pathfinding.Path) bool {
     return true
 }
 
+func (unit *ArmyUnit) AddAbility(ability data.AbilityType) {
+    unit.Abilities = append(unit.Abilities, ability)
+}
+
 func (unit *ArmyUnit) GetResistances(enchantments... data.UnitEnchantment) int {
     resistance := 0
 
@@ -563,12 +570,14 @@ func (unit *ArmyUnit) GetResistances(enchantments... data.UnitEnchantment) int {
 }
 
 func (unit *ArmyUnit) CanCast() bool {
-    if len(unit.Spells.Spells) == 0 {
+    if unit.Casted {
         return false
     }
 
-    if unit.Casted {
-        return false
+    for _, charges := range unit.SpellCharges {
+        if charges > 0 {
+            return true
+        }
     }
 
     for _, spell := range unit.Spells.Spells {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3687,7 +3687,7 @@ func (game *Game) MakeInfoUI(cornerX int, cornerY int) []*uilib.UIElement {
 }
 
 func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerlib.Player){
-    game.HudUI.AddElements(spellbook.MakeSpellBookCastUI(game.HudUI, game.Cache, player.KnownSpells.OverlandSpells(), player.ComputeCastingSkill(), player.CastingSpell, player.CastingSpellProgress, true, func (spell spellbook.Spell, picked bool){
+    game.HudUI.AddElements(spellbook.MakeSpellBookCastUI(game.HudUI, game.Cache, player.KnownSpells.OverlandSpells(), make(map[spellbook.Spell]int), player.ComputeCastingSkill(), player.CastingSpell, player.CastingSpellProgress, true, func (spell spellbook.Spell, picked bool){
         if picked {
             if spell.Name == "Create Artifact" || spell.Name == "Enchant Item" {
 

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -581,52 +581,47 @@ func (hero *Hero) IsHero() bool {
     return true
 }
 
-func (hero *Hero) GetSpellChargeSpells() []spellbook.Spell {
-    var spells []spellbook.Spell
+func (hero *Hero) GetSpellChargeSpells() map[spellbook.Spell]int {
+    out := make(map[spellbook.Spell]int)
 
     for _, item := range hero.Equipment {
         if item != nil {
             spell, count := item.GetSpellCharge()
             if count > 0 {
-                spells = append(spells, spell)
+                _, ok := out[spell]
+                if !ok {
+                    out[spell] = 0
+                }
+
+                out[spell] += count
             }
         }
     }
 
-    return spells
+    return out
 }
 
 func (hero *Hero) GetKnownSpells() []string {
-    defaultSpells := func() []string {
-        switch hero.HeroType {
-            case HeroAerie: return []string{"Psionic Blast", "Vertigo", "Mind Storm"}
-            case HeroAlorra: return []string{"Resist Magic", "Flight"}
-            case HeroElana: return []string{"Dispel Evil", "Healing", "Prayer", "Holy Word"}
-            case HeroGreyfairer: return []string{"Ice Bolt", "Petrify", "Web"}
-            case HeroJaer: return []string{"Guardian Wind", "Word of Recall"}
-            case HeroMalleus: return []string{"Fire Bolt", "Fireball", "Flame Strike", "Fire Elemental"}
-            case HeroMarcus: return []string{"Resist Elements", "Stone Skin"}
-            case HeroMorgana: return []string{"Darkness", "Possession", "Black Prayer", "Mana Leak"}
-            case HeroRakir: return []string{"Resist Elements"}
-            case HeroRavashack: return []string{"Weakness", "Black Sleep", "Animate Dead", "Wrack"}
-            case HeroReywind: return []string{"Flame Blade", "Shatter", "Eldritch Weapon"}
-            case HeroSerena: return []string{"Healing"}
-            case HeroTorin: return []string{"Healing", "Holy Armor", "Lionheart"}
-            case HeroValana: return []string{"Confusion", "Vertigo"}
-            case HeroYramrag: return []string{"Lightning Bolt", "Doom Bolt", "Warp Lightning"}
-            case HeroZaldron: return []string{"Counter Magic", "Dispel Magic True"}
-        }
-
-        return nil
+    switch hero.HeroType {
+        case HeroAerie: return []string{"Psionic Blast", "Vertigo", "Mind Storm"}
+        case HeroAlorra: return []string{"Resist Magic", "Flight"}
+        case HeroElana: return []string{"Dispel Evil", "Healing", "Prayer", "Holy Word"}
+        case HeroGreyfairer: return []string{"Ice Bolt", "Petrify", "Web"}
+        case HeroJaer: return []string{"Guardian Wind", "Word of Recall"}
+        case HeroMalleus: return []string{"Fire Bolt", "Fireball", "Flame Strike", "Fire Elemental"}
+        case HeroMarcus: return []string{"Resist Elements", "Stone Skin"}
+        case HeroMorgana: return []string{"Darkness", "Possession", "Black Prayer", "Mana Leak"}
+        case HeroRakir: return []string{"Resist Elements"}
+        case HeroRavashack: return []string{"Weakness", "Black Sleep", "Animate Dead", "Wrack"}
+        case HeroReywind: return []string{"Flame Blade", "Shatter", "Eldritch Weapon"}
+        case HeroSerena: return []string{"Healing"}
+        case HeroTorin: return []string{"Healing", "Holy Armor", "Lionheart"}
+        case HeroValana: return []string{"Confusion", "Vertigo"}
+        case HeroYramrag: return []string{"Lightning Bolt", "Doom Bolt", "Warp Lightning"}
+        case HeroZaldron: return []string{"Counter Magic", "Dispel Magic True"}
     }
 
-    chargeSpells := hero.GetSpellChargeSpells()
-    var names []string
-    for _, spell := range chargeSpells {
-        names = append(names, spell.Name)
-    }
-
-    return append(defaultSpells(), names...)
+    return nil
 }
 
 func (hero *Hero) GetToHitMelee() int {

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -8,6 +8,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/lib/fraction"
 )
 
@@ -580,27 +581,52 @@ func (hero *Hero) IsHero() bool {
     return true
 }
 
-func (hero *Hero) GetKnownSpells() []string {
-    switch hero.HeroType {
-        case HeroAerie: return []string{"Psionic Blast", "Vertigo", "Mind Storm"}
-        case HeroAlorra: return []string{"Resist Magic", "Flight"}
-        case HeroElana: return []string{"Dispel Evil", "Healing", "Prayer", "Holy Word"}
-        case HeroGreyfairer: return []string{"Ice Bolt", "Petrify", "Web"}
-        case HeroJaer: return []string{"Guardian Wind", "Word of Recall"}
-        case HeroMalleus: return []string{"Fire Bolt", "Fireball", "Flame Strike", "Fire Elemental"}
-        case HeroMarcus: return []string{"Resist Elements", "Stone Skin"}
-        case HeroMorgana: return []string{"Darkness", "Possession", "Black Prayer", "Mana Leak"}
-        case HeroRakir: return []string{"Resist Elements"}
-        case HeroRavashack: return []string{"Weakness", "Black Sleep", "Animate Dead", "Wrack"}
-        case HeroReywind: return []string{"Flame Blade", "Shatter", "Eldritch Weapon"}
-        case HeroSerena: return []string{"Healing"}
-        case HeroTorin: return []string{"Healing", "Holy Armor", "Lionheart"}
-        case HeroValana: return []string{"Confusion", "Vertigo"}
-        case HeroYramrag: return []string{"Lightning Bolt", "Doom Bolt", "Warp Lightning"}
-        case HeroZaldron: return []string{"Counter Magic", "Dispel Magic True"}
+func (hero *Hero) GetSpellChargeSpells() []spellbook.Spell {
+    var spells []spellbook.Spell
+
+    for _, item := range hero.Equipment {
+        if item != nil {
+            spell, count := item.GetSpellCharge()
+            if count > 0 {
+                spells = append(spells, spell)
+            }
+        }
     }
 
-    return nil
+    return spells
+}
+
+func (hero *Hero) GetKnownSpells() []string {
+    defaultSpells := func() []string {
+        switch hero.HeroType {
+            case HeroAerie: return []string{"Psionic Blast", "Vertigo", "Mind Storm"}
+            case HeroAlorra: return []string{"Resist Magic", "Flight"}
+            case HeroElana: return []string{"Dispel Evil", "Healing", "Prayer", "Holy Word"}
+            case HeroGreyfairer: return []string{"Ice Bolt", "Petrify", "Web"}
+            case HeroJaer: return []string{"Guardian Wind", "Word of Recall"}
+            case HeroMalleus: return []string{"Fire Bolt", "Fireball", "Flame Strike", "Fire Elemental"}
+            case HeroMarcus: return []string{"Resist Elements", "Stone Skin"}
+            case HeroMorgana: return []string{"Darkness", "Possession", "Black Prayer", "Mana Leak"}
+            case HeroRakir: return []string{"Resist Elements"}
+            case HeroRavashack: return []string{"Weakness", "Black Sleep", "Animate Dead", "Wrack"}
+            case HeroReywind: return []string{"Flame Blade", "Shatter", "Eldritch Weapon"}
+            case HeroSerena: return []string{"Healing"}
+            case HeroTorin: return []string{"Healing", "Holy Armor", "Lionheart"}
+            case HeroValana: return []string{"Confusion", "Vertigo"}
+            case HeroYramrag: return []string{"Lightning Bolt", "Doom Bolt", "Warp Lightning"}
+            case HeroZaldron: return []string{"Counter Magic", "Dispel Magic True"}
+        }
+
+        return nil
+    }
+
+    chargeSpells := hero.GetSpellChargeSpells()
+    var names []string
+    for _, spell := range chargeSpells {
+        names = append(names, spell.Name)
+    }
+
+    return append(defaultSpells(), names...)
 }
 
 func (hero *Hero) GetToHitMelee() int {

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -937,7 +937,7 @@ func CastRightSideDistortions2(page *ebiten.Image) util.Distortion {
 // selected a spell or because they canceled the ui
 // if a spell is chosen then it will be passed in as the first argument to the callback along with true
 // if the ui is cancelled then the second argument will be false
-func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, castingSkill int, currentSpell Spell, currentProgress int, overland bool, chosenCallback func(Spell, bool)) []*uilib.UIElement {
+func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charges map[Spell]int, castingSkill int, currentSpell Spell, currentProgress int, overland bool, chosenCallback func(Spell, bool)) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
     imageCache := util.MakeImageCache(cache)
@@ -998,7 +998,14 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, casti
 
     pageCache := make(map[int]*ebiten.Image)
 
-    spellPages := computeHalfPages(spells, 6)
+    useSpells := spells.Copy()
+    for spell, charge := range charges {
+        if charge > 0 {
+            useSpells.AddSpell(spell)
+        }
+    }
+
+    spellPages := computeHalfPages(useSpells, 6)
 
     renderPage := func(screen *ebiten.Image, options ebiten.DrawImageOptions, page Page, highlightedSpell Spell){
         // section := spells.Spells[0].Section

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -6,6 +6,7 @@ import (
 
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/lib/fraction"
 )
 
@@ -40,6 +41,10 @@ func (unit *OverworldUnit) AddEnchantment(enchantment data.UnitEnchantment) {
 
 func (unit *OverworldUnit) HasEnchantment(enchantment data.UnitEnchantment) bool {
     return slices.Contains(unit.Enchantments, enchantment)
+}
+
+func (unit *OverworldUnit) GetSpellChargeSpells() map[spellbook.Spell]int {
+    return make(map[spellbook.Spell]int)
 }
 
 func (unit *OverworldUnit) IsUndead() bool {

--- a/game/magic/units/stack-unit.go
+++ b/game/magic/units/stack-unit.go
@@ -3,6 +3,7 @@ package units
 import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/lib/fraction"
 )
 
@@ -75,5 +76,6 @@ type StackUnit interface {
     CanTouchAttack(Damage) bool
     GetArtifactSlots() []artifact.ArtifactSlot
     GetArtifacts() []*artifact.Artifact
+    GetSpellChargeSpells() map[spellbook.Spell]int
 }
 

--- a/test/cast-spell/main.go
+++ b/test/cast-spell/main.go
@@ -62,7 +62,7 @@ func (engine *Engine) MakeUI() *uilib.UI {
     }
     ui.SetElementsFromArray(nil)
 
-    more := spellbook.MakeSpellBookCastUI(ui, engine.Cache, spells, 60, spellbook.Spell{}, 0, true, func (result spellbook.Spell, picked bool){
+    more := spellbook.MakeSpellBookCastUI(ui, engine.Cache, spells, make(map[spellbook.Spell]int), 60, spellbook.Spell{}, 0, true, func (result spellbook.Spell, picked bool){
         if picked {
             log.Printf("Picked spell %v", result)
         }

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -14,6 +14,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/combat"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/artifact"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/player"
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
@@ -177,15 +178,33 @@ func createArchAngelArmy(player *player.Player) *combat.Army {
     }
 }
 
-func createHeroArmy(player *player.Player) *combat.Army{
+func createHeroArmy(player *player.Player, cache *lbx.LbxCache) *combat.Army{
     var armyUnits []*combat.ArmyUnit
 
     armyUnits = append(armyUnits, &combat.ArmyUnit{
         Unit: herolib.MakeHero(units.MakeOverworldUnitFromUnit(units.HeroRakir, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()), herolib.HeroRakir, "bubba"),
     })
 
+    allSpells, _ := spellbook.ReadSpellsFromCache(cache)
+
+    item := artifact.Artifact{
+        Type: artifact.ArtifactTypeStaff,
+        Name: "Staff of Power",
+        Image: 40,
+        Powers: []artifact.Power{
+            artifact.Power{
+                Type: artifact.PowerTypeSpellCharges,
+                Amount: 2,
+                Spell: allSpells.FindByName("Ice Bolt"),
+            },
+        },
+    }
+
+    torin := herolib.MakeHero(units.MakeOverworldUnitFromUnit(units.HeroTorin, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()), herolib.HeroTorin, "warby")
+    torin.Equipment[0] = &item
+
     armyUnits = append(armyUnits, &combat.ArmyUnit{
-        Unit: herolib.MakeHero(units.MakeOverworldUnitFromUnit(units.HeroTorin, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()), herolib.HeroTorin, "warby"),
+        Unit: torin,
     })
 
     return &combat.Army{
@@ -332,7 +351,7 @@ func makeScenario3(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer.CastingSkillPower = 10
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
-    attackingArmy := createHeroArmy(attackingPlayer)
+    attackingArmy := createHeroArmy(attackingPlayer, cache)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeGrass, data.PlaneArcanus, combat.ZoneType{})
@@ -410,7 +429,7 @@ func makeScenario5(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer.CastingSkillPower = 10
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
-    attackingArmy := createHeroArmy(attackingPlayer)
+    attackingArmy := createHeroArmy(attackingPlayer, cache)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
     city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, fraction.Zero(), nil, nil, nil)

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -196,6 +196,7 @@ func createHeroArmy(player *player.Player, cache *lbx.LbxCache) *combat.Army{
                 Type: artifact.PowerTypeSpellCharges,
                 Amount: 2,
                 Spell: allSpells.FindByName("Ice Bolt"),
+                // Spell: allSpells.FindByName("Healing"),
             },
         },
     }


### PR DESCRIPTION
If a hero is granted spells via a spell charge power on an item then the casting that spell should first use up a charge before using any mana that hero may have.