### PR TITLE
encounter: give treasure when the node is defeated

### DIFF
--- a/TODO
+++ b/TODO
@@ -65,6 +65,6 @@
 1/9/2025 * play ui sounds
 1/9/2025 * build roads
 1/14/2025 * add edge glow to enchanted items
+1/16/2025 * combat: use item skill charges for casting spells
 1/17/2025 * map contains rivers and other terrain types, as well as magic nodes and encounter nodes
-1/18/2025 * combat: use item skill charges for casting spells
 1/19/2025 * nodes and encounters give treasure

--- a/TODO
+++ b/TODO
@@ -67,3 +67,4 @@
 1/9/2025 * build roads
 1/14/2025 * add edge glow to enchanted items
 1/17/2025 * map contains rivers and other terrain types, as well as magic nodes and encounter nodes
+1/19/2025 * nodes and encounters give treasure

--- a/TODO
+++ b/TODO
@@ -11,7 +11,6 @@
 * combat: implement boulder ranged attacks
 * combat: town damage, destroy buildings/people after a battle
 * combat: implement flying fortress
-* combat: use item skill charges for casting spells
 * hero: ability progress (https://masterofmagic.fandom.com/wiki/Experience_Level#Ability_Improvement_Tables_-_Heroes)
 
 9/22/2024 * city view: separate surplus food/gold from subsistence food/gold
@@ -67,4 +66,5 @@
 1/9/2025 * build roads
 1/14/2025 * add edge glow to enchanted items
 1/17/2025 * map contains rivers and other terrain types, as well as magic nodes and encounter nodes
+1/18/2025 * combat: use item skill charges for casting spells
 1/19/2025 * nodes and encounters give treasure

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -1236,8 +1236,8 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
         }
     }
 
-    powerEntries, costs, compatibilities, error := ReadPowers(cache)
-    if error != nil {
+    powerEntries, costs, compatibilities, err := ReadPowers(cache)
+    if err != nil {
         return nil, true
     }
 

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -383,10 +383,13 @@ func MakeRandomArtifact(cache *lbx.LbxCache) Artifact {
         }
     }
 
