### PR TITLE
map: optimize land generation

### DIFF
--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -430,9 +430,10 @@ func (map_ *Map) placeRivers(area int, data *TerrainData, plane data.Plane) {
         // work with a copy where the path is rendered to allow resolving and discarding it
         // mapCopy := map_.Copy()
         for x := range mapCopy.Columns() {
-            for y := range mapCopy.Rows() {
-                mapCopy.Terrain[x][y] = map_.Terrain[x][y]
-            }
+            // for _ := range mapCopy.Rows() {
+                copy(mapCopy.Terrain[x], map_.Terrain[x])
+                // mapCopy.Terrain[x][y] = map_.Terrain[x][y]
+            // }
         }
 
         for _, point := range path {

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -421,12 +421,20 @@ func (map_ *Map) placeRivers(area int, data *TerrainData, plane data.Plane) {
         return true
     }
 
+    mapCopy := map_.Copy()
+
     resolves := func(path []image.Point) bool {
         // check if the rendered path would resolve
         checked := make(map[image.Point]bool)
 
         // work with a copy where the path is rendered to allow resolving and discarding it
-        mapCopy := map_.Copy()
+        // mapCopy := map_.Copy()
+        for x := range mapCopy.Columns() {
+            for y := range mapCopy.Rows() {
+                mapCopy.Terrain[x][y] = map_.Terrain[x][y]
+            }
+        }
+
         for _, point := range path {
             mapCopy.Terrain[point.X][point.Y] = TileRiver0001.Index(plane)
         }
@@ -656,7 +664,9 @@ func GenerateLandCellularAutomata(columns int, rows int, data *TerrainData, plan
     map_.removeSmallIslands(100, plane)
     map_.placeRandomTerrainTiles(plane)
     map_.placeRivers(100, data, plane)
+    /*
     map_.ResolveTiles(data, plane)
+    */
     end := time.Now()
     log.Printf("Generated %vx%v %v map in %v", columns, rows, plane, end.Sub(start))
     return map_

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -664,9 +664,7 @@ func GenerateLandCellularAutomata(columns int, rows int, data *TerrainData, plan
     map_.removeSmallIslands(100, plane)
     map_.placeRandomTerrainTiles(plane)
     map_.placeRivers(100, data, plane)
-    /*
     map_.ResolveTiles(data, plane)
-    */
     end := time.Now()
     log.Printf("Generated %vx%v %v map in %v", columns, rows, plane, end.Sub(start))
     return map_

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -545,7 +545,7 @@ func (map_ *Map) removeSmallIslands(area int, plane data.Plane){
 
 func (map_ *Map) getTerrainAt(x int, y int, data *TerrainData) TerrainType {
     if y < 0 || y > map_.Rows() - 1 {
-        return  Ocean
+        return Ocean
     }
 
     x = map_.WrapX(x)

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -421,6 +421,7 @@ func (map_ *Map) placeRivers(area int, data *TerrainData, plane data.Plane) {
         return true
     }
 
+    // keep one in-memory copy of the original map
     mapCopy := map_.Copy()
 
     resolves := func(path []image.Point) bool {
@@ -428,12 +429,9 @@ func (map_ *Map) placeRivers(area int, data *TerrainData, plane data.Plane) {
         checked := make(map[image.Point]bool)
 
         // work with a copy where the path is rendered to allow resolving and discarding it
-        // mapCopy := map_.Copy()
+        // reset the copy here back to the original map
         for x := range mapCopy.Columns() {
-            // for _ := range mapCopy.Rows() {
-                copy(mapCopy.Terrain[x], map_.Terrain[x])
-                // mapCopy.Terrain[x][y] = map_.Terrain[x][y]
-            // }
+            copy(mapCopy.Terrain[x], map_.Terrain[x])
         }
 
         for _, point := range path {

--- a/game/magic/terrain/map_test.go
+++ b/game/magic/terrain/map_test.go
@@ -9,19 +9,21 @@ import (
 func createTerrainData() *TerrainData {
 
     var tiles []TerrainTile
-    for _, tile := range allTiles {
+    for i, tile := range allTiles {
         tiles = append(tiles, TerrainTile{
             ImageIndex: 0,
-            TileIndex: 0,
+            TileIndex: i,
             Tile: tile,
             Images: []image.Image{},
         })
     }
 
-    return &TerrainData{
+    out := &TerrainData{
         Images: []image.Image{},
         Tiles: tiles,
     }
+    out.optimize()
+    return out
 }
 
 

--- a/game/magic/terrain/map_test.go
+++ b/game/magic/terrain/map_test.go
@@ -18,12 +18,7 @@ func createTerrainData() *TerrainData {
         })
     }
 
-    out := &TerrainData{
-        Images: []image.Image{},
-        Tiles: tiles,
-    }
-    out.optimize()
-    return out
+    return MakeTerrainData(nil, tiles)
 }
 
 

--- a/game/magic/terrain/terrain.go
+++ b/game/magic/terrain/terrain.go
@@ -4,6 +4,7 @@ import (
     "bytes"
     "image"
     "fmt"
+    "slices"
 
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/lib/lbx"
@@ -165,9 +166,9 @@ type DirectedCompatibility struct {
 
 func (compatibility DirectedCompatibility) String() string {
     if compatibility.Type == AnyOf {
-        return fmt.Sprintf("(%s, %s)", compatibility.Direction, compatibility.Terrains.Values())
+        return fmt.Sprintf("(%s, %s)", compatibility.Direction, slices.Sorted(slices.Values(compatibility.Terrains.Values())))
     } else {
-        return fmt.Sprintf("!(%s, %s)", compatibility.Direction, compatibility.Terrains.Values())
+        return fmt.Sprintf("!(%s, %s)", compatibility.Direction, slices.Sorted(slices.Values(compatibility.Terrains.Values())))
     }
 }
 
@@ -178,9 +179,9 @@ type Compatibility struct {
 
 func (compatibility Compatibility) String() string {
     if compatibility.Type == AnyOf {
-        return fmt.Sprintf("%s", compatibility.Terrains.Values())
+        return fmt.Sprintf("%s", slices.Sorted(slices.Values(compatibility.Terrains.Values())))
     } else {
-        return fmt.Sprintf("!%s", compatibility.Terrains.Values())
+        return fmt.Sprintf("!%s", slices.Sorted(slices.Values(compatibility.Terrains.Values())))
     }
 }
 

--- a/game/magic/terrain/terrain.go
+++ b/game/magic/terrain/terrain.go
@@ -1387,12 +1387,29 @@ func (data *TerrainData) FindMatchingAllTiles(match map[Direction]TerrainType, p
     return out
 }
 
-func (data *TerrainData) FindMatchingTile(match map[Direction]TerrainType, plane data.Plane) int {
+func (terrain *TerrainData) FindMatchingTile(match map[Direction]TerrainType, plane data.Plane) int {
+    switch plane {
+        case data.PlaneMyrror:
+            for i, tile := range terrain.Tiles[MyrrorStart:] {
+                if tile.Tile.matches(match) {
+                    return i
+                }
+            }
+        case data.PlaneArcanus:
+            for i, tile := range terrain.Tiles[:MyrrorStart] {
+                if tile.Tile.matches(match) {
+                    return i
+                }
+            }
+    }
+
+    /*
     for i, tile := range data.Tiles {
         if tile.IsPlane(plane) && tile.Tile.matches(match) {
             return i
         }
     }
+    */
 
     return -1
 }

--- a/game/magic/terrain/terrain.go
+++ b/game/magic/terrain/terrain.go
@@ -1375,6 +1375,17 @@ type TerrainData struct {
     OnlyTiles map[TerrainType][]TerrainTile
 }
 
+func MakeTerrainData(images []image.Image, tiles []TerrainTile) *TerrainData {
+    out := &TerrainData{
+        Images: images,
+        Tiles: tiles,
+    }
+
+    out.optimize()
+
+    return out
+}
+
 func (data *TerrainData) optimize() {
     data.OnlyTiles = make(map[TerrainType][]TerrainTile)
 
@@ -1436,14 +1447,6 @@ func (terrain *TerrainData) FindMatchingTile(match map[Direction]TerrainType, pl
             return tile.TileIndex
         }
     }
-
-    /*
-    for i, tile := range data.Tiles {
-        if tile.IsPlane(plane) && tile.Tile.matches(match) {
-            return i
-        }
-    }
-    */
 
     return -1
 }
@@ -1554,12 +1557,5 @@ func ReadTerrainData(lbxFile *lbx.LbxFile) (*TerrainData, error) {
         tileIndex += 1
     }
 
-    out := &TerrainData{
-        Images: images,
-        Tiles: tiles,
-    }
-
-    out.optimize()
-
-    return out, nil
+    return MakeTerrainData(images, tiles), nil
 }

--- a/game/magic/terrain/terrain_test.go
+++ b/game/magic/terrain/terrain_test.go
@@ -2,6 +2,7 @@ package terrain
 
 import (
     "testing"
+    "github.com/kazzmir/master-of-magic/lib/set"
 )
 
 
@@ -28,7 +29,7 @@ func TestTerrainMatches(test *testing.T) {
 
     // AnyOf
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: AnyOf,
     }
     match[North] = Ocean
@@ -37,7 +38,7 @@ func TestTerrainMatches(test *testing.T) {
     }
 
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: AnyOf,
     }
     match[North] = Shore
@@ -46,7 +47,7 @@ func TestTerrainMatches(test *testing.T) {
     }
 
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: AnyOf,
     }
     match[North] = Grass
@@ -56,7 +57,7 @@ func TestTerrainMatches(test *testing.T) {
 
     // NoneOf
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: NoneOf,
     }
     match[North] = Ocean
@@ -65,7 +66,7 @@ func TestTerrainMatches(test *testing.T) {
     }
 
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: NoneOf,
     }
     match[North] = Shore
@@ -74,7 +75,7 @@ func TestTerrainMatches(test *testing.T) {
     }
 
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: NoneOf,
     }
     match[North] = Grass
@@ -84,11 +85,11 @@ func TestTerrainMatches(test *testing.T) {
 
     // two directions
     tile.Compatibilities[North] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: AnyOf,
     }
     tile.Compatibilities[South] = Compatibility{
-        Terrains: []TerrainType{Ocean, Shore},
+        Terrains: set.NewSet([]TerrainType{Ocean, Shore}...),
         Type: NoneOf,
     }
 

--- a/util/mapeditor/main.go
+++ b/util/mapeditor/main.go
@@ -122,7 +122,7 @@ func (editor *Editor) Update() error {
                 editor.clear()
             case ebiten.KeyG:
                 start := time.Now()
-                editor.Map = terrain.GenerateLandCellularAutomata(editor.Map.Rows(), editor.Map.Columns(), editor.Data, editor.Plane)
+                editor.Map = terrain.GenerateLandCellularAutomata(editor.Map.Columns(), editor.Map.Rows(), editor.Data, editor.Plane)
                 end := time.Now()
                 log.Printf("Generate land took %v", end.Sub(start))
             case ebiten.KeyS:


### PR DESCRIPTION
master:
```
map.go:661: Generated 200x150 Arcanus map in 324.832612ms
```
this pr:
```
map.go:670: Generated 200x150 Arcanus map in 124.716458ms
```
I applied the following optimizations, sorted from biggest gain to smallest gain:
1. Store a map from TerrainType to []TerrainTile in the TerrainData object. This means that for FindMatchingTile(), if the match map has a Center direction then it only has to consider tiles of that type, so this can avoid iterating through every single tile.
2. Instead of calling map_.Copy() in placeRivers ::resolves() each time instead a single map copy is made in placeRivers, and resolves() just copies all the values from the original map to the copied map using the builtin copy() function.
3. The DirectedCompatibility and Compatibilty structs have a *set.Set[TerrainType] instead of a []TerrainType, which simplifies tile.matches() so that we can just do a single set.Contains() instead of iterating through the []TerrainType. This actually doesn't seem to gain that much performance, so it might not be worth it.