### PR TITLE
Exploration

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2949,6 +2949,8 @@ func (game *Game) doMoveSelectedUnit(yield coroutine.YieldFunc, player *playerli
                     game.doEncounter(yield, player, stack, encounter, mapUse, stack.X(), stack.Y())
 
                     game.RefreshUI()
+                } else {
+                    encounter.ExploredBy.Insert(player)
                 }
 
                 stopMoving = true
@@ -3539,6 +3541,7 @@ func (game *Game) doEncounter(yield coroutine.YieldFunc, player *playerlib.Playe
 
         game.createTreasure(encounter.Type, encounter.Budget, player)
     } else {
+        encounter.ExploredBy.Insert(player)
         // FIXME: remove killed defenders
     }
 

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -158,8 +158,10 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                 }
             })
 
-            game.WhiteFont.PrintRight(screen, float64(276 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v GP", game.Players[0].Gold))
-            game.WhiteFont.PrintRight(screen, float64(313 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v MP", game.Players[0].Mana))
+            player := game.Players[0]
+
+            game.WhiteFont.PrintRight(screen, float64(276 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v GP", player.Gold))
+            game.WhiteFont.PrintRight(screen, float64(313 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v MP", player.Mana))
 
             surveyorFont.PrintCenter(screen, float64(280 * data.ScreenScale), float64(81 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Surveyor")
 
@@ -257,8 +259,22 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                         }
                     }
 
-                    // FIXME: show lair/node/tower
-                    // FIXME: show "Unexplored" or toughest opponent for lairs/nodes
+                    // Lairs
+                    encounter := mapObject.GetEncounter(selectedPoint.X, selectedPoint.Y)
+                    if encounter != nil && encounter.Type != maplib.EncounterTypeChaosNode && encounter.Type != maplib.EncounterTypeNatureNode && encounter.Type != maplib.EncounterTypeSorceryNode {
+                        yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, encounter.Type.Name())
+                        y += float64(yellowFont.Height() * data.ScreenScale)
+                    }
+
+                    // Enemies
+                    if encounter != nil {
+                        text := "Unexplored"
+                        if encounter.ExploredBy.Contains(player) {
+                            text = encounter.Units[0].Name
+                        }
+                        whiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, text)
+                        y += float64(whiteFont.Height() * data.ScreenScale)
+                    }
 
                     if cityMap[selectedPoint] != nil {
                         city := cityMap[selectedPoint]

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -15,6 +15,7 @@ import (
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
+    "github.com/kazzmir/master-of-magic/game/magic/maplib"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
@@ -166,10 +167,23 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                 if overworld.Fog[selectedPoint.X][selectedPoint.Y] {
                     mapObject := game.CurrentMap()
                     tile := mapObject.GetTile(selectedPoint.X, selectedPoint.Y)
+                    node := mapObject.GetMagicNode(selectedPoint.X, selectedPoint.Y)
+
                     y := float64(93 * data.ScreenScale)
-                    yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, tile.Name(mapObject))
+
+                    // Terrain
+                    name := tile.Name(mapObject)
+                    if node != nil {
+                        switch node.Kind {
+                            case maplib.MagicNodeNature: name = "Forest"
+                            case maplib.MagicNodeSorcery: name = "Grasslands"
+                            case maplib.MagicNodeChaos: name = "Mountain"
+                        }
+                    }
+                    yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, name)
                     y += float64(yellowFont.Height() * data.ScreenScale)
 
+                    // Terrain bonuses
                     if tile.Corrupted() {
                         whiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Corruption")
                         y += float64(whiteFont.Height() * data.ScreenScale)
@@ -195,6 +209,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
                     y += float64(whiteFont.Height() * data.ScreenScale)
 
+                    // Bonuses
                     bonus := tile.GetBonus()
                     if bonus != data.BonusNone {
                         yellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, bonus.String())
@@ -225,8 +240,11 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                         }
                     }
 
-                    node := mapObject.GetMagicNode(selectedPoint.X, selectedPoint.Y)
+                    // Nodes
                     if node != nil {
+                        yellowFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, node.Kind.Name())
+                        y += float64(yellowFont.Height() * data.ScreenScale)
+
                         if node.Warped {
                             whiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Warped")
                             y += float64(whiteFont.Height() * data.ScreenScale)

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -281,7 +281,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                         yellowFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, city.String())
                     }
 
-                    y = float64(160 * data.ScreenScale) - cityInfoText.TotalHeight
+                    y = float64(170 * data.ScreenScale) - cityInfoText.TotalHeight
 
                     if resources.Enabled {
                         y = float64(170 * data.ScreenScale) - float64(whiteFont.Height() * data.ScreenScale) * 3 - cityInfoText.TotalHeight

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -8,6 +8,7 @@ import (
     "image/color"
 
     "github.com/kazzmir/master-of-magic/lib/fraction"
+    "github.com/kazzmir/master-of-magic/lib/set"
     "github.com/kazzmir/master-of-magic/game/magic/terrain"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
@@ -250,6 +251,7 @@ type ExtraEncounter struct {
     Type EncounterType
     Units []units.Unit
     Budget int // used for treasure
+    ExploredBy *set.Set[Wizard]
 }
 
 // choices is a map from a name to the chance of choosing that name, where all the int values should add up to 100
@@ -338,6 +340,7 @@ func makeEncounter(encounterType EncounterType, difficulty data.DifficultySettin
         Type: encounterType,
         Budget: budget,
         Units: append(guardians, secondary...),
+        ExploredBy: set.MakeSet[Wizard](),
     }
 }
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -39,6 +39,15 @@ const (
     MagicNodeChaos
 )
 
+func (magicNode MagicNode) Name() string {
+    switch magicNode {
+        case MagicNodeNature: return "Nature Node"
+        case MagicNodeSorcery: return "Sorcery Node"
+        case MagicNodeChaos: return "Chaos Node"
+    }
+    return ""
+}
+
 type ExtraTile interface {
     DrawLayer1(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64, tileWidth int, tileHeight int)
     DrawLayer2(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64, tileWidth int, tileHeight int)

--- a/game/magic/maplib/node.go
+++ b/game/magic/maplib/node.go
@@ -7,6 +7,7 @@ import (
 
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/lib/set"
 )
 
 /* choose X points surrounding the node. 0,0 is the node itself. for arcanus, choose 5-10 points from a 4x4 square.
@@ -420,6 +421,7 @@ func MakeMagicNode(kind MagicNode, magicSetting data.MagicSetting, difficulty da
         Type: encouterType,
         Units: append(guardians, secondary...),
         Budget: budget,
+        ExploredBy: set.MakeSet[Wizard](),
     }
 
     return &magicNode, &encounter


### PR DESCRIPTION
Adds exploration: Once an encounter has been started (and not entered or fled), the (first) enemy type is shown in the surveyor.

Also makes the surveyor output more like the original: show nodes as a terrain + special, move city margin message further down.

<img width="751" alt="Bildschirmfoto 2025-01-29 um 16 45 07" src="https://github.com/user-attachments/assets/0a5e14b5-cb4c-4c41-8113-0e2cd052c40c" />

<img width="751" alt="Bildschirmfoto 2025-01-29 um 16 45 23" src="https://github.com/user-attachments/assets/0b2460c6-1178-41fa-8230-57b9afa929f4" />
