### PR TITLE
new-game: increase contrast

### DIFF
--- a/game/magic/setup/new-game.go
+++ b/game/magic/setup/new-game.go
@@ -130,7 +130,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
 
     var elements []*uilib.UIElement
 
-    okX := 160 + 91
+    okX := 161 + 91
     okY := 179
 
     okButtons, _ := newGameScreen.ImageCache.GetImages("newgame.lbx", 2)
@@ -152,7 +152,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
         },
     })
 
-    cancelX := 160 + 10
+    cancelX := 161 + 10
     cancelY := 179
 
     cancelButtons, _ := newGameScreen.ImageCache.GetImages("newgame.lbx", 3)

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -993,7 +993,7 @@ func (screen *NewWizardScreen) Load(cache *lbx.LbxCache) error {
 
     screen.LbxFonts = fonts
 
-    screen.Font = font.MakeOptimizedFont(fonts[4])
+    screen.Font = font.MakeOptimizedFont(fonts[3])
     screen.WizardSlots = DefaultWizardSlots()
 
     // FIXME: load with a yellowish palette

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -579,7 +579,7 @@ func (screen *NewWizardScreen) MakeCustomNameUI() *uilib.UI {
                 name += "_"
             }
 
-            screen.NameFont.Print(window, 195, 39, 1, ebiten.ColorScale{}, name)
+            screen.NameFontBright.Print(window, 195, 39, 1, ebiten.ColorScale{}, name)
 
             return
         },


### PR DESCRIPTION
Icrease the contrast for the font's used in the start game screens for better readability.

Before:
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 54 00" src="https://github.com/user-attachments/assets/12286949-868d-484b-ae29-9a6e261ba6b7" />
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 54 08" src="https://github.com/user-attachments/assets/459f262e-9b9d-40ef-a5b9-3f4a108609a9" />
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 54 20" src="https://github.com/user-attachments/assets/3ecd2f95-c4ff-478e-b84f-3e80342ee2c3" />


After:
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 52 47" src="https://github.com/user-attachments/assets/7ec0e21f-e6a3-4611-9cee-f42cea1717db" />
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 53 04" src="https://github.com/user-attachments/assets/2f7d9742-1361-4fa1-a47a-34021fdf3455" />
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 54 41" src="https://github.com/user-attachments/assets/07ef51f8-7cb3-4cf0-8374-c1b562bb57be" />

For Reference: This is the original game:
<img width="911" alt="Bildschirmfoto 2025-01-19 um 17 02 47" src="https://github.com/user-attachments/assets/d4310c7c-cb02-4880-beff-60b6cda04140" />


Also fixes button positions.

Before:
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 53 54" src="https://github.com/user-attachments/assets/88d6fe96-cc56-47cc-a6d3-1486f8f74f23" />

After:
<img width="500" alt="Bildschirmfoto 2025-01-20 um 05 53 37" src="https://github.com/user-attachments/assets/4f326c86-6e26-4479-bbdb-8c64cc2e625f" />