-    numPowers := min(rand.N(4) + 1, len(powers))
+    // it would be very bad if there are no powers
+    if len(powers) > 0 {
+        numPowers := min(rand.N(4) + 1, len(powers))
 
-    for _, index := range rand.Perm(len(powers))[:numPowers] {
-        artifact.Powers = append(artifact.Powers, powers[index])
+        for _, index := range rand.Perm(len(powers))[:numPowers] {
+            artifact.Powers = append(artifact.Powers, powers[index])
+        }
     }
 
     artifact.Image = chooseImage(artifact.Type)

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -5,6 +5,7 @@ import (
     "fmt"
     "slices"
     "cmp"
+    "log"
     "math/rand/v2"
     _ "log"
 
@@ -408,7 +409,8 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
 
     spells, err := spellbook.ReadSpellsFromCache(cache)
     if err != nil {
-        return nil, fmt.Errorf("unable to read spells: %v", err)
+        // return nil, fmt.Errorf("unable to read spells: %v", err)
+        log.Printf("Warning: could not load spells: %v", err)
     }
 
     reader, err := itemData.GetReader(0)

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -41,6 +41,17 @@ const (
     CombatStateDone
 )
 
+func (state CombatState) String() string {
+    switch state {
+        case CombatStateRunning: return "Running"
+        case CombatStateAttackerWin: return "AttackerWin"
+        case CombatStateDefenderWin: return "DefenderWin"
+        case CombatStateDone: return "Done"
+    }
+
+    return ""
+}
+
 type CombatEvent interface {
 }
 

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -517,6 +517,19 @@ type ArmyUnit struct {
     Paths map[image.Point]pathfinding.Path
 }
 
+// roughly represents the strength of this unit, used for strategic combat
+func (unit *ArmyUnit) GetPower() int {
+    power := 0
+
+    power += unit.Unit.GetMaxHealth()
+    power += unit.Unit.GetDefense()
+    power += unit.Unit.GetResistance()
+    power += unit.Unit.GetRangedAttackPower() * unit.Figures()
+    power += unit.Unit.GetMeleeAttackPower() * unit.Figures()
+
+    return power
+}
+
 // true if this unit can move through a tile with a wall tile
 func (unit *ArmyUnit) CanTraverseWall() bool {
     return unit.Unit.IsFlying() || unit.Unit.HasAbility(data.AbilityMerging) || unit.Unit.HasAbility(data.AbilityTeleporting)
@@ -884,6 +897,17 @@ type Army struct {
     Player *playerlib.Player
     Units []*ArmyUnit
     Auto bool
+}
+
+// a number that mostly represents the strength of this army
+func (army *Army) GetPower() int {
+    power := 0
+
+    for _, unit := range army.Units {
+        power += unit.GetPower()
+    }
+
+    return power
 }
 
 func (army *Army) IsAI() bool {
@@ -2166,4 +2190,24 @@ func (model *CombatModel) GetOtherArmy(unit *ArmyUnit) *Army {
     }
 
     return model.DefendingArmy
+}
+
+// predicts the outcome of a battle just by comparing the relative power level of each army
+func DoStrategicCombat(attackingArmy *Army, defendingArmy *Army) (CombatState, int, int) {
+    attackingPower := attackingArmy.GetPower()
+    defendingPower := defendingArmy.GetPower()
+
+    if attackingPower > defendingPower {
+        for _, unit := range defendingArmy.Units {
+            unit.TakeDamage(unit.Unit.GetMaxHealth())
+        }
+
+        return CombatStateAttackerWin, 0, len(defendingArmy.Units)
+    } else {
+        for _, unit := range attackingArmy.Units {
+            unit.TakeDamage(unit.Unit.GetMaxHealth())
+        }
+
+        return CombatStateDefenderWin, len(attackingArmy.Units), 0
+    }
 }

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -2197,6 +2197,8 @@ func DoStrategicCombat(attackingArmy *Army, defendingArmy *Army) (CombatState, i
     attackingPower := attackingArmy.GetPower()
     defendingPower := defendingArmy.GetPower()
 
+    log.Printf("strategic combat: attacking power: %v, defending power: %v", attackingPower, defendingPower)
+
     if attackingPower > defendingPower {
         for _, unit := range defendingArmy.Units {
             unit.TakeDamage(unit.Unit.GetMaxHealth())

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3440,6 +3440,7 @@ func (game *Game) doTreasure(yield coroutine.YieldFunc, player *playerlib.Player
                 player.KnownSpells.AddSpell(spell.Spell)
             case *TreasureSpellbook:
                 spellbook := item.(*TreasureSpellbook)
+                // FIXME: somehow recompute the research spell pool for the player
                 player.Wizard.AddMagicLevel(spellbook.Magic, 1)
             case *TreasureRetort:
                 retort := item.(*TreasureRetort)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3371,9 +3371,9 @@ func (game *Game) doTreasure(yield coroutine.YieldFunc, player *playerlib.Player
         color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
         color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
         orange,
-        orange,
-        orange,
-        orange,
+        util.Lighten(orange, 15),
+        util.Lighten(orange, 30),
+        util.Lighten(orange, 50),
         orange,
         orange,
     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3322,11 +3322,13 @@ func (game *Game) createTreasure(encounterType maplib.EncounterType, budget int,
     if err != nil {
         log.Printf("Error: unable to read spells: %v", err)
     } else {
-        heroes := slices.Clone(player.Heroes[:])
-        // only include alive non-champion heroes
-        heroes = slices.DeleteFunc(heroes, func (hero *herolib.Hero) bool {
-            return hero.Status != herolib.StatusAvailable || hero.IsChampion()
-        })
+        var heroes []*herolib.Hero
+        for _, hero := range game.Heroes {
+            // only include available heroes that are not champions
+            if hero.Status == herolib.StatusAvailable && !hero.IsChampion() {
+                heroes = append(heroes, hero)
+            }
+        }
 
         // FIXME: store all premade artifacts as a field of Game and just return that
         makeArtifacts := func () []artifact.Artifact {
@@ -3522,6 +3524,7 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
 
     if attacker.StrategicCombat && defender.StrategicCombat {
         state, defeatedAttackers, defeatedDefenders = combat.DoStrategicCombat(&attackingArmy, &defendingArmy)
+        log.Printf("Strategic combat result state=%v", state)
     } else {
 
         defer mouse.Mouse.SetImage(game.MouseData.Normal)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3456,6 +3456,7 @@ func (game *Game) doMagicEncounter(yield coroutine.YieldFunc, player *playerlib.
         Wizard: setup.WizardCustom{
             Name: "Node",
         },
+        StrategicCombat: true,
     }
 
     var enemies []units.StackUnit
@@ -3482,7 +3483,14 @@ func (game *Game) doMagicEncounter(yield coroutine.YieldFunc, player *playerlib.
         // node should have no guardians
         node.Empty = true
 
-        // FIXME: give treasure
+        var encounterType maplib.EncounterType
+        switch node.Kind {
+            case maplib.MagicNodeNature: encounterType = maplib.EncounterTypeNatureNode
+            case maplib.MagicNodeSorcery: encounterType = maplib.EncounterTypeSorceryNode
+            case maplib.MagicNodeChaos: encounterType = maplib.EncounterTypeChaosNode
+        }
+
+        game.createTreasure(encounterType, node.Budget, player)
     }
 
     // absorb extra clicks

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3378,7 +3378,7 @@ func (game *Game) doTreasure(yield coroutine.YieldFunc, player *playerlib.Player
         orange,
     }
 
-    treasureFont := font.MakeOptimizedFontWithPalette(fonts[3], yellowPalette)
+    treasureFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowPalette)
 
     element := &uilib.UIElement{
         Layer: 2,
@@ -3396,11 +3396,14 @@ func (game *Game) doTreasure(yield coroutine.YieldFunc, player *playerlib.Player
             screen.DrawImage(left, &options)
             right, _ := game.ImageCache.GetImage("resource.lbx", 58, 0)
             options.GeoM.Translate(float64(left.Bounds().Dx()), 0)
-            screen.DrawImage(right, &options)
+            rightGeom := options.GeoM
 
             chest, _ := game.ImageCache.GetImage("reload.lbx", 20, 0)
-            options.GeoM.Translate(1, 1)
+            options.GeoM.Translate(6, 8)
             screen.DrawImage(chest, &options)
+
+            options.GeoM = rightGeom
+            screen.DrawImage(right, &options)
 
             treasureFont.PrintWrap(screen, fontX, fontY, float64(left.Bounds().Dx()) - 5, 1.0, ebiten.ColorScale{}, treasure.String())
         },

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3433,7 +3433,8 @@ func (game *Game) doTreasure(yield coroutine.YieldFunc, player *playerlib.Player
                 magicalItem := item.(*TreasureMagicalItem)
                 game.doVault(yield, &magicalItem.Artifact)
             case *TreasurePrisonerHero:
-                // FIXME: show hire hero screen?
+                hero := item.(*TreasurePrisonerHero)
+                game.doHireHero(yield, 0, hero.Hero, player)
             case *TreasureSpell:
                 spell := item.(*TreasureSpell)
                 player.KnownSpells.AddSpell(spell.Spell)

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -324,7 +324,7 @@ func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budge
                     }
                 } else {
                     randomArtifact := artifact.MakeRandomArtifact(cache)
-                    if budget >= randomArtifact.Cost {
+                    if budget >= randomArtifact.Cost && canUseArtifact(randomArtifact) {
                         magicItemRemaining -= 1
                         budget -= randomArtifact.Cost
                         items = append(items, &TreasureMagicalItem{Artifact: randomArtifact})

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -1,0 +1,33 @@
+package main
+
+type TreasureItem interface {
+}
+
+type TreasureGold struct {
+}
+
+type TreasureMana struct {
+}
+
+type TreasureMagicalItem struct {
+}
+
+type TreasurePrisonerHero struct {
+}
+
+type TreasureSpell struct {
+}
+
+type TreasureSpellbook struct {
+}
+
+type TreasureRetort struct {
+}
+
+type Treasure struct {
+    Treasures []TreasureItem
+}
+
+func makeTreasure() *Treasure {
+    return &Treasure{}
+}

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -7,6 +7,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/maplib"
 )
 
 type TreasureItem interface {
@@ -66,7 +67,7 @@ func chooseValue[T comparable](choices map[T]int) T {
 }
 
 // given some budget, keep choosing a treasure type within the budget and add it to the treasure
-func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
+func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom) *Treasure {
     type TreasureType int
     const (
         TreasureTypeGold TreasureType = iota
@@ -174,6 +175,7 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
             case TreasureTypeSpellbook:
                 spellBookRemaining -= 1
 
+                // FIXME: depends on the type of encounter/node
                 books := []data.MagicType{data.LifeMagic, data.SorceryMagic, data.ChaosMagic, data.NatureMagic, data.DeathMagic}
                 items = append(items, &TreasureSpellbook{Magic: books[rand.N(len(books))]})
 

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -312,7 +312,6 @@ func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budge
                 budget -= mana
             case TreasureTypeMagicalItem:
                 artifacts := getPremadeArtifacts()
-                // FIXME: if there are no premade artifacts left, then generate a random new one
                 if len(artifacts) > 0 {
 
                     for _, choice := range rand.Perm(len(artifacts)) {

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -67,7 +67,7 @@ func chooseValue[T comparable](choices map[T]int) T {
 }
 
 // given some budget, keep choosing a treasure type within the budget and add it to the treasure
-func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom) *Treasure {
+func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom, knownSpells spellbook.Spells, allSpells spellbook.Spells) *Treasure {
     type TreasureType int
     const (
         TreasureTypeGold TreasureType = iota
@@ -157,9 +157,19 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
                 // FIXME: find an alive and unemployed non-champion hero
                 budget -= prisonerSpend
             case TreasureTypeCommonSpell:
-                spellsRemaining -= 1
-                // FIXME: choose some unknown common spell given the wizard's spell books
-                budget -= spellCommonSpend
+                common := allSpells.GetSpellsByRarity(spellbook.SpellRarityCommon)
+                common.RemoveSpells(knownSpells)
+
+                if len(common.Spells) > 0 {
+                    // FIXME: filter by wizard's spell books
+                    spell := common.Spells[rand.N(len(common.Spells))]
+                    spellsRemaining -= 1
+                    // FIXME: choose some unknown common spell given the wizard's spell books
+
+                    items = append(items, &TreasureSpell{Spell: spell})
+
+                    budget -= spellCommonSpend
+                }
             case TreasureTypeUncommonSpell:
                 spellsRemaining -= 1
                 // FIXME: choose some unknown uncommon spell given the wizard's spell books

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -70,7 +70,7 @@ func chooseValue[T comparable](choices map[T]int) T {
 }
 
 // given some budget, keep choosing a treasure type within the budget and add it to the treasure
-func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom, knownSpells spellbook.Spells, allSpells spellbook.Spells, heroes []*herolib.Hero, getPremadeArtifacts func() []artifact.Artifact) *Treasure {
+func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom, knownSpells spellbook.Spells, allSpells spellbook.Spells, heroes []*herolib.Hero, getPremadeArtifacts func() []artifact.Artifact) Treasure {
     type TreasureType int
     const (
         TreasureTypeGold TreasureType = iota
@@ -299,5 +299,5 @@ func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budge
         }
     }
 
-    return &Treasure{Treasures: items}
+    return Treasure{Treasures: items}
 }

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -10,6 +10,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/maplib"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
+    "github.com/kazzmir/master-of-magic/lib/lbx"
 )
 
 type TreasureItem interface {
@@ -69,7 +70,7 @@ func chooseValue[T comparable](choices map[T]int) T {
 }
 
 // given some budget, keep choosing a treasure type within the budget and add it to the treasure
-func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom, knownSpells spellbook.Spells, allSpells spellbook.Spells, heroes []*herolib.Hero, getPremadeArtifacts func() []artifact.Artifact) *Treasure {
+func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budget int, wizard setup.WizardCustom, knownSpells spellbook.Spells, allSpells spellbook.Spells, heroes []*herolib.Hero, getPremadeArtifacts func() []artifact.Artifact) *Treasure {
     type TreasureType int
     const (
         TreasureTypeGold TreasureType = iota
@@ -212,6 +213,13 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
                         magicItemRemaining -= 1
                         budget -= choice.Cost
                         items = append(items, &TreasureMagicalItem{Artifact: choice})
+                    }
+                } else {
+                    randomArtifact := artifact.MakeRandomArtifact(cache)
+                    if budget >= randomArtifact.Cost {
+                        magicItemRemaining -= 1
+                        budget -= randomArtifact.Cost
+                        items = append(items, &TreasureMagicalItem{Artifact: randomArtifact})
                     }
                 }
             case TreasureTypePrisonerHero:

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -243,13 +243,33 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
                     budget -= spellVeryRareSpend
                 }
             case TreasureTypeSpellbook:
-                spellBookRemaining -= 1
 
-                // FIXME: depends on the type of encounter/node
-                books := []data.MagicType{data.LifeMagic, data.SorceryMagic, data.ChaosMagic, data.NatureMagic, data.DeathMagic}
-                items = append(items, &TreasureSpellbook{Magic: books[rand.N(len(books))]})
+                var books []data.MagicType
+                switch encounterType {
+                    case maplib.EncounterTypeLair, maplib.EncounterTypeCave, maplib.EncounterTypePlaneTower:
+                        books = []data.MagicType{data.LifeMagic, data.SorceryMagic, data.ChaosMagic, data.NatureMagic, data.DeathMagic}
 
-                budget = 0
+                    case maplib.EncounterTypeAncientTemple, maplib.EncounterTypeFallenTemple:
+                        books = []data.MagicType{data.LifeMagic}
+
+                    case maplib.EncounterTypeRuins, maplib.EncounterTypeAbandonedKeep, maplib.EncounterTypeDungeon:
+                        books = []data.MagicType{data.DeathMagic}
+
+                    case maplib.EncounterTypeChaosNode:
+                        books = []data.MagicType{data.ChaosMagic}
+
+                    case maplib.EncounterTypeNatureNode:
+                        books = []data.MagicType{data.NatureMagic}
+
+                    case maplib.EncounterTypeSorceryNode:
+                        books = []data.MagicType{data.SorceryMagic}
+                }
+
+                if len(books) > 0 {
+                    spellBookRemaining -= 1
+                    items = append(items, &TreasureSpellbook{Magic: books[rand.N(len(books))]})
+                    budget = 0
+                }
             case TreasureTypeRetort:
                 retort, ok := chooseRetort()
                 if ok {

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+    "fmt"
     "slices"
     "math/rand/v2"
 
@@ -14,26 +15,47 @@ import (
 )
 
 type TreasureItem interface {
+    fmt.Stringer
 }
 
 type TreasureGold struct {
     Amount int
 }
 
+func (gold *TreasureGold) String() string {
+    return fmt.Sprintf("%v gold coins", gold.Amount)
+}
+
 type TreasureMana struct {
     Amount int
+}
+
+func (mana *TreasureMana) String() string {
+    return fmt.Sprintf("%v mana crystals", mana.Amount)
 }
 
 type TreasureMagicalItem struct {
     Artifact artifact.Artifact
 }
 
+func (item *TreasureMagicalItem) String() string {
+    return fmt.Sprintf("a %v", item.Artifact.Name)
+}
+
 type TreasurePrisonerHero struct {
     Hero *herolib.Hero
 }
 
+func (prisoner *TreasurePrisonerHero) String() string {
+    return fmt.Sprintf("%v, a prisoner hero", prisoner.Hero.Name)
+}
+
 type TreasureSpell struct {
     Spell spellbook.Spell
+}
+
+func (spell *TreasureSpell) String() string {
+    return fmt.Sprintf("the spell %v", spell.Spell.Name)
 }
 
 // always gives one spellbook of the specified magic type
@@ -41,12 +63,55 @@ type TreasureSpellbook struct {
     Magic data.MagicType
 }
 
+func (spellbook *TreasureSpellbook) String() string {
+    return fmt.Sprintf("a spellbook of %v magic", spellbook.Magic)
+}
+
 type TreasureRetort struct {
     Retort setup.WizardAbility
 }
 
+func (retort *TreasureRetort) String() string {
+    return fmt.Sprintf("the retort %v", retort.Retort)
+}
+
 type Treasure struct {
     Treasures []TreasureItem
+}
+
+func combineAnd[T fmt.Stringer](pieces []T) string {
+    // this could be simplified by iterating backwards through the array and
+    // preprending 'and' or ', ' for each element, depending on its index
+
+    if len(pieces) == 0 {
+        return ""
+    }
+
+    // x
+    if len(pieces) == 1 {
+        return pieces[0].String()
+    }
+
+    // x and y
+    if len(pieces) == 2 {
+        return fmt.Sprintf("%v and %v", pieces[0], pieces[1])
+    }
+
+    // x, y, and z
+    out := ""
+    for i := range len(pieces) - 2 {
+        out += fmt.Sprintf("%v, ", pieces[i])
+    }
+    out += fmt.Sprintf("%v and %v", pieces[len(pieces) - 2], pieces[len(pieces) - 1])
+    return out
+}
+
+func (treasure Treasure) String() string {
+    if len(treasure.Treasures) == 0 {
+        return "Inside you find absolutely nothing."
+    }
+
+    return "Inside you find " + combineAnd(treasure.Treasures)
 }
 
 // stolen from maplib/map.go

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -203,6 +203,27 @@ func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budge
         return spellbook.Spell{}, false
     }
 
+    // to be able to use the artifact, the wizard must have enough magic books to satisfy the artifact's requirements
+    canUseArtifact := func (check artifact.Artifact) bool {
+        // all artifact requirements must be satisfied
+        for _, requirement := range check.Requirements {
+            if wizard.MagicLevel(requirement.MagicType) < requirement.Amount {
+                return false
+            }
+        }
+
+        // and all ability requirements must be satisfied
+        for _, power := range check.Powers {
+            if power.Type == artifact.PowerTypeAbility1 || power.Type == artifact.PowerTypeAbility2 || power.Type == artifact.PowerTypeAbility3 {
+                if wizard.MagicLevel(power.Magic) < power.Amount {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
     // treasure cannot contain more than these values of each type
     spellsRemaining := 1
     spellBookRemaining := 1
@@ -293,11 +314,14 @@ func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budge
                 artifacts := getPremadeArtifacts()
                 // FIXME: if there are no premade artifacts left, then generate a random new one
                 if len(artifacts) > 0 {
-                    choice := artifacts[rand.N(len(artifacts))]
-                    if budget >= choice.Cost {
-                        magicItemRemaining -= 1
-                        budget -= choice.Cost
-                        items = append(items, &TreasureMagicalItem{Artifact: choice})
+
+                    for _, choice := range rand.Perm(len(artifacts)) {
+                        use := artifacts[choice]
+                        if budget >= use.Cost && canUseArtifact(use) {
+                            magicItemRemaining -= 1
+                            budget -= use.Cost
+                            items = append(items, &TreasureMagicalItem{Artifact: use})
+                        }
                     }
                 } else {
                     randomArtifact := artifact.MakeRandomArtifact(cache)

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -65,6 +65,7 @@ func chooseValue[T comparable](choices map[T]int) T {
     return out
 }
 
+// given some budget, keep choosing a treasure type within the budget and add it to the treasure
 func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
     type TreasureType int
     const (
@@ -80,6 +81,7 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
         TreasureTypeRetort
     )
 
+    // treasure cannot contain more than these values of each type
     spellsRemaining := 1
     spellBookRemaining := 1
     retortRemaining := 1
@@ -94,6 +96,8 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
     const spellBookSpend = 1000
     const retortSpend = 1000
     const magicItemSpend = 400
+
+    var items []TreasureItem
 
     for budget > 0 {
         choices := make(map[TreasureType]int)
@@ -133,10 +137,15 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
                 coins := rand.N(200)
                 coins = min(coins, budget)
 
+                items = append(items, &TreasureGold{Amount: coins})
+
                 budget -= coins
             case TreasureTypeMana:
                 mana := rand.N(200)
                 mana = min(mana, budget)
+
+                items = append(items, &TreasureMana{Amount: mana})
+
                 budget -= mana
             case TreasureTypeMagicalItem:
                 magicItemRemaining -= 1
@@ -164,7 +173,10 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
                 budget -= spellVeryRareSpend
             case TreasureTypeSpellbook:
                 spellBookRemaining -= 1
-                // FIXME: give some spellbook of any type
+
+                books := []data.MagicType{data.LifeMagic, data.SorceryMagic, data.ChaosMagic, data.NatureMagic, data.DeathMagic}
+                items = append(items, &TreasureSpellbook{Magic: books[rand.N(len(books))]})
+
                 budget = 0
             case TreasureTypeRetort:
                 retortRemaining -= 1
@@ -173,5 +185,5 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
         }
     }
 
-    return &Treasure{}
+    return &Treasure{Treasures: items}
 }

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -1,11 +1,12 @@
 package game
 
 import (
+    "math/rand/v2"
+
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/data"
-    "github.com/kazzmir/master-of-magic/game/magic/maplib"
 )
 
 type TreasureItem interface {
@@ -44,6 +45,133 @@ type Treasure struct {
     Treasures []TreasureItem
 }
 
-func makeTreasure(encounter maplib.EncounterType) *Treasure {
+// stolen from maplib/map.go
+func chooseValue[T comparable](choices map[T]int) T {
+    total := 0
+    for _, value := range choices {
+        total += value
+    }
+
+    pick := rand.N(total)
+    for key, value := range choices {
+        if pick < value {
+            return key
+        }
+
+        pick -= value
+    }
+
+    var out T
+    return out
+}
+
+func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
+    type TreasureType int
+    const (
+        TreasureTypeGold TreasureType = iota
+        TreasureTypeMana
+        TreasureTypeMagicalItem
+        TreasureTypePrisonerHero
+        TreasureTypeCommonSpell
+        TreasureTypeUncommonSpell
+        TreasureTypeRareSpell
+        TreasureTypeVeryRareSpell
+        TreasureTypeSpellbook
+        TreasureTypeRetort
+    )
+
+    spellsRemaining := 1
+    spellBookRemaining := 1
+    retortRemaining := 1
+    prisonerRemaining := 1
+    magicItemRemaining := 3
+
+    const prisonerSpend = 1000
+    const spellCommonSpend = 50
+    const spellUncommonSpend = 200
+    const spellRareSpend = 450
+    const spellVeryRareSpend = 800
+    const spellBookSpend = 1000
+    const retortSpend = 1000
+    const magicItemSpend = 400
+
+    for budget > 0 {
+        choices := make(map[TreasureType]int)
+        choices[TreasureTypeGold] = 2
+        choices[TreasureTypeMana] = 2
+        if spellsRemaining > 0 {
+            if budget >= spellCommonSpend {
+                choices[TreasureTypeCommonSpell] = 1
+            }
+            if budget >= spellUncommonSpend {
+                choices[TreasureTypeUncommonSpell] = 1
+            }
+            if budget >= spellRareSpend {
+                choices[TreasureTypeRareSpell] = 1
+            }
+            if budget >= spellVeryRareSpend {
+                choices[TreasureTypeVeryRareSpell] = 1
+            }
+        }
+        if spellBookRemaining > 0 && budget > spellBookSpend {
+            choices[TreasureTypeSpellbook] = 2
+        }
+        if retortRemaining > 0 && budget > retortSpend {
+            choices[TreasureTypeRetort] = 2
+        }
+        if prisonerRemaining > 0 && budget > prisonerSpend {
+            choices[TreasureTypePrisonerHero] = 1
+        }
+        if magicItemRemaining > 0 && budget > magicItemSpend {
+            choices[TreasureTypeMagicalItem] = 5
+        }
+
+        choice := chooseValue(choices)
+
+        switch choice {
+            case TreasureTypeGold:
+                coins := rand.N(200)
+                coins = min(coins, budget)
+
+                budget -= coins
+            case TreasureTypeMana:
+                mana := rand.N(200)
+                mana = min(mana, budget)
+                budget -= mana
+            case TreasureTypeMagicalItem:
+                magicItemRemaining -= 1
+                // FIXME: give a premade magical item, or create a new one. Take the wizard's spell books into account
+                budget -= 400
+            case TreasureTypePrisonerHero:
+                prisonerRemaining -= 1
+                // FIXME: find an alive and unemployed non-champion hero
+                budget -= prisonerSpend
+            case TreasureTypeCommonSpell:
+                spellsRemaining -= 1
+                // FIXME: choose some unknown common spell given the wizard's spell books
+                budget -= spellCommonSpend
+            case TreasureTypeUncommonSpell:
+                spellsRemaining -= 1
+                // FIXME: choose some unknown uncommon spell given the wizard's spell books
+                budget -= spellUncommonSpend
+            case TreasureTypeRareSpell:
+                spellsRemaining -= 1
+                // FIXME: choose some unknown rare spell given the wizard's spell books
+                budget -= spellRareSpend
+            case TreasureTypeVeryRareSpell:
+                spellsRemaining -= 1
+                // FIXME: choose some unknown very rare spell given the wizard's spell books
+                budget -= spellVeryRareSpend
+            case TreasureTypeSpellbook:
+                spellBookRemaining -= 1
+                // FIXME: give some spellbook of any type
+                budget = 0
+            case TreasureTypeRetort:
+                retortRemaining -= 1
+                // FIXME: give a retort of any type (maybe not myrror though?)
+                budget = 0
+        }
+    }
+
     return &Treasure{}
 }

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -5,6 +5,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/maplib"
 )
 
 type TreasureItem interface {
@@ -43,6 +44,6 @@ type Treasure struct {
     Treasures []TreasureItem
 }
 
-func makeTreasure() *Treasure {
+func makeTreasure(encounter maplib.EncounterType) *Treasure {
     return &Treasure{}
 }

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -166,6 +166,9 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
                     possible.AddAllSpells(common.GetSpellsByMagic(book.Magic))
                 }
 
+                // arcane spells are always available I guess?
+                possible.AddAllSpells(common.GetSpellsByMagic(data.ArcaneMagic))
+
                 if len(possible.Spells) > 0 {
                     spell := possible.Spells[rand.N(len(possible.Spells))]
                     spellsRemaining -= 1

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -1,27 +1,42 @@
-package main
+package game
+
+import (
+    "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
+    "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+)
 
 type TreasureItem interface {
 }
 
 type TreasureGold struct {
+    Amount int
 }
 
 type TreasureMana struct {
+    Amount int
 }
 
 type TreasureMagicalItem struct {
+    Artifact artifact.Artifact
 }
 
 type TreasurePrisonerHero struct {
+    Name string
 }
 
 type TreasureSpell struct {
+    Spell spellbook.Spell
 }
 
+// always gives one spellbook of the specified magic type
 type TreasureSpellbook struct {
+    Magic data.MagicType
 }
 
 type TreasureRetort struct {
+    Retort setup.WizardAbility
 }
 
 type Treasure struct {

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -160,9 +160,14 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
                 common := allSpells.GetSpellsByRarity(spellbook.SpellRarityCommon)
                 common.RemoveSpells(knownSpells)
 
-                if len(common.Spells) > 0 {
-                    // FIXME: filter by wizard's spell books
-                    spell := common.Spells[rand.N(len(common.Spells))]
+                var possible spellbook.Spells
+
+                for _, book := range wizard.Books {
+                    possible.AddAllSpells(common.GetSpellsByMagic(book.Magic))
+                }
+
+                if len(possible.Spells) > 0 {
+                    spell := possible.Spells[rand.N(len(possible.Spells))]
                     spellsRemaining -= 1
                     // FIXME: choose some unknown common spell given the wizard's spell books
 

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+    "slices"
     "math/rand/v2"
 
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
@@ -81,6 +82,38 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
         TreasureTypeSpellbook
         TreasureTypeRetort
     )
+
+    chooseRetort := func () (setup.WizardAbility, bool) {
+        choices := []setup.WizardAbility{
+            setup.AbilityAlchemy,
+            setup.AbilityWarlord,
+            setup.AbilityChanneler,
+            setup.AbilityArchmage,
+            setup.AbilityArtificer,
+            setup.AbilityConjurer,
+            setup.AbilitySageMaster,
+            setup.AbilityDivinePower,
+            setup.AbilityFamous,
+            setup.AbilityRunemaster,
+            setup.AbilityCharismatic,
+            setup.AbilityChaosMastery,
+            setup.AbilityNatureMastery,
+            setup.AbilitySorceryMastery,
+            setup.AbilityInfernalPower,
+            setup.AbilityManaFocusing,
+            setup.AbilityNodeMastery,
+        }
+
+        choices = slices.DeleteFunc(choices, func (ability setup.WizardAbility) bool {
+            return wizard.AbilityEnabled(ability)
+        })
+
+        if len(choices) > 0 {
+            return choices[rand.N(len(choices))], true
+        }
+
+        return setup.AbilityNone, false
+    }
 
     chooseSpell := func (rarity spellbook.SpellRarity) (spellbook.Spell, bool) {
         spells := allSpells.GetSpellsByRarity(rarity)
@@ -218,9 +251,12 @@ func makeTreasure(encounterType maplib.EncounterType, budget int, wizard setup.W
 
                 budget = 0
             case TreasureTypeRetort:
-                retortRemaining -= 1
-                // FIXME: give a retort of any type (maybe not myrror though?)
-                budget = 0
+                retort, ok := chooseRetort()
+                if ok {
+                    retortRemaining -= 1
+                    budget = 0
+                    items = append(items, &TreasureRetort{Retort: retort})
+                }
         }
     }
 

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -259,14 +259,34 @@ func makeTreasure(cache *lbx.LbxCache, encounterType maplib.EncounterType, budge
                 coins := rand.N(200) + 1
                 coins = min(coins, budget)
 
-                items = append(items, &TreasureGold{Amount: coins})
+                added := false
+                for _, item := range items {
+                    if gold, ok := item.(*TreasureGold); ok {
+                        coins += gold.Amount
+                        added = true
+                    }
+                }
+
+                if !added {
+                    items = append(items, &TreasureGold{Amount: coins})
+                }
 
                 budget -= coins
             case TreasureTypeMana:
                 mana := rand.N(200) + 1
                 mana = min(mana, budget)
 
-                items = append(items, &TreasureMana{Amount: mana})
+                added := false
+                for _, item := range items {
+                    if manaItem, ok := item.(*TreasureMana); ok {
+                        mana += manaItem.Amount
+                        added = true
+                    }
+                }
+
+                if !added {
+                    items = append(items, &TreasureMana{Amount: mana})
+                }
 
                 budget -= mana
             case TreasureTypeMagicalItem:

--- a/game/magic/game/treasure.go
+++ b/game/magic/game/treasure.go
@@ -117,16 +117,16 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
                 choices[TreasureTypeVeryRareSpell] = 1
             }
         }
-        if spellBookRemaining > 0 && budget > spellBookSpend {
+        if spellBookRemaining > 0 && budget >= spellBookSpend {
             choices[TreasureTypeSpellbook] = 2
         }
-        if retortRemaining > 0 && budget > retortSpend {
+        if retortRemaining > 0 && budget >= retortSpend {
             choices[TreasureTypeRetort] = 2
         }
-        if prisonerRemaining > 0 && budget > prisonerSpend {
+        if prisonerRemaining > 0 && budget >= prisonerSpend {
             choices[TreasureTypePrisonerHero] = 1
         }
-        if magicItemRemaining > 0 && budget > magicItemSpend {
+        if magicItemRemaining > 0 && budget >= magicItemSpend {
             choices[TreasureTypeMagicalItem] = 5
         }
 
@@ -134,14 +134,14 @@ func makeTreasure(budget int, wizard setup.WizardCustom) *Treasure {
 
         switch choice {
             case TreasureTypeGold:
-                coins := rand.N(200)
+                coins := rand.N(200) + 1
                 coins = min(coins, budget)
 
                 items = append(items, &TreasureGold{Amount: coins})
 
                 budget -= coins
             case TreasureTypeMana:
-                mana := rand.N(200)
+                mana := rand.N(200) + 1
                 mana = min(mana, budget)
 
                 items = append(items, &TreasureMana{Amount: mana})

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -414,6 +414,22 @@ func (hero *Hero) SetExtraAbilities() {
     // fmt.Printf("Hero %v took %v loops: %v\n", hero.ShortName(), totalLoops, hero.GetAbilities())
 }
 
+func (hero *Hero) IsChampion() bool {
+    switch hero.HeroType {
+        case HeroTorin, HeroWarrax, HeroMysticX, HeroDethStryke, HeroSirHarold,
+             HeroRavashack, HeroRoland, HeroMortu, HeroElana, HeroAerie,
+             HeroAlorra: return true
+
+        case HeroAureus, HeroBahgtru, HeroTumu, HeroTheria, HeroBrax,
+             HeroBShan, HeroFang, HeroGreyfairer, HeroGunther, HeroJaer,
+             HeroMalleus, HeroMarcus, HeroMorgana, HeroRakir, HeroReywind,
+             HeroSerena, HeroShalla, HeroShinBo, HeroShuri, HeroSpyder,
+             HeroTaki, HeroValana, HeroYramrag, HeroZaldron: return false
+    }
+
+    return false
+}
+
 func (hero *Hero) SetStatus(status HeroStatus) {
     hero.Status = status
 }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -193,6 +193,7 @@ func randomEncounterType() EncounterType {
 type ExtraEncounter struct {
     Type EncounterType
     Units []units.Unit
+    Budget int // used for treasure
     Empty bool
 }
 
@@ -280,6 +281,7 @@ func makeEncounter(encounterType EncounterType, difficulty data.DifficultySettin
 
     return &ExtraEncounter{
         Type: encounterType,
+        Budget: budget,
         Units: append(guardians, secondary...),
     }
 }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -323,6 +323,7 @@ func (extra *ExtraEncounter) DrawLayer2(screen *ebiten.Image, imageCache *util.I
 type ExtraMagicNode struct {
     Kind MagicNode
     Empty bool
+    Budget int
     Guardians []units.Unit
     Secondary []units.Unit
     // list of points that are affected by the node

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -774,8 +774,7 @@ func (mapObject *Map) GetBonusTile(x int, y int) data.BonusType {
 }
 
 func (mapObject *Map) CreateEncounter(x int, y int, encounterType EncounterType, difficulty data.DifficultySetting, weakStrength bool, plane data.Plane) bool {
-    _, ok := mapObject.ExtraMap[image.Pt(x, y)]
-    if ok {
+    if mapObject.GetLair(x, y) != nil {
         return false
     }
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -172,6 +172,12 @@ const (
     EncounterTypeRuins
     EncounterTypeAbandonedKeep
     EncounterTypeDungeon
+
+    // somewhat of a hack, but its useful to have a single type that can represent all the
+    // different types of nodes and encounters
+    EncounterTypeChaosNode
+    EncounterTypeNatureNode
+    EncounterTypeSorceryNode
 )
 
 func randomEncounterType() EncounterType {

--- a/game/magic/maplib/node.go
+++ b/game/magic/maplib/node.go
@@ -403,6 +403,7 @@ func MakeMagicNode(kind MagicNode, magicSetting data.MagicSetting, difficulty da
     return &ExtraMagicNode{
         Kind: kind,
         Empty: false,
+        Budget: budget,
         Guardians: guardians,
         Secondary: secondary,
         Zone: zone,

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -73,6 +73,9 @@ type Player struct {
     BookOrderSeed1 uint64
     BookOrderSeed2 uint64
 
+    // if true, the game will only do strategic (non-graphics/non-realtime) based combat if both sides are strategic
+    StrategicCombat bool
+
     // known spells
     KnownSpells spellbook.Spells
 

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -429,6 +429,16 @@ func (wizard *WizardCustom) AbilityEnabled(ability WizardAbility) bool {
     return false
 }
 
+func (wizard *WizardCustom) EnableAbility(ability WizardAbility) {
+    for _, check := range wizard.Abilities {
+        if check == ability {
+            return
+        }
+    }
+
+    wizard.Abilities = append(wizard.Abilities, ability)
+}
+
 func (wizard *WizardCustom) ToggleAbility(ability WizardAbility, picksLeft int){
     var out []WizardAbility
 
@@ -447,6 +457,20 @@ func (wizard *WizardCustom) ToggleAbility(ability WizardAbility, picksLeft int){
     }
 
     wizard.Abilities = out
+}
+
+func (wizard *WizardCustom) AddMagicLevel(kind data.MagicType, count int){
+    for i := range wizard.Books {
+        if wizard.Books[i].Magic == kind {
+            wizard.Books[i].Count += count
+            return
+        }
+    }
+
+    wizard.Books = append(wizard.Books, data.WizardBook{
+        Magic: kind,
+        Count: count,
+    })
 }
 
 func (wizard *WizardCustom) SetMagicLevel(kind data.MagicType, count int){

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -2642,6 +2642,17 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
 
     game.Camera.Center(stack.X(), stack.Y())
 
+    game.Events <- &gamelib.GameEventTreasure{
+        Player: player,
+        Treasure: gamelib.Treasure{
+            Treasures: []gamelib.TreasureItem{
+                &gamelib.TreasureGold{
+                    Amount: 300,
+                },
+            },
+        },
+    }
+
     return game
 }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -2609,6 +2609,7 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
     city.Wall = false
+    city.Buildings.Insert(buildinglib.BuildingFortress)
 
     city.ResetCitizens(nil)
 
@@ -2646,8 +2647,13 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
         Player: player,
         Treasure: gamelib.Treasure{
             Treasures: []gamelib.TreasureItem{
+                /*
                 &gamelib.TreasureGold{
                     Amount: 300,
+                },
+                */
+                &gamelib.TreasurePrisonerHero{
+                    Hero: game.Heroes[0],
                 },
             },
         },

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -2561,6 +2561,90 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// test getting treasure
+func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 31")
+
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerBlue,
+        Race: data.RaceTroll,
+        Abilities: []setup.WizardAbility{
+            setup.AbilityAlchemy,
+            setup.AbilitySageMaster,
+        },
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.LifeMagic,
+                Count: 3,
+            },
+            data.WizardBook{
+                Magic: data.SorceryMagic,
+                Count: 8,
+            },
+        },
+    }
+
+    game := gamelib.MakeGame(cache, setup.NewGameSettings{})
+
+    game.Plane = data.PlaneArcanus
+
+    player := game.AddPlayer(wizard, true)
+    player.StrategicCombat = true
+
+    x, y := game.FindValidCityLocation(game.Plane)
+
+    /*
+    x = 20
+    y = 20
+    */
+
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game)
+    city.Population = 16190
+    city.Plane = data.PlaneArcanus
+    city.Banner = wizard.Banner
+    city.ProducingBuilding = buildinglib.BuildingGranary
+    city.ProducingUnit = units.UnitNone
+    city.Race = wizard.Race
+    city.Farmers = 3
+    city.Workers = 3
+    city.Wall = false
+
+    city.ResetCitizens(nil)
+
+    player.AddCity(city)
+
+    player.Gold = 83
+    player.Mana = 2600
+
+    // game.Map.Map.Terrain[3][6] = terrain.TileNatureForest.Index
+
+    // log.Printf("City at %v, %v", x, y)
+
+    player.LiftFog(x, y, 30, data.PlaneArcanus)
+
+    drake := player.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, nil))
+
+    for i := 0; i < 4; i++ {
+        player.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, nil))
+    }
+
+    // player.AddUnit(units.MakeOverworldUnitFromUnit(units.HighMenSpearmen, 30, 30, data.PlaneArcanus, wizard.Banner))
+
+    stack := player.FindStackByUnit(drake)
+    player.SetSelectedStack(stack)
+
+    player.LiftFog(stack.X(), stack.Y(), 2, data.PlaneArcanus)
+
+    if !game.CurrentMap().CreateEncounter(game.CurrentMap().WrapX(stack.X() + 1), stack.Y(), maplib.EncounterTypeLair, data.DifficultyAverage, false, data.PlaneArcanus) {
+        log.Printf("Unable to create encounter")
+    }
+
+    game.Camera.Center(stack.X(), stack.Y())
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -2597,6 +2681,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 28: game = createScenario28(cache)
         case 29: game = createScenario29(cache)
         case 30: game = createScenario30(cache)
+        case 31: game = createScenario31(cache)
         default: game = createScenario1(cache)
     }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -602,7 +602,7 @@ func createScenario8(cache *lbx.LbxCache) *gamelib.Game {
     player.AddCity(city)
 
     player.Gold = 83
-    player.Mana = 26
+    player.Mana = 2600
 
     // game.Map.Map.Terrain[3][6] = terrain.TileNatureForest.Index
 


### PR DESCRIPTION
create treasure loosely based on the logic described in https://masterofmagic.fandom.com/wiki/Treasure

This logic is a bit simpler. Given a budget (which normally comes directly from the encounter itself), a random treasure type is selected if it will fit in the budget, and that type of treasure is added to the overall list of treasure items. Then the budget is decreased by an amount related to the selected treasure item, and another treasure type is selected at random.