### PR TITLE
map: refactor nodes and encounters

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3451,6 +3451,7 @@ func (game *Game) confirmLairEncounter(yield coroutine.YieldFunc, encounter *map
             lairIndex = 9
         case maplib.EncounterTypeAncientTemple:
             lairIndex = 15
+            article = "an"
         case maplib.EncounterTypeFallenTemple:
             lairIndex = 19
         case maplib.EncounterTypeRuins:

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2938,7 +2938,7 @@ func (game *Game) doMoveSelectedUnit(yield coroutine.YieldFunc, player *playerli
 
         if canMove {
 
-            encounter := mapUse.GetEncounter(step.X, step.Y)
+            encounter := mapUse.GetEncounter(mapUse.WrapX(step.X), step.Y)
             if encounter != nil {
                 if game.confirmLairEncounter(yield, encounter) {
                     stack.Move(step.X - stack.X(), step.Y - stack.Y(), terrainCost, game.GetNormalizeCoordinateFunc())
@@ -2956,7 +2956,7 @@ func (game *Game) doMoveSelectedUnit(yield coroutine.YieldFunc, player *playerli
             }
 
             stepsTaken = i + 1
-            mergeStack = player.FindStack(step.X, step.Y, stack.Plane())
+            mergeStack = player.FindStack(mapUse.WrapX(step.X), step.Y, stack.Plane())
 
             stack.Move(step.X - stack.X(), step.Y - stack.Y(), terrainCost, game.GetNormalizeCoordinateFunc())
             game.showMovement(yield, oldX, oldY, stack)

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -185,7 +185,7 @@ const (
 
 func (encounterType EncounterType) Name() string {
     switch encounterType {
-        case EncounterTypeLair: return "Monstar Lair"
+        case EncounterTypeLair: return "Monster Lair"
         case EncounterTypeCave: return "Mysterious Cave"
         case EncounterTypePlaneTower: return "Tower"
         case EncounterTypePlaneTowerOpen: return "Tower"

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -178,13 +178,48 @@ const (
     EncounterTypeRuins
     EncounterTypeAbandonedKeep
     EncounterTypeDungeon
-
-    // somewhat of a hack, but its useful to have a single type that can represent all the
-    // different types of nodes and encounters
     EncounterTypeChaosNode
     EncounterTypeNatureNode
     EncounterTypeSorceryNode
 )
+
+func (encounterType EncounterType) Name() string {
+    switch encounterType {
+        case EncounterTypeLair: return "Monstar Lair"
+        case EncounterTypeCave: return "Mysterious Cave"
+        case EncounterTypePlaneTower: return "Tower"
+        case EncounterTypePlaneTowerOpen: return "Tower"
+        case EncounterTypeAncientTemple: return "Ancient Temple"
+        case EncounterTypeFallenTemple: return "Fallen Temple"
+        case EncounterTypeRuins: return "Ruins"
+        case EncounterTypeAbandonedKeep: return "Abandoned Keep"
+        case EncounterTypeDungeon: return "Dungeon"
+        case EncounterTypeChaosNode: return "Chaos Node"
+        case EncounterTypeNatureNode: return "Nature Node"
+        case EncounterTypeSorceryNode: return "Sorcery Node"
+    }
+
+    return ""
+}
+
+func (encounterType EncounterType) ShortName() string {
+    switch encounterType {
+        case EncounterTypeLair: return "Lair"
+        case EncounterTypeCave: return "Cave"
+        case EncounterTypePlaneTower: return "Tower"
+        case EncounterTypePlaneTowerOpen: return "Tower"
+        case EncounterTypeAncientTemple: return "Temple"
+        case EncounterTypeFallenTemple: return "Temple"
+        case EncounterTypeRuins: return "Ruins"
+        case EncounterTypeAbandonedKeep: return "Keep"
+        case EncounterTypeDungeon: return "Dungeon"
+        case EncounterTypeChaosNode: return "Node"
+        case EncounterTypeNatureNode: return "Node"
+        case EncounterTypeSorceryNode: return "Node"
+    }
+
+    return ""
+}
 
 func randomEncounterType() EncounterType {
     all := []EncounterType{
@@ -201,12 +236,11 @@ func randomEncounterType() EncounterType {
     return all[rand.N(len(all))]
 }
 
-// lair, plane tower, etc
+// lair, plane tower, etc and also the initial enemies on nodes
 type ExtraEncounter struct {
     Type EncounterType
     Units []units.Unit
     Budget int // used for treasure
-    Empty bool
 }
 
 // choices is a map from a name to the chance of choosing that name, where all the int values should add up to 100
@@ -328,10 +362,7 @@ func (extra *ExtraEncounter) DrawLayer2(screen *ebiten.Image, imageCache *util.I
 
 type ExtraMagicNode struct {
     Kind MagicNode
-    Empty bool
-    Budget int
-    Guardians []units.Unit
-    Secondary []units.Unit
+
     // list of points that are affected by the node
     Zone []image.Point
 
@@ -340,7 +371,6 @@ type ExtraMagicNode struct {
     // true if melded by a guardian spirit, otherwise false if melded by a magic spirit
     GuardianSpiritMeld bool
 
-    // also contains treasure
     Warped bool
 }
 
@@ -350,7 +380,7 @@ func (node *ExtraMagicNode) DrawLayer1(screen *ebiten.Image, imageCache *util.Im
 func (node *ExtraMagicNode) DrawLayer2(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64, tileWidth int, tileHeight int){
     // if the node is melded then show the zone of influence with the sparkly images
 
-    if node.Empty && node.MeldingWizard != nil {
+    if node.MeldingWizard != nil {
         index := 63
         switch node.MeldingWizard.GetBanner() {
             case data.BannerBlue: index = 63
@@ -676,11 +706,11 @@ func MakeMap(terrainData *terrain.TerrainData, landSize int, magicSetting data.M
             tile := terrainData.Tiles[map_.Terrain[x][y]].Tile
             switch tile.TerrainType() {
                 case terrain.SorceryNode:
-                    extraMap[point][ExtraKindMagicNode] = MakeMagicNode(MagicNodeSorcery, magicSetting, difficulty, plane)
+                    extraMap[point][ExtraKindMagicNode], extraMap[point][ExtraKindEncounter] = MakeMagicNode(MagicNodeSorcery, magicSetting, difficulty, plane)
                 case terrain.NatureNode:
-                    extraMap[point][ExtraKindMagicNode] = MakeMagicNode(MagicNodeNature, magicSetting, difficulty, plane)
+                    extraMap[point][ExtraKindMagicNode], extraMap[point][ExtraKindEncounter] = MakeMagicNode(MagicNodeNature, magicSetting, difficulty, plane)
                 case terrain.ChaosNode:
-                    extraMap[point][ExtraKindMagicNode] = MakeMagicNode(MagicNodeChaos, magicSetting, difficulty, plane)
+                    extraMap[point][ExtraKindMagicNode], extraMap[point][ExtraKindEncounter] = MakeMagicNode(MagicNodeChaos, magicSetting, difficulty, plane)
             }
         }
     }
@@ -982,8 +1012,20 @@ func (mapObject *Map) RemoveRoad(x int, y int) {
     delete(mapObject.ExtraMap[image.Pt(x, y)], ExtraKindRoad)
 }
 
-func (mapObject *Map) GetLair(x int, y int) *ExtraEncounter {
+func (mapObject *Map) GetEncounter(x int, y int) *ExtraEncounter {
     return getExtra[*ExtraEncounter](mapObject.ExtraMap[image.Pt(x, y)], ExtraKindEncounter)
+}
+
+func (mapObject *Map) RemoveEncounter(x int, y int) {
+    _, exists := mapObject.ExtraMap[image.Pt(x, y)]
+    if !exists {
+        return
+    }
+
+    _, exists = mapObject.ExtraMap[image.Pt(x, y)][ExtraKindEncounter]
+    if exists {
+        delete(mapObject.ExtraMap[image.Pt(x, y)], ExtraKindEncounter)
+    }
 }
 
 func (mapObject *Map) GetMagicNode(x int, y int) *ExtraMagicNode {
@@ -1023,7 +1065,7 @@ func (mapObject *Map) GetBonusTile(x int, y int) data.BonusType {
 }
 
 func (mapObject *Map) CreateEncounter(x int, y int, encounterType EncounterType, difficulty data.DifficultySetting, weakStrength bool, plane data.Plane) bool {
-    if mapObject.GetLair(x, y) != nil {
+    if mapObject.GetEncounter(x, y) != nil {
         return false
     }
 
@@ -1046,7 +1088,7 @@ func (mapObject *Map) CreateNode(x int, y int, node MagicNode, plane data.Plane,
 
     mapObject.Map.Terrain[x][y] = tileType
 
-    out := MakeMagicNode(node, magicSetting, difficulty, plane)
+    out, _ := MakeMagicNode(node, magicSetting, difficulty, plane)
 
     mapObject.ExtraMap[image.Pt(x, y)][ExtraKindMagicNode] = out
 

--- a/game/magic/maplib/node.go
+++ b/game/magic/maplib/node.go
@@ -380,32 +380,40 @@ func computeChaosNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
     return chooseGuardianAndSecondary(enemyCosts, makeUnit, budget)
 }
 
-func MakeMagicNode(kind MagicNode, magicSetting data.MagicSetting, difficulty data.DifficultySetting, plane data.Plane) *ExtraMagicNode {
+func MakeMagicNode(kind MagicNode, magicSetting data.MagicSetting, difficulty data.DifficultySetting, plane data.Plane) (*ExtraMagicNode, *ExtraEncounter) {
     zone := makeZone(plane)
     var guardians []units.Unit
     var secondary []units.Unit
 
     budget := computeEncounterBudget(magicSetting, difficulty, len(zone))
 
+    var encouterType EncounterType
+
     switch kind {
         case MagicNodeNature:
             guardians, secondary = computeNatureNodeEnemies(budget)
+            encouterType = EncounterTypeNatureNode
             // log.Printf("Created nature node guardians: %v secondary: %v", guardians, secondary)
         case MagicNodeSorcery:
             guardians, secondary = computeSorceryNodeEnemies(budget)
+            encouterType = EncounterTypeSorceryNode
             // log.Printf("Created sorcery node guardians: %v secondary: %v", guardians, secondary)
         case MagicNodeChaos:
             guardians, secondary = computeChaosNodeEnemies(budget)
+            encouterType = EncounterTypeChaosNode
             // log.Printf("Created chaos node guardians: %v secondary: %v", guardians, secondary)
     }
 
-
-    return &ExtraMagicNode{
+    magicNode := ExtraMagicNode{
         Kind: kind,
-        Empty: false,
-        Budget: budget,
-        Guardians: guardians,
-        Secondary: secondary,
         Zone: zone,
     }
+
+    encounter := ExtraEncounter{
+        Type: encouterType,
+        Units: append(guardians, secondary...),
+        Budget: budget,
+    }
+
+    return &magicNode, &encounter
 }

--- a/game/magic/maplib/node.go
+++ b/game/magic/maplib/node.go
@@ -389,19 +389,26 @@ func MakeMagicNode(kind MagicNode, magicSetting data.MagicSetting, difficulty da
 
     var encouterType EncounterType
 
-    switch kind {
-        case MagicNodeNature:
-            guardians, secondary = computeNatureNodeEnemies(budget)
-            encouterType = EncounterTypeNatureNode
-            // log.Printf("Created nature node guardians: %v secondary: %v", guardians, secondary)
-        case MagicNodeSorcery:
-            guardians, secondary = computeSorceryNodeEnemies(budget)
-            encouterType = EncounterTypeSorceryNode
-            // log.Printf("Created sorcery node guardians: %v secondary: %v", guardians, secondary)
-        case MagicNodeChaos:
-            guardians, secondary = computeChaosNodeEnemies(budget)
-            encouterType = EncounterTypeChaosNode
-            // log.Printf("Created chaos node guardians: %v secondary: %v", guardians, secondary)
+    for len(guardians) == 0 {
+        switch kind {
+            case MagicNodeNature:
+                guardians, secondary = computeNatureNodeEnemies(budget)
+                encouterType = EncounterTypeNatureNode
+                // log.Printf("Created nature node guardians: %v secondary: %v", guardians, secondary)
+            case MagicNodeSorcery:
+                guardians, secondary = computeSorceryNodeEnemies(budget)
+                encouterType = EncounterTypeSorceryNode
+                // log.Printf("Created sorcery node guardians: %v secondary: %v", guardians, secondary)
+            case MagicNodeChaos:
+                guardians, secondary = computeChaosNodeEnemies(budget)
+                encouterType = EncounterTypeChaosNode
+                // log.Printf("Created chaos node guardians: %v secondary: %v", guardians, secondary)
+        }
+
+        // failed, so increase the budget
+        if len(guardians) == 0 {
+            budget += 50
+        }
     }
 
     magicNode := ExtraMagicNode{

--- a/game/magic/ui/dialogs.go
+++ b/game/magic/ui/dialogs.go
@@ -453,7 +453,7 @@ func MakeLairConfirmDialogWithLayer(ui *UI, cache *lbx.LbxCache, imageCache *uti
 
     confirmFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowFade)
 
-    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5
+    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5 * data.ScreenScale
 
     wrapped := confirmFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
 
@@ -607,7 +607,7 @@ func MakeLairShowDialogWithLayer(ui *UI, cache *lbx.LbxCache, imageCache *util.I
 
     confirmFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowFade)
 
-    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5
+    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5 * data.ScreenScale
 
     wrapped := confirmFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
 

--- a/game/magic/ui/dialogs.go
+++ b/game/magic/ui/dialogs.go
@@ -562,6 +562,90 @@ func MakeLairConfirmDialogWithLayer(ui *UI, cache *lbx.LbxCache, imageCache *uti
     return elements
 }
 
+func MakeLairShowDialogWithLayer(ui *UI, cache *lbx.LbxCache, imageCache *util.ImageCache, lairPicture *util.Animation, layer UILayer, message string, dismiss func()) []*UIElement {
+    confirmX := 67 * data.ScreenScale
+    confirmY := 40 * data.ScreenScale
+
+    confirmMargin := 55 * data.ScreenScale
+    confirmTopMargin := 10 * data.ScreenScale
+
+    const fadeSpeed = 7
+
+    getAlpha := ui.MakeFadeIn(fadeSpeed)
+
+    confirmTop, err := imageCache.GetImage("backgrnd.lbx", 25, 0)
+    if err != nil {
+        return nil
+    }
+
+    confirmBottom, err := imageCache.GetImage("backgrnd.lbx", 27, 0)
+    if err != nil {
+        return nil
+    }
+
+    // FIXME: this should be a fade from bright yellow to dark yellow/orange
+    yellowFade := color.Palette{
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        color.RGBA{R: 0, G: 0, B: 0x00, A: 0},
+        color.RGBA{R: 0xb2, G: 0x8c, B: 0x05, A: 0xff},
+        color.RGBA{R: 0xc9, G: 0xa1, B: 0x26, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xd3, B: 0x5b, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xe8, B: 0x6f, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff},
+        color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff},
+    }
+
+    fontLbx, err := cache.GetLbxFile("fonts.lbx")
+    if err != nil {
+        return nil
+    }
+
+    fonts, err := font.ReadFonts(fontLbx, 0)
+    if err != nil {
+        return nil
+    }
+
+    confirmFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowFade)
+
+    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5
+
+    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
+
+    bottom := float64(confirmY + confirmTopMargin) + max(wrapped.TotalHeight, float64(lairPicture.Frame().Bounds().Dy()))
+
+    topDraw := confirmTop.SubImage(image.Rect(0, 0, confirmTop.Bounds().Dx(), int(bottom) - confirmY)).(*ebiten.Image)
+
+    var elements []*UIElement
+
+    elements = append(elements, &UIElement{
+        Rect: image.Rect(0, 0, data.ScreenWidth, data.ScreenHeight),
+        Layer: layer,
+        LeftClick: func(this *UIElement){
+            getAlpha = ui.MakeFadeOut(fadeSpeed)
+            ui.AddDelay(fadeSpeed, func(){
+                dismiss()
+            })
+        },
+        Draw: func(this *UIElement, window *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(float64(confirmX), float64(confirmY))
+            options.ColorScale.ScaleAlpha(getAlpha())
+            window.DrawImage(topDraw, &options)
+
+            options.GeoM.Translate(float64(7 * data.ScreenScale), float64(7 * data.ScreenScale))
+            window.DrawImage(lairPicture.Frame(), &options)
+
+            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, true)
+
+            options.GeoM.Reset()
+            options.GeoM.Translate(float64(confirmX), float64(bottom))
+            window.DrawImage(confirmBottom, &options)
+        },
+    })
+
+    return elements
+}
+
 type Selection struct {
     Name string
     Action func()

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -860,7 +860,7 @@ func createScenario11(cache *lbx.LbxCache) *gamelib.Game {
 
     nodes := findNodes(game.CurrentMap())
     node := nodes[terrain.SorceryNode][0]
-    node.Node.Empty = true
+    game.CurrentMap().RemoveEncounter(node.X, node.Y)
 
     player.LiftFog(node.X, node.Y, 3, data.PlaneArcanus)
 
@@ -2431,7 +2431,7 @@ func createScenario28(cache *lbx.LbxCache) *gamelib.Game {
 
     nodes := findNodes(game.CurrentMap())
     node := nodes[terrain.SorceryNode][0]
-    node.Node.Empty = true
+    game.CurrentMap().RemoveEncounter(node.X, node.Y)
 
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.MagicSpirit, node.X + 1, node.Y + 1, game.Plane, wizard.Banner, nil))
     // has pathfinding
@@ -2502,7 +2502,7 @@ func createScenario29(cache *lbx.LbxCache) *gamelib.Game {
 
     nodes := findNodes(game.CurrentMap())
     node := nodes[terrain.SorceryNode][0]
-    node.Node.Empty = true
+    game.CurrentMap().RemoveEncounter(node.X, node.Y)
 
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.OrcSwordsmen, node.X + 1, node.Y + 1, game.Plane, wizard.Banner, nil))
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.OrcEngineers, node.X + 1, node.Y + 1, game.Plane, wizard.Banner, nil))
@@ -2800,7 +2800,7 @@ func createScenario32(cache *lbx.LbxCache) *gamelib.Game {
         log.Printf("Unable to create encounter")
     }
 
-    encounter := game.CurrentMap().GetLair(x, y)
+    encounter := game.CurrentMap().GetEncounter(x, y)
     encounter.Units = []units.Unit{units.SkyDrake, units.SkyDrake}
 
     game.Camera.Center(stack.X(), stack.Y())
@@ -2941,7 +2941,7 @@ func createScenario34(cache *lbx.LbxCache) *gamelib.Game {
 
     nodes := findNodes(game.CurrentMap())
     node := nodes[terrain.NatureNode][0]
-    node.Node.Empty = true
+    game.CurrentMap().RemoveEncounter(node.X, node.Y)
     node.Node.MeldingWizard = player2
     player1.LiftFog(node.X, node.Y, 3, data.PlaneArcanus)
 
@@ -2951,13 +2951,13 @@ func createScenario34(cache *lbx.LbxCache) *gamelib.Game {
     player1.LiftFog(stack.X(), stack.Y(), 2, data.PlaneArcanus)
 
     node = nodes[terrain.SorceryNode][0]
-    node.Node.Empty = true
+    game.CurrentMap().RemoveEncounter(node.X, node.Y)
     node.Node.MeldingWizard = player2
     node.Node.Warped = true
     player1.LiftFog(node.X, node.Y, 3, data.PlaneArcanus)
 
     node = nodes[terrain.ChaosNode][0]
-    node.Node.Empty = true
+    game.CurrentMap().RemoveEncounter(node.X, node.Y)
     node.Node.MeldingWizard = player2
     node.Node.Warped = true
     player1.LiftFog(node.X, node.Y, 3, data.PlaneArcanus)


### PR DESCRIPTION
Use `ExtraEncounter` for all kinds of enemy encounters including the (initial) enemies on nodes.

Once an encounter is won, it will be removed from the map. Nodes initially have both an `ExtraEncounter` and an `ExtraMagicNode`, but the first player to win removes the encounter.

This will remove some code code duplication and makes some parts easier (for example path finding will never cross an encounter; removes `IsEmpty` as it isn't needed anymore).

It will also allow to add a set of players already explored an encounter centrally to `ExtraEncounter`.