### PR TITLE
read item power requirements correctly

### DIFF
--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -625,44 +625,19 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
 
         // Requirements
         var requirements []Requirement
-        natureRanksNeeded, err := lbx.ReadByte(reader)
-        if err != nil {
-            return nil, fmt.Errorf("read error: %v", err)
-        }
-        if natureRanksNeeded != 0 {
-            requirements = append(requirements, Requirement{MagicType: data.NatureMagic, Amount: int(natureRanksNeeded)})
-        }
-
-        sorceryRanksNeeded, err := lbx.ReadByte(reader)
-        if err != nil {
-            return nil, fmt.Errorf("read error: %v", err)
-        }
-        if sorceryRanksNeeded != 0 {
-            requirements = append(requirements, Requirement{MagicType: data.SorceryMagic, Amount: int(sorceryRanksNeeded)})
-        }
-
-        chaosRanksNeeded, err := lbx.ReadByte(reader)
-        if err != nil {
-            return nil, fmt.Errorf("read error: %v", err)
-        }
-        if chaosRanksNeeded != 0 {
-            requirements = append(requirements, Requirement{MagicType: data.ChaosMagic, Amount: int(chaosRanksNeeded)})
-        }
-
-        lifeRanksNeeded, err := lbx.ReadByte(reader)
-        if err != nil {
-            return nil, fmt.Errorf("read error: %v", err)
-        }
-        if lifeRanksNeeded != 0 {
-            requirements = append(requirements, Requirement{MagicType: data.LifeMagic, Amount: int(lifeRanksNeeded)})
-        }
-
-        deathRanksNeeded, err := lbx.ReadByte(reader)
-        if err != nil {
-            return nil, fmt.Errorf("read error: %v", err)
-        }
-        if deathRanksNeeded != 0 {
-            requirements = append(requirements, Requirement{MagicType: data.DeathMagic, Amount: int(deathRanksNeeded)})
+        // read 5 more bytes, where each the powerIndex refers to the Nth power, and the read byte is the number of magic books needed
+        // for that power's magic type
+        for powerIndex := range 5 {
+            value, err := lbx.ReadByte(reader)
+            if err != nil {
+                return nil, fmt.Errorf("read error: %v", err)
+            }
+            if value != 0 && len(powers) > powerIndex && powers[powerIndex].Ability != data.AbilityNone {
+                magic := data.MakeAbility(powers[powerIndex].Ability).MagicType()
+                if magic != data.MagicNone {
+                    requirements = append(requirements, Requirement{MagicType: magic, Amount: int(value)})
+                }
+            }
         }
 
         // The last byte seems to be some sort of flag

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -625,7 +625,7 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
 
         // Requirements
         var requirements []Requirement
-        // read 5 more bytes, where each the powerIndex refers to the Nth power, and the read byte is the number of magic books needed
+        // read 5 more bytes, where the powerIndex refers to the Nth power, and the read byte is the number of magic books needed
         // for that power's magic type
         for powerIndex := range 5 {
             value, err := lbx.ReadByte(reader)


### PR DESCRIPTION
The magic requirements for an item are in a different format than how we currently parse it. Given the 5 bytes of requirement data, such as 2 1 3 4 3
Current:
The bytes are assumed to be read in the order of nature, sorcery, chaos, life, death. That would mean the bytes are
2 nature
1 sorcery
3 chaos
4 life
3 death

But the way itemdata.lbx is designed the index of the byte refers to the Nth power, and the value of the byte is the number of books for that power's magic realm. So the above numbers should mean
1st power needs 2 books
2nd power needs 1 book
3rd power needs 3 books
4th power needs 4 books
5th power needs 3 books

note that no item will ever have a 5th power, so that byte is basically useless.
