### PR TITLE
cast: implement raise volcano

### DIFF
--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -569,8 +569,17 @@ func (game *Game) doCastRaiseVolcano(yield coroutine.YieldFunc, tileX int, tileY
     game.doCastOnMap(yield, tileX, tileY, 11, false, 98, update)
 
     mapObject := game.CurrentMap()
-    mapObject.Map.SetTerrainAt(tileX, tileY, terrain.Volcano, mapObject.Data, mapObject.Plane)
     mapObject.SetVolcano(tileX, tileY, player)
 
-    // FIXME: Destruct buildings in towns
+    // volcanoes may destroy buildings if cast in a city
+    for _, player := range game.Players {
+        city := player.FindCity(tileX, tileY, mapObject.Plane)
+        if city != nil {
+            for _, building := range city.Buildings.Values() {
+                if rand.N(100) < 15 {
+                    city.Buildings.Remove(building)
+                }
+            }
+        }
+    }
 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -435,9 +435,9 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     return 0, 0, true
 }
 
-type UpdateTerrainFunction func (int, int, int)
+type UpdateMapFunction func (int, int, int)
 
-func (game *Game) doCastOnTerrain(yield coroutine.YieldFunc, tileX int, tileY int, animationIndex int, newSound bool, soundIndex int, terrainFunction UpdateTerrainFunction) {
+func (game *Game) doCastOnMap(yield coroutine.YieldFunc, tileX int, tileY int, animationIndex int, newSound bool, soundIndex int, update UpdateMapFunction) {
     game.Camera.Zoom = camera.ZoomDefault
     game.doMoveCamera(yield, tileX, tileY)
 
@@ -478,7 +478,7 @@ func (game *Game) doCastOnTerrain(yield coroutine.YieldFunc, tileX int, tileY in
 
         quit = false
         if game.Counter % 6 == 0 {
-            terrainFunction(tileX, tileY, animation.CurrentFrame)
+            update(tileX, tileY, animation.CurrentFrame)
             quit = !animation.Next()
         }
 
@@ -489,7 +489,7 @@ func (game *Game) doCastOnTerrain(yield coroutine.YieldFunc, tileX int, tileY in
 func (game *Game) doCastEnchantRoad(yield coroutine.YieldFunc, tileX int, tileY int) {
     update := func (x int, y int, frame int) {}
 
-    game.doCastOnTerrain(yield, tileX, tileY, 46, false, 86, update)
+    game.doCastOnMap(yield, tileX, tileY, 46, false, 86, update)
 
     useMap := game.CurrentMap()
 
@@ -512,7 +512,7 @@ func (game *Game) doCastEnchantRoad(yield coroutine.YieldFunc, tileX int, tileY 
 func (game *Game) doCastEarthLore(yield coroutine.YieldFunc, tileX int, tileY int, player *playerlib.Player) {
     update := func (x int, y int, frame int) {}
 
-    game.doCastOnTerrain(yield, tileX, tileY, 45, true, 18, update)
+    game.doCastOnMap(yield, tileX, tileY, 45, true, 18, update)
 
     player.LiftFogSquare(tileX, tileY, 5, game.Plane)
 }
@@ -536,7 +536,7 @@ func (game *Game) doCastChangeTerrain(yield coroutine.YieldFunc, tileX int, tile
         }
     }
 
-    game.doCastOnTerrain(yield, tileX, tileY, 8, false, 28, update)
+    game.doCastOnMap(yield, tileX, tileY, 8, false, 28, update)
 }
 
 
@@ -555,7 +555,7 @@ func (game *Game) doCastTransmute(yield coroutine.YieldFunc, tileX int, tileY in
         }
     }
 
-    game.doCastOnTerrain(yield, tileX, tileY, 0, false, 28, update)
+    game.doCastOnMap(yield, tileX, tileY, 0, false, 28, update)
 }
 
 
@@ -568,7 +568,7 @@ func (game *Game) doCastRaiseVolcano(yield coroutine.YieldFunc, tileX int, tileY
         }
     }
 
-    game.doCastOnTerrain(yield, tileX, tileY, 11, false, 98, update)
+    game.doCastOnMap(yield, tileX, tileY, 11, false, 98, update)
 
     mapObject := game.CurrentMap()
     mapObject.Map.SetTerrainAt(tileX, tileY, terrain.Volcano, mapObject.Data, mapObject.Plane)

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -435,7 +435,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     return 0, 0, true
 }
 
