### PR TITLE
map: unify usage of terrain tile bonuses

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -13,7 +13,6 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
-    "github.com/kazzmir/master-of-magic/game/magic/terrain"
     "github.com/kazzmir/master-of-magic/game/magic/maplib"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
 )
@@ -566,21 +565,8 @@ func (city *City) BaseFoodLevel() int {
     food := fraction.Zero()
 
     for _, tile := range catchment {
-        switch tile.Tile.TerrainType() {
-            case terrain.Ocean, terrain.Mountain, terrain.Desert, terrain.Tundra, terrain.Volcano: // nothing
-            case terrain.Grass: food = food.Add(fraction.Make(3, 2))
-            case terrain.Forest, terrain.Hill, terrain.Shore, terrain.Swamp: food = food.Add(fraction.Make(1, 2))
-            case terrain.SorceryNode, terrain.River: food = food.Add(fraction.FromInt(2))
-            case terrain.NatureNode: food = food.Add(fraction.Make(5, 2))
-            case terrain.ChaosNode: // nothing
-            case terrain.Lake:
-                switch tile.Tile.Index(city.Plane) {
-                    case terrain.IndexLake1, terrain.IndexLake2, terrain.IndexLake3, terrain.IndexLake4:
-                        food = food.Add(fraction.Make(3, 2))
-                }
-        }
-
-        food.Add(fraction.FromInt(tile.GetBonus().FoodBonus()))
+        food = food.Add(tile.FoodBonus())
+        food = food.Add(fraction.FromInt(tile.GetBonus().FoodBonus()))
     }
 
     return int(food.ToFloat())
@@ -816,10 +802,7 @@ func (city *City) ProductionTerrain() float32 {
     mineralProduction := float32(0)
 
     for _, tile := range catchment {
-        switch tile.Tile.TerrainType() {
-            case terrain.Mountain, terrain.ChaosNode: production += 0.05
-            case terrain.Desert, terrain.Forest, terrain.Hill, terrain.NatureNode: production += 0.03
-        }
+        production += float32(tile.ProductionBonus()) / 100
 
         // FIXME: This should be only when producing units
         mineralProduction += float32(tile.GetBonus().UnitReductionBonus()) / 100

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4106,7 +4106,7 @@ func (game *Game) ComputeMaximumPopulation(x int, y int, plane data.Plane) int {
     food := fraction.Zero()
 
     for _, tile := range catchment {
-        food = food.Add(tile.Tile.FoodBonus())
+        food = food.Add(tile.FoodBonus())
         bonus := tile.GetBonus()
         food = food.Add(fraction.FromInt(bonus.FoodBonus()))
     }
@@ -4120,32 +4120,9 @@ func (game *Game) ComputeMaximumPopulation(x int, y int, plane data.Plane) int {
 }
 
 func (game *Game) CityGoldBonus(x int, y int, plane data.Plane) int {
-    gold := 0
-    tile := game.GetMap(plane).GetTile(x, y)
-    if tile.Tile.TerrainType() == terrain.River {
-        gold += 20
-    }
-
-    // check tiles immediately touching the city
-    touchingShore := false
-    for dx := -1; dx <= 1; dx++ {
-        for dy := -1; dy <= 1; dy++ {
-            if dx == 0 && dy == 0 {
-                continue
-            }
-
-            tile := game.GetMap(plane).GetTile(x + dx, y + dy)
-            if tile.Tile.TerrainType() == terrain.Shore {
-                touchingShore = true
-            }
-        }
-    }
-
-    if touchingShore {
-        gold += 10
-    }
-
-    return gold
+    mapObject := game.GetMap(plane)
+    tile := mapObject.GetTile(x, y)
+    return tile.GoldBonus(mapObject)
 }
 
 func (game *Game) CityProductionBonus(x int, y int, plane data.Plane) int {
@@ -4155,7 +4132,7 @@ func (game *Game) CityProductionBonus(x int, y int, plane data.Plane) int {
     production := 0
 
     for _, tile := range catchment {
-        production += tile.Tile.ProductionBonus()
+        production += tile.ProductionBonus()
     }
 
     return production

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -164,20 +164,27 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
             if selectedPoint.X >= 0 && selectedPoint.X < game.CurrentMap().Width() && selectedPoint.Y >= 0 && selectedPoint.Y < game.CurrentMap().Height() {
                 if overworld.Fog[selectedPoint.X][selectedPoint.Y] {
-                    tile := game.CurrentMap().GetTile(selectedPoint.X, selectedPoint.Y)
+                    mapObject := game.CurrentMap()
+                    tile := mapObject.GetTile(selectedPoint.X, selectedPoint.Y)
                     y := float64(93 * data.ScreenScale)
-                    yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, tile.Tile.Name())
+                    yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, tile.Name(mapObject))
                     y += float64(yellowFont.Height() * data.ScreenScale)
 
-                    foodBonus := tile.Tile.FoodBonus()
+                    foodBonus := tile.FoodBonus()
                     if !foodBonus.IsZero() {
                         whiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v food", foodBonus.NormalString()))
                         y += float64(whiteFont.Height() * data.ScreenScale)
                     }
 
-                    productionBonus := tile.Tile.ProductionBonus()
+                    productionBonus := tile.ProductionBonus()
                     if productionBonus != 0 {
                         whiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v%% production", productionBonus))
+                        y += float64(whiteFont.Height() * data.ScreenScale)
+                    }
+
+                    goldBonus := tile.GoldBonus(mapObject)
+                    if goldBonus != 0 {
+                        whiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v%% gold", goldBonus))
                         y += float64(whiteFont.Height() * data.ScreenScale)
                     }
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -499,7 +499,6 @@ func (tile *FullTile) IsRiverMouth(mapObject *Map) bool {
 }
 
 func (tile *FullTile) IsTouchingShore(mapObject *Map) bool {
-    touchingShore := false
     for dx := -1; dx <= 1; dx++ {
         for dy := -1; dy <= 1; dy++ {
             if dx == 0 && dy == 0 {
@@ -508,12 +507,12 @@ func (tile *FullTile) IsTouchingShore(mapObject *Map) bool {
 
             tile := mapObject.GetTile(tile.X + dx, tile.Y + dy)
             if tile.Tile.IsShore() {
-                touchingShore = true
+                return true
             }
         }
     }
 
-    return touchingShore
+    return false
 }
 
 func (tile *FullTile) GetBonus() data.BonusType {

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -7,6 +7,7 @@ import (
     "image"
     "image/color"
 
+    "github.com/kazzmir/master-of-magic/lib/fraction"
     "github.com/kazzmir/master-of-magic/game/magic/terrain"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
@@ -419,8 +420,100 @@ type FullTile struct {
     Y int
 }
 
+func (tile *FullTile) Name(mapObject *Map) string {
+    if tile.IsRiverMouth(mapObject) {
+        return "River Mouth"
+    }
+
+    return tile.Tile.Name()
+}
+
 func (tile *FullTile) Valid() bool {
     return tile.Tile.Valid()
+}
+
+func (tile *FullTile) FoodBonus() fraction.Fraction {
+    if tile.Tile.IsLakeWithFlow() {
+        return fraction.FromInt(2)
+    }
+    // FIXME: Shore with two river deltas = 2
+    // FIXME: Shore with single river delta surrounded by ocean = 2
+
+    switch tile.Tile.TerrainType() {
+        case terrain.Ocean: return fraction.Zero()
+        case terrain.Grass: return fraction.Make(3, 2)
+        case terrain.Forest: return fraction.Make(1, 2)
+        case terrain.Mountain: return fraction.Zero()
+        case terrain.Desert: return fraction.Zero()
+        case terrain.Swamp: return fraction.Zero()
+        case terrain.Tundra: return fraction.Zero()
+        case terrain.SorceryNode: return fraction.FromInt(2)
+        case terrain.NatureNode: return fraction.Make(5, 2)
+        case terrain.ChaosNode: return fraction.Zero()
+        case terrain.Hill: return fraction.Make(1, 2)
+        case terrain.Volcano: return fraction.Zero()
+        case terrain.Lake: return fraction.Zero()
+        case terrain.River: return fraction.FromInt(2)
+        case terrain.Shore: return fraction.Make(1, 2)
+    }
+
+    return fraction.Zero()
+}
+
+// percent bonus increase, 3 = 3%
+func (tile *FullTile) GoldBonus(mapObject *Map) int {
+    switch {
+        case tile.IsRiverMouth(mapObject): return 30
+        case tile.IsTouchingShore(mapObject): return 10
+        case tile.Tile.TerrainType() == terrain.River: return 20
+    }
+
+    return 0
+}
+
+// percent bonus increase, 3 = 3%
+func (tile *FullTile) ProductionBonus() int {
+    switch tile.Tile.TerrainType() {
+        case terrain.Ocean: return 0
+        case terrain.Grass: return 0
+        case terrain.Forest: return 3
+        case terrain.Mountain: return 5
+        case terrain.Desert: return 3
+        case terrain.Swamp: return 0
+        case terrain.Tundra: return 0
+        case terrain.SorceryNode: return 0
+        case terrain.NatureNode: return 3
+        case terrain.ChaosNode: return 5
+        case terrain.Hill: return 3
+        case terrain.Volcano: return 0
+        case terrain.Lake: return 0
+        case terrain.River: return 0
+        case terrain.Shore: return 0
+    }
+
+    return 0
+}
+
+func (tile *FullTile) IsRiverMouth(mapObject *Map) bool {
+    return tile.Tile.TerrainType() == terrain.River && tile.IsTouchingShore(mapObject)
+}
+
+func (tile *FullTile) IsTouchingShore(mapObject *Map) bool {
+    touchingShore := false
+    for dx := -1; dx <= 1; dx++ {
+        for dy := -1; dy <= 1; dy++ {
+            if dx == 0 && dy == 0 {
+                continue
+            }
+
+            tile := mapObject.GetTile(tile.X + dx, tile.Y + dy)
+            if tile.Tile.IsShore() {
+                touchingShore = true
+            }
+        }
+    }
+
+    return touchingShore
 }
 
 func (tile *FullTile) GetBonus() data.BonusType {

--- a/game/magic/terrain/terrain.go
+++ b/game/magic/terrain/terrain.go
@@ -7,7 +7,6 @@ import (
 
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/lib/lbx"
-    "github.com/kazzmir/master-of-magic/lib/fraction"
 )
 
 // terrain tiles are indicies 0-0x259 for arcanus, and 0x2fA - 0x5f4 for myrror
@@ -302,74 +301,6 @@ func (tile Tile) Name() string {
     }
 }
 
-func (tile Tile) FoodBonus() fraction.Fraction {
-    switch tile.TerrainType() {
-        case Ocean: return fraction.Zero()
-        case Grass: return fraction.Make(3, 2)
-        case Forest: return fraction.Make(1, 2)
-        case Mountain: return fraction.Zero()
-        case Desert: return fraction.Zero()
-        case Swamp: return fraction.Zero()
-        case Tundra: return fraction.Zero()
-        case SorceryNode: return fraction.FromInt(2)
-        case NatureNode: return fraction.Make(5, 2)
-        case ChaosNode: return fraction.Zero()
-        case Hill: return fraction.Make(1, 2)
-        case Volcano: return fraction.Zero()
-        case Lake: return fraction.Zero()
-        case River: return fraction.FromInt(2)
-        case Shore: return fraction.Make(1, 2)
-    }
-
-    return fraction.Zero()
-}
-
-// percent bonus increase, 3 = 3%
-func (tile Tile) GoldBonus() int {
-    // FIXME
-    switch tile.TerrainType() {
-        case Ocean: return 0
-        case Grass: return 0
-        case Forest: return 0
-        case Mountain: return 0
-        case Desert: return 0
-        case Swamp: return 0
-        case Tundra: return 0
-        case SorceryNode: return 0
-        case NatureNode: return 0
-        case ChaosNode: return 0
-        case Hill: return 0
-        case Volcano: return 0
-        case Lake: return 0
-        case River: return 0
-        case Shore: return 0
-    }
-    return 0
-}
-
-// percent bonus increase, 3 = 3%
-func (tile Tile) ProductionBonus() int {
-    switch tile.TerrainType() {
-        case Ocean: return 0
-        case Grass: return 0
-        case Forest: return 3
-        case Mountain: return 5
-        case Desert: return 3
-        case Swamp: return 0
-        case Tundra: return 0
-        case SorceryNode: return 0
-        case NatureNode: return 0
-        case ChaosNode: return 0
-        case Hill: return 3
-        case Volcano: return 0
-        case Lake: return 0
-        case River: return 0
-        case Shore: return 0
-    }
-
-    return 0
-}
-
 func (tile Tile) IsShore() bool {
     return tile.TerrainType() == Shore
 }
@@ -391,6 +322,14 @@ func (tile Tile) IsWater() bool {
         case Ocean, Shore, Lake: return true
         default: return false
     }
+}
+
+func (tile Tile) IsLakeWithFlow() bool {
+    switch tile.index {
+        case IndexLake1, IndexLake2, IndexLake3, IndexLake4: return true
+    }
+
+    return false
 }
 
 // match the given match to a terrain


### PR DESCRIPTION
Rely (only) on `FoodBonus`, `GoldBonus` and `ProductionBonus` of a tile.

Since some of these Bonuses rely on neighboring tiles in case of River Mouths, I've moved these definitions from `terrain` to `map`. This will also be needed when disabling the bonuses in case of corruption.

I've also moved the gold bonus logic previously in `city` to `GoldBonus` together with `IsRiverMouth` and `IsTouchingShore`. This also allows the surveyor to display the gold bonus and river shores.

TBH, the wiki is very confusing (maybe sometimes contradicting) regarding these bonuses and the original surveyor seems to report many errors. Although this implementation might be more correct, most of the informations of the surveyor per se are actually not useful as it's not clear how the bonuses apply (e.g. gold bonus only if city is built there etc.). However, I would leave it as it is since people will probably expect to behave similar to the original (or patched) surveyor...

Surveyor now displays "River mouths" and "Gold Bonus":
<img width="820" alt="Bildschirmfoto 2025-01-25 um 11 12 36" src="https://github.com/user-attachments/assets/f6a11603-aa91-4ed8-ac83-3cbb83632799" />
