### PR TITLE
data: unify usage of BonusType

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -319,13 +319,7 @@ func (city *City) PowerMinerals() int {
 
     extra := 0
     for _, tile := range catchment {
-        bonus := tile.GetBonus()
-        switch bonus {
-            case data.BonusMithrilOre: extra += 1
-            case data.BonusAdamantiumOre: extra += 2
-            case data.BonusQuorkCrystal: extra += 3
-            case data.BonusCrysxCrystal: extra += 5
-        }
+        extra += tile.GetBonus().PowerBonus()
     }
 
     if city.Race == data.RaceDwarf {
@@ -586,9 +580,7 @@ func (city *City) BaseFoodLevel() int {
                 }
         }
 
-        if tile.HasWildGame() {
-            food = food.Add(fraction.FromInt(2))
-        }
+        food.Add(fraction.FromInt(tile.GetBonus().FoodBonus()))
     }
 
     return int(food.ToFloat())
@@ -672,12 +664,7 @@ func (city *City) GoldMinerals() int {
     extra := 0
 
     for _, tile := range catchment {
-        bonus := tile.GetBonus()
-        switch bonus {
-            case data.BonusSilverOre: extra += 2
-            case data.BonusGoldOre: extra += 3
-            case data.BonusGem: extra += 5
-        }
+        extra += tile.GetBonus().GoldBonus()
     }
 
     if city.Race == data.RaceDwarf {
@@ -834,10 +821,8 @@ func (city *City) ProductionTerrain() float32 {
             case terrain.Desert, terrain.Forest, terrain.Hill, terrain.NatureNode: production += 0.03
         }
 
-        switch tile.GetBonus() {
-            case data.BonusIronOre: mineralProduction += 0.05
-            case data.BonusCoal: mineralProduction += 0.1
-        }
+        // FIXME: This should be only when producing units
+        mineralProduction += float32(tile.GetBonus().UnitReductionBonus()) / 100
     }
 
     if city.Race == data.RaceDwarf {

--- a/game/magic/data/data.go
+++ b/game/magic/data/data.go
@@ -215,6 +215,24 @@ const (
     BonusCrysxCrystal
 )
 
+func (bonus BonusType) String() string {
+    switch bonus {
+        case BonusGoldOre: return "Gold Ore"
+        case BonusSilverOre: return "Silver Ore"
+        case BonusWildGame: return "Wild Game"
+        case BonusNightshade: return "Nightshade"
+        case BonusIronOre: return "Iron Ore"
+        case BonusCoal: return "Coal"
+        case BonusMithrilOre: return "Mithril Ore"
+        case BonusAdamantiumOre: return "Adamantium Ore"
+        case BonusGem: return "Gem"
+        case BonusQuorkCrystal: return "Quork Crystal"
+        case BonusCrysxCrystal: return "Crysx Crystal"
+    }
+
+    return ""
+}
+
 func (bonus BonusType) FoodBonus() int {
     if bonus == BonusWildGame {
         return 2

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -183,26 +183,34 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
                     y += float64(whiteFont.Height() * data.ScreenScale)
 
-                    showBonus := func (name string, bonus string) {
-                        yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, name)
-                        y += float64(yellowFont.Height() * data.ScreenScale)
-                        whiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, bonus)
-                    }
-
                     bonus := tile.GetBonus()
-                    switch bonus {
-                        case data.BonusNone: // nothing
-                        case data.BonusGoldOre: showBonus("Gold Ore", fmt.Sprintf("+%v gold", bonus.GoldBonus()))
-                        case data.BonusSilverOre: showBonus("Silver Ore", fmt.Sprintf("+%v gold", bonus.GoldBonus()))
-                        case data.BonusWildGame: showBonus("Wild Game", fmt.Sprintf("+%v food", bonus.FoodBonus()))
-                        case data.BonusNightshade: showBonus("Nightshade", "")
-                        case data.BonusIronOre: showBonus("Iron Ore", fmt.Sprintf("Reduces normal unit cost by %v%%", bonus.UnitReductionBonus()))
-                        case data.BonusCoal: showBonus("Coal", fmt.Sprintf("Reduces normal unit cost by %v%%", bonus.UnitReductionBonus()))
-                        case data.BonusMithrilOre: showBonus("Mithril Ore", fmt.Sprintf("+%v power", bonus.PowerBonus()))
-                        case data.BonusAdamantiumOre: showBonus("Adamantium Ore", fmt.Sprintf("+%v power", bonus.PowerBonus()))
-                        case data.BonusGem: showBonus("Gem", fmt.Sprintf("+%v gold", bonus.GoldBonus()))
-                        case data.BonusQuorkCrystal: showBonus("Quork Crystal", fmt.Sprintf("+%v power", bonus.PowerBonus()))
-                        case data.BonusCrysxCrystal: showBonus("Crysx Crystal", fmt.Sprintf("+%v power", bonus.PowerBonus()))
+                    if bonus != data.BonusNone {
+                        yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, bonus.String())
+                        y += float64(yellowFont.Height() * data.ScreenScale)
+
+                        food := bonus.FoodBonus()
+                        if food != 0 {
+                            whiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v food", food))
+                            y += float64(whiteFont.Height() * data.ScreenScale)
+                        }
+
+                        gold := bonus.GoldBonus()
+                        if gold != 0 {
+                            whiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v gold", gold))
+                            y += float64(whiteFont.Height() * data.ScreenScale)
+                        }
+
+                        power := bonus.PowerBonus()
+                        if power != 0 {
+                            whiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v power", power))
+                            y += float64(whiteFont.Height() * data.ScreenScale)
+                        }
+
+                        reduction := bonus.UnitReductionBonus()
+                        if reduction != 0 {
+                            whiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Reduces normal unit cost by %v%%", reduction))
+                            y += float64(whiteFont.Height() * data.ScreenScale)
+                        }
                     }
 
                     if cityMap[selectedPoint] != nil {

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -432,10 +432,6 @@ func (tile *FullTile) GetBonus() data.BonusType {
     return data.BonusNone
 }
 
-func (tile *FullTile) HasWildGame() bool {
-    return tile.GetBonus() == data.BonusWildGame
-}
-
 type Map struct {
     Map *terrain.Map
 


### PR DESCRIPTION
Rely (only) on the `BonusType` definitions in `city`, `maplib` and `surveyor`.

I think there is also a small bug: coal and iron currently provide a general production bonus instead of only bonus to producting new units. I would leave this as a FIXME for now.