-type UpdateMapFunction func (int, int, int)
+type UpdateMapFunction func (tileX int, tileY int, animationFrame int)
 
 func (game *Game) doCastOnMap(yield coroutine.YieldFunc, tileX int, tileY int, animationIndex int, newSound bool, soundIndex int, update UpdateMapFunction) {
     game.Camera.Zoom = camera.ZoomDefault

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -527,9 +527,7 @@ func (game *Game) doCastChangeTerrain(yield coroutine.YieldFunc, tileX int, tile
                 case terrain.Grass:
                     mapObject.Map.SetTerrainAt(x, y, terrain.Forest, mapObject.Data, mapObject.Plane)
                 case terrain.Volcano:
-                    mapObject.Map.SetTerrainAt(x, y, terrain.Mountain, mapObject.Data, mapObject.Plane)
                     mapObject.RemoveVolcano(x, y)
-                    // FIXME: chance of generating mineral
                 case terrain.Mountain:
                     mapObject.Map.SetTerrainAt(x, y, terrain.Hill, mapObject.Data, mapObject.Plane)
             }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -100,7 +100,7 @@ func (game *Game) doCastSpell(yield coroutine.YieldFunc, player *playerlib.Playe
                 return
             }
 
-            game.doCastRaiseVolcano(yield, tileX, tileY)
+            game.doCastRaiseVolcano(yield, tileX, tileY, player)
         case "Summon Hero":
             var choices []*herolib.Hero
             for _, hero := range game.Heroes {
@@ -530,6 +530,7 @@ func (game *Game) doCastChangeTerrain(yield coroutine.YieldFunc, tileX int, tile
                     mapObject.Map.SetTerrainAt(x, y, terrain.Forest, mapObject.Data, mapObject.Plane)
                 case terrain.Volcano:
                     mapObject.Map.SetTerrainAt(x, y, terrain.Mountain, mapObject.Data, mapObject.Plane)
+                    mapObject.RemoveVolcano(x, y)
                 case terrain.Mountain:
                     mapObject.Map.SetTerrainAt(x, y, terrain.Hill, mapObject.Data, mapObject.Plane)
             }
@@ -559,7 +560,7 @@ func (game *Game) doCastTransmute(yield coroutine.YieldFunc, tileX int, tileY in
 }
 
 
-func (game *Game) doCastRaiseVolcano(yield coroutine.YieldFunc, tileX int, tileY int) {
+func (game *Game) doCastRaiseVolcano(yield coroutine.YieldFunc, tileX int, tileY int, player *playerlib.Player) {
     update := func (x int, y int, frame int) {
         if frame == 8 {
             mapObject := game.CurrentMap()
@@ -572,8 +573,8 @@ func (game *Game) doCastRaiseVolcano(yield coroutine.YieldFunc, tileX int, tileY
 
     mapObject := game.CurrentMap()
     mapObject.Map.SetTerrainAt(tileX, tileY, terrain.Volcano, mapObject.Data, mapObject.Plane)
+    mapObject.SetVolcano(tileX, tileY, player)
 
     // FIXME: Destruct buildings in towns
-    // FIXME: Raise wizard's power
     // FIXME: Chance of reverting with chance of generating minerals
 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -531,6 +531,7 @@ func (game *Game) doCastChangeTerrain(yield coroutine.YieldFunc, tileX int, tile
                 case terrain.Volcano:
                     mapObject.Map.SetTerrainAt(x, y, terrain.Mountain, mapObject.Data, mapObject.Plane)
                     mapObject.RemoveVolcano(x, y)
+                    // FIXME: chance of generating mineral
                 case terrain.Mountain:
                     mapObject.Map.SetTerrainAt(x, y, terrain.Hill, mapObject.Data, mapObject.Plane)
             }
@@ -576,5 +577,4 @@ func (game *Game) doCastRaiseVolcano(yield coroutine.YieldFunc, tileX int, tileY
     mapObject.SetVolcano(tileX, tileY, player)
 
     // FIXME: Destruct buildings in towns
-    // FIXME: Chance of reverting with chance of generating minerals
 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -463,7 +463,6 @@ func (game *Game) doCastOnTerrain(yield coroutine.YieldFunc, tileX int, tileY in
     }
 
     if newSound {
-        // FIXME: Are sounds for earth lore/change terrain/transmute not also in sound?
         sound, err := audio.LoadNewSound(game.Cache, soundIndex)
         if err == nil {
             sound.Play()
@@ -492,8 +491,7 @@ func (game *Game) doCastOnTerrain(yield coroutine.YieldFunc, tileX int, tileY in
 func (game *Game) doCastEnchantRoad(yield coroutine.YieldFunc, tileX int, tileY int) {
     update := func (x int, y int, frame int) {}
 
-    // FIXME: verify this is the right sound
-    game.doCastOnTerrain(yield, tileX, tileY, 46, true, 18, update)
+    game.doCastOnTerrain(yield, tileX, tileY, 46, false, 86, update)
 
     useMap := game.CurrentMap()
 
@@ -538,7 +536,7 @@ func (game *Game) doCastChangeTerrain(yield coroutine.YieldFunc, tileX int, tile
         }
     }
 
-    game.doCastOnTerrain(yield, tileX, tileY, 8, true, 18, update)
+    game.doCastOnTerrain(yield, tileX, tileY, 8, false, 28, update)
 }
 
 
@@ -557,7 +555,7 @@ func (game *Game) doCastTransmute(yield coroutine.YieldFunc, tileX int, tileY in
         }
     }
 
-    game.doCastOnTerrain(yield, tileX, tileY, 0, true, 18, update)
+    game.doCastOnTerrain(yield, tileX, tileY, 0, false, 28, update)
 }
 
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -874,6 +874,9 @@ func (game *Game) ComputePower(player *playerlib.Player) int {
         power += float64(len(node.Zone)) * magicBonus
     }
 
+    power += float64(len(game.ArcanusMap.GetCastedVolcanoes(player)))
+    power += float64(len(game.MyrrorMap.GetCastedVolcanoes(player)))
+
     if power < 0 {
         power = 0
     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5285,6 +5285,8 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
 func (game *Game) EndOfTurn() {
     // put stuff here that should happen when all players have taken their turn
 
+    // FIXME: Chance of reverting volcanos with chance of generating minerals
+
     game.TurnNumber += 1
 }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5298,10 +5298,24 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
     game.RefreshUI()
 }
 
+func (game *Game) revertVolcanos() {
+    mapObjects := []*maplib.Map{game.ArcanusMap, game.MyrrorMap}
+    for _, mapObject := range mapObjects {
+        for location, extras := range mapObject.ExtraMap {
+            _, ok := extras[maplib.ExtraKindVolcano]
+            if ok {
+                if rand.N(100) < 2 {
+                    mapObject.RemoveVolcano(location.X, location.Y)
+                }
+            }
+        }
+    }
+}
+
 func (game *Game) EndOfTurn() {
     // put stuff here that should happen when all players have taken their turn
 
-    // FIXME: Chance of reverting volcanos with chance of generating minerals
+    game.revertVolcanos()
 
     game.TurnNumber += 1
 }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -26,7 +26,7 @@ type CityProvider interface {
     ContainsCity(x int, y int, plane data.Plane) bool
 }
 
-type Caster interface {
+type Wizard interface {
     GetBanner() data.BannerType
 }
 
@@ -331,7 +331,7 @@ type ExtraMagicNode struct {
     Zone []image.Point
 
     // if this node is melded, then this player receives the power
-    MeldingWizard Caster
+    MeldingWizard Wizard
     // true if melded by a guardian spirit, otherwise false if melded by a magic spirit
     GuardianSpiritMeld bool
 
@@ -365,7 +365,7 @@ func (node *ExtraMagicNode) DrawLayer2(screen *ebiten.Image, imageCache *util.Im
     }
 }
 
-func (node *ExtraMagicNode) Meld(meldingWizard Caster, spirit units.Unit) bool {
+func (node *ExtraMagicNode) Meld(meldingWizard Wizard, spirit units.Unit) bool {
     if node.MeldingWizard == nil {
         node.MeldingWizard = meldingWizard
         if spirit.Equals(units.GuardianSpirit) {
@@ -403,7 +403,7 @@ func (node *ExtraMagicNode) Meld(meldingWizard Caster, spirit units.Unit) bool {
 }
 
 type ExtraVolcano struct {
-    CastingWizard Caster
+    CastingWizard Wizard
 }
 
 func (node *ExtraVolcano) DrawLayer1(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64, tileWidth int, tileHeight int){
@@ -723,7 +723,7 @@ func (mapObject *Map) GetRoadNeighbors(x int, y int) map[Direction]bool {
     return out
 }
 
-func (mapObject *Map) GetMeldedNodes(melder Caster) []*ExtraMagicNode {
+func (mapObject *Map) GetMeldedNodes(melder Wizard) []*ExtraMagicNode {
     var out []*ExtraMagicNode
 
     for _, extras := range mapObject.ExtraMap {
@@ -739,7 +739,7 @@ func (mapObject *Map) GetMeldedNodes(melder Caster) []*ExtraMagicNode {
     return out
 }
 
-func (mapObject *Map) GetCastedVolcanoes(caster Caster) []*ExtraVolcano {
+func (mapObject *Map) GetCastedVolcanoes(caster Wizard) []*ExtraVolcano {
     var out []*ExtraVolcano
 
     for _, extras := range mapObject.ExtraMap {
@@ -793,7 +793,7 @@ func (mapObject *Map) GetMagicNode(x int, y int) *ExtraMagicNode {
     return getExtra[*ExtraMagicNode](mapObject.ExtraMap[image.Pt(x, y)], ExtraKindMagicNode)
 }
 
-func (mapObject *Map) SetVolcano(x int, y int, caster Caster) {
+func (mapObject *Map) SetVolcano(x int, y int, caster Wizard) {
     mapObject.ExtraMap[image.Pt(x, y)][ExtraKindVolcano] = &ExtraVolcano{CastingWizard: caster}
     mapObject.Map.SetTerrainAt(x, y, terrain.Volcano, mapObject.Data, mapObject.Plane)
 }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -795,6 +795,7 @@ func (mapObject *Map) GetMagicNode(x int, y int) *ExtraMagicNode {
 
 func (mapObject *Map) SetVolcano(x int, y int, caster Caster) {
     mapObject.ExtraMap[image.Pt(x, y)][ExtraKindVolcano] = &ExtraVolcano{CastingWizard: caster}
+    mapObject.Map.SetTerrainAt(x, y, terrain.Volcano, mapObject.Data, mapObject.Plane)
 }
 
 func (mapObject *Map) RemoveVolcano(x int, y int) {

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -743,9 +743,9 @@ func (mapObject *Map) GetCastedVolcanoes(caster Caster) []*ExtraVolcano {
     var out []*ExtraVolcano
 
     for _, extras := range mapObject.ExtraMap {
-        node, ok := extras[ExtraKindVolcano]
+        extra, ok := extras[ExtraKindVolcano]
         if ok {
-            volcano := node.(*ExtraVolcano)
+            volcano := extra.(*ExtraVolcano)
             if volcano.CastingWizard == caster {
                 out = append(out, volcano)
             }
@@ -798,7 +798,21 @@ func (mapObject *Map) SetVolcano(x int, y int, caster Caster) {
 }
 
 func (mapObject *Map) RemoveVolcano(x int, y int) {
-    delete(mapObject.ExtraMap[image.Pt(x, y)], ExtraKindVolcano)
+    _, exists := mapObject.ExtraMap[image.Pt(x, y)][ExtraKindVolcano]
+    if exists {
+        delete(mapObject.ExtraMap[image.Pt(x, y)], ExtraKindVolcano)
+
+        mapObject.Map.SetTerrainAt(x, y, terrain.Mountain, mapObject.Data, mapObject.Plane)
+
+        // chance of 5% to generate a mineral
+        if rand.N(100) < 5 {
+            choices := []data.BonusType{data.BonusSilverOre, data.BonusGoldOre, data.BonusIronOre, data.BonusCoal, data.BonusMithrilOre}
+            if mapObject.Plane == data.PlaneMyrror {
+                choices = append(choices, data.BonusAdamantiumOre)
+            }
+            mapObject.SetBonus(x, y, choices[rand.IntN(len(choices))])
+        }
+    }
 }
 
 func (mapObject *Map) GetBonusTile(x int, y int) data.BonusType {

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1004,6 +1004,9 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city.Workers = 3
     city.Wall = false
 
+    city.AddBuilding(buildinglib.BuildingShrine)
+    city.AddBuilding(buildinglib.BuildingGranary)
+
     city.ResetCitizens(nil)
 
     player.AddCity(city)

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -970,6 +970,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Change Terrain"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Transmute"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Raise Volcano"))
 
     x, y := game.FindValidCityLocation(game.Plane)
 


### PR DESCRIPTION
Implement [Raise Volcano](https://masterofmagic.fandom.com/wiki/Raise_Volcano) Spell.

Volcanoes:
- may be cast on desert, forest, swamp, frass, and tundra
- destroys any bonus
- may destroy buildings with a chance of 15%
- generate 1 power for the casting wizard
- have a chance of 2% of reverting back to mountain, and thereby a chance of 5% of generating a random mineral
- can be reverted also with change terrain

I also reused the `Melder` interace but renamed it to `Wizard`, not sure if that is a good idea.

I also refactored the spells that affect the map. They now all behave the same way: for example centering on the tile and resetting zoom. The common/duplicated code is now in `doCastOnMap`. Since some things need to happen mid-animation (for example changing terrain when the animation covers most of the tile), `doCastOnMap` accepts an `UpdateMapFunction`. I also moved the spell logic to the `doXYZ` for better clarity.


