### PR TITLE
game: add some sources for fame

### DIFF
--- a/game/magic/combat/end-screen.go
+++ b/game/magic/combat/end-screen.go
@@ -32,19 +32,21 @@ type CombatEndScreen struct {
     CombatScreen *CombatScreen
     Result CombatEndScreenResult
     UnitsLost int
+    Fame int
     Cache *lbx.LbxCache
     ImageCache util.ImageCache
     UI *uilib.UI
     State CombatEndScreenState
 }
 
-func MakeCombatEndScreen(cache *lbx.LbxCache, combat *CombatScreen, result CombatEndScreenResult, unitsLost int) *CombatEndScreen {
+func MakeCombatEndScreen(cache *lbx.LbxCache, combat *CombatScreen, result CombatEndScreenResult, unitsLost int, fame int) *CombatEndScreen {
     end := &CombatEndScreen{
         CombatScreen: combat,
         Cache: cache,
         ImageCache: util.MakeImageCache(cache),
         Result: result,
         UnitsLost: unitsLost,
+        Fame: fame,
         State: CombatEndScreenRunning,
     }
 
@@ -94,17 +96,20 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
 
     titleFont := font.MakeOptimizedFontWithPalette(fonts[4], titlePalette)
 
-    // FIXME: implement fame gain
     extraText := ""
     switch {
-        case end.Result == CombatEndScreenResultWin:
-            extraText = "You have gained 1 fame"
-        case end.Result == CombatEndScreenResultLoose:
-            extraText = "You have lost 1 fame"
-        case end.Result == CombatEndScreenResultRetreat && end.UnitsLost == 1 :
-            extraText = "You have lost 1 unit while fleeing"
-        case end.Result == CombatEndScreenResultRetreat && end.UnitsLost > 1 :
-            extraText = fmt.Sprintf("You have lost %v units while fleeing", end.UnitsLost)
+        case end.Result == CombatEndScreenResultWin && end.Fame > 0:
+            extraText = fmt.Sprintf("You gained %v fame", end.Fame)
+        case end.Result == CombatEndScreenResultLoose && end.Fame > 0:
+            extraText = fmt.Sprintf("You lost %v fame", end.Fame)
+        case end.Result == CombatEndScreenResultRetreat && end.UnitsLost == 1 && end.Fame == 0:
+            extraText = "You lost 1 unit while fleeing"
+        case end.Result == CombatEndScreenResultRetreat && end.UnitsLost > 1 && end.Fame == 0:
+            extraText = fmt.Sprintf("You lost %v units while fleeing.", end.UnitsLost)
+        case end.Result == CombatEndScreenResultRetreat && end.UnitsLost == 1 && end.Fame > 0:
+            extraText = fmt.Sprintf("You lost %v fame and 1 unit while fleeing.", end.Fame)
+        case end.Result == CombatEndScreenResultRetreat && end.UnitsLost > 1 && end.Fame > 0:
+            extraText = fmt.Sprintf("You lost %v fame and %v units while fleeing", end.Fame, end.UnitsLost)
     }
 
     black := color.RGBA{R: 0, G: 0, B: 0, A: 0xff}

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3026,6 +3026,8 @@ func (game *Game) doMoveSelectedUnit(yield coroutine.YieldFunc, player *playerli
                     // FIXME: if there was a city here and the attacker won then the attacker
                     // should be able to raze or occupy the city
 
+                    // FIXME: loose fame if razing
+
                     stack.ExhaustMoves()
                     game.RefreshUI()
 
@@ -3327,6 +3329,7 @@ func (game *Game) doAiMoveUnit(yield coroutine.YieldFunc, player *playerlib.Play
                     City: enemy.FindCity(stack.X(), stack.Y(), stack.Plane()),
                 }
                 game.doCombat(yield, player, stack, enemy, enemyStack, zone)
+                // FIXME: loose fame if razing
             }
         }
     } else if move.Invalid != nil {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -452,6 +452,11 @@ func (game *Game) AddPlayer(wizard setup.WizardCustom, human bool) *playerlib.Pl
 
     // log.Printf("Research spells: %v", newPlayer.ResearchPoolSpells)
 
+    // famous wizards get a head start of 10 fame
+    if wizard.AbilityEnabled(setup.AbilityFamous) {
+        newPlayer.Fame += 10
+    }
+
     game.Players = append(game.Players, newPlayer)
     return newPlayer
 }

--- a/game/magic/maplib/node.go
+++ b/game/magic/maplib/node.go
@@ -192,17 +192,17 @@ func computeNatureNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
 
     enemyCosts := map[Enemy]int{
         None: 0,
-        WarBear: 70,
-        Sprite: 100,
-        EarthElemental: 160,
-        Spiders: 200,
-        Cockatrice: 275,
-        Basilisk: 325,
-        StoneGiant: 450,
-        Gorgons: 600,
-        Behemoth: 700,
-        Colossus: 800,
-        GreatWyrm: 1000,
+        WarBear: units.WarBear.CastingCost,
+        Sprite: units.Sprite.CastingCost,
+        EarthElemental: units.EarthElemental.CastingCost,
+        Spiders: units.GiantSpider.CastingCost,
+        Cockatrice: units.Cockatrice.CastingCost,
+        Basilisk: units.Basilisk.CastingCost,
+        StoneGiant: units.StoneGiant.CastingCost,
+        Gorgons: units.Gorgon.CastingCost,
+        Behemoth: units.Behemoth.CastingCost,
+        Colossus: units.Colossus.CastingCost,
+        GreatWyrm: units.GreatWyrm.CastingCost,
     }
 
     return chooseGuardianAndSecondary(enemyCosts, makeUnit, budget)
@@ -237,13 +237,13 @@ func computeSorceryNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
 
     enemyCosts := map[Enemy]int{
         None: 0,
-        PhantomWarriors: 20,
-        Naga: 120,
-        AirElemental: 170,
-        PhantomBeast: 225,
-        StormGiant: 500,
-        Djinn: 650,
-        SkyDrake: 1000,
+        PhantomWarriors: units.PhantomWarrior.CastingCost,
+        Naga: units.Nagas.CastingCost,
+        AirElemental: units.AirElemental.CastingCost,
+        PhantomBeast: units.PhantomBeast.CastingCost,
+        StormGiant: units.StormGiant.CastingCost,
+        Djinn: units.Djinn.CastingCost,
+        SkyDrake: units.SkyDrake.CastingCost,
     }
 
     return chooseGuardianAndSecondary(enemyCosts, makeUnit, budget)
@@ -284,16 +284,16 @@ func computeDeathNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
 
     enemyCosts := map[Enemy]int{
         None: 0,
-        Skeletons: 25,
-        Zombies: 30,
-        Ghouls: 80,
-        Demons: 125,
-        NightStalker: 200,
-        Werewolves: 250,
-        ShadowDemons: 325,
-        Wraiths: 500,
-        DeathKnight: 600,
-        DemonLord: 900,
+        Skeletons: units.Skeleton.CastingCost,
+        Zombies: units.Zombie.CastingCost,
+        Ghouls: units.Ghoul.CastingCost,
+        Demons: units.Demon.CastingCost,
+        NightStalker: units.NightStalker.CastingCost,
+        Werewolves: units.WereWolf.CastingCost,
+        ShadowDemons: units.ShadowDemon.CastingCost,
+        Wraiths: units.Wraith.CastingCost,
+        DeathKnight: units.DeathKnight.CastingCost,
+        DemonLord: units.DemonLord.CastingCost,
     }
 
     return chooseGuardianAndSecondary(enemyCosts, makeUnit, budget)

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -86,6 +86,7 @@ type Player struct {
     Human bool
     Defeated bool
 
+    // Global Fame (without Just Cause and/or heroes)
     Fame int
 
     // used to seed the random number generator for generating the order of how magic books are drawn
@@ -302,6 +303,8 @@ func (player *Player) GetFame() int {
             fame += hero.GetAbilityFame()
         }
     }
+
+    // FIXME: add fame from Jause Cause spell
 
     return fame
 }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -86,7 +86,7 @@ type Player struct {
     Human bool
     Defeated bool
 
-    // Global Fame (without Just Cause and/or heroes)
+    // Fame (without just cause and/or heroes)
     Fame int
 
     // used to seed the random number generator for generating the order of how magic books are drawn
@@ -304,7 +304,7 @@ func (player *Player) GetFame() int {
         }
     }
 
-    // FIXME: add fame from Jause Cause spell
+    // FIXME: add fame from just cause spell
 
     return fame
 }

--- a/game/magic/units/unit.go
+++ b/game/magic/units/unit.go
@@ -169,6 +169,9 @@ type Unit struct {
 
     // For heroes, the spells the unit can cast
     Spells []string
+
+    // For fantastic units
+    CastingCost int
 }
 
 func (unit *Unit) Equals(other Unit) bool {
@@ -1113,6 +1116,7 @@ var MagicSpirit Unit = Unit{
     HitPoints: 10,
     Abilities: []data.Ability{data.MakeAbility(data.AbilityMeld), data.MakeAbility(data.AbilityNonCorporeal)},
     Race: data.RaceFantastic,
+    CastingCost: 30,
 }
 
 var HellHounds Unit = Unit{
@@ -1133,6 +1137,7 @@ var HellHounds Unit = Unit{
     HitPoints: 4,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityFireBreath, 3), data.MakeAbilityValue(data.AbilityToHit, 10)},
     Race: data.RaceFantastic,
+    CastingCost: 40,
 }
 
 var Gargoyle Unit = Unit{
@@ -1154,6 +1159,7 @@ var Gargoyle Unit = Unit{
     HitPoints: 4,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbility(data.AbilityPoisonImmunity), data.MakeAbility(data.AbilityStoningImmunity)},
     Race: data.RaceFantastic,
+    CastingCost: 200,
 }
 
 var FireGiant Unit = Unit{
@@ -1179,6 +1185,7 @@ var FireGiant Unit = Unit{
     Resistance: 7,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbility(data.AbilityMountaineer), data.MakeAbility(data.AbilityWallCrusher), data.MakeAbility(data.AbilityFireImmunity)},
     Race: data.RaceFantastic,
+    CastingCost: 150,
 }
 
 var FireElemental Unit = Unit{
@@ -1198,6 +1205,7 @@ var FireElemental Unit = Unit{
     Resistance: 6,
     HitPoints: 10,
     Abilities: []data.Ability{data.MakeAbility(data.AbilityFireImmunity), data.MakeAbility(data.AbilityPoisonImmunity), data.MakeAbility(data.AbilityStoningImmunity)},
+    CastingCost: 20,
 }
 
 var ChaosSpawn Unit = Unit{
@@ -1225,6 +1233,7 @@ var ChaosSpawn Unit = Unit{
         data.MakeAbilityValue(data.AbilityStoningGaze, 4),
     },
     Race: data.RaceFantastic,
+    CastingCost: 500,
 }
 
 var Chimeras Unit = Unit{
@@ -1246,6 +1255,7 @@ var Chimeras Unit = Unit{
     HitPoints: 8,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityFireBreath, 4), data.MakeAbilityValue(data.AbilityToHit, 10)},
     Race: data.RaceFantastic,
+    CastingCost: 350,
 }
 
 var DoomBat Unit = Unit{
@@ -1267,6 +1277,7 @@ var DoomBat Unit = Unit{
     HitPoints: 20,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbility(data.AbilityImmolation)},
     Race: data.RaceFantastic,
+    CastingCost: 300,
 }
 
 var Efreet Unit = Unit{
@@ -1304,6 +1315,7 @@ var Efreet Unit = Unit{
     HitPoints: 12,
     Abilities: []data.Ability{data.MakeAbility(data.AbilityFireImmunity), data.MakeAbilityValue(data.AbilityToHit, 20), data.MakeAbilityValue(data.AbilityCaster, 20)},
     Race: data.RaceFantastic,
+    CastingCost: 550,
 }
 
 // FIXME: hydra has 9 virtual figures, one for each head
@@ -1325,6 +1337,7 @@ var Hydra Unit = Unit{
     HitPoints: 10,
     Abilities: []data.Ability{data.MakeAbility(data.AbilityRegeneration), data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbilityValue(data.AbilityFireBreath, 5)},
     Race: data.RaceFantastic,
+    CastingCost: 650,
 }
 
 var GreatDrake Unit = Unit{
@@ -1349,6 +1362,7 @@ var GreatDrake Unit = Unit{
     UpkeepMana: 30,
     Defense: 10,
     Resistance: 12,
+    CastingCost: 900,
 }
 
 var Skeleton Unit = Unit{
@@ -1369,13 +1383,14 @@ var Skeleton Unit = Unit{
     Abilities: []data.Ability{
         data.MakeAbilityValue(data.AbilityToHit, 10),
         data.MakeAbility(data.AbilityPoisonImmunity),
-        data.MakeAbility(data.AbilityMissileImmunity), 
+        data.MakeAbility(data.AbilityMissileImmunity),
         data.MakeAbility(data.AbilityIllusionsImmunity),
         data.MakeAbility(data.AbilityColdImmunity),
         data.MakeAbility(data.AbilityDeathImmunity),
     },
     Race: data.RaceFantastic,
     Realm: data.DeathMagic,
+    CastingCost: 25,
 }
 
 var Ghoul Unit = Unit{
@@ -1404,6 +1419,7 @@ var Ghoul Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 80,
 }
 
 var NightStalker Unit = Unit{
@@ -1432,6 +1448,7 @@ var NightStalker Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 250,
 }
 
 var WereWolf Unit = Unit{
@@ -1460,6 +1477,7 @@ var WereWolf Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 180,
 }
 
 var Demon Unit = Unit{
@@ -1488,6 +1506,7 @@ var Demon Unit = Unit{
         data.MakeAbility(data.AbilityWeaponImmunity),
         data.MakeAbility(data.AbilityMissileImmunity),
     },
+    // no CastingCost
 }
 
 var Wraith Unit = Unit{
@@ -1518,6 +1537,7 @@ var Wraith Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 500,
 }
 
 var ShadowDemon Unit = Unit{
@@ -1554,6 +1574,7 @@ var ShadowDemon Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 325,
 }
 
 var DeathKnight Unit = Unit{
@@ -1585,6 +1606,7 @@ var DeathKnight Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 600,
 }
 
 var DemonLord Unit = Unit{
@@ -1621,6 +1643,7 @@ var DemonLord Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    CastingCost: 1000,
 }
 
 var Zombie Unit = Unit{
@@ -1646,6 +1669,7 @@ var Zombie Unit = Unit{
     },
     Realm: data.DeathMagic,
     Race: data.RaceFantastic,
+    // no CastingCost
 }
 
 var Unicorn Unit = Unit{
@@ -1671,6 +1695,7 @@ var Unicorn Unit = Unit{
     },
     Race: data.RaceFantastic,
     Realm: data.LifeMagic,
+    CastingCost: 250,
 }
 
 var GuardianSpirit Unit = Unit{
@@ -1696,6 +1721,7 @@ var GuardianSpirit Unit = Unit{
         data.MakeAbility(data.AbilityNonCorporeal),
     },
     Realm: data.LifeMagic,
+    CastingCost: 80,
 }
 
 var Angel Unit = Unit{
@@ -1722,6 +1748,7 @@ var Angel Unit = Unit{
     },
     Race: data.RaceFantastic,
     Realm: data.LifeMagic,
+    CastingCost: 550,
 }
 
 var ArchAngel Unit = Unit{
@@ -1764,6 +1791,7 @@ var ArchAngel Unit = Unit{
     },
     Race: data.RaceFantastic,
     Realm: data.LifeMagic,
+    CastingCost: 950,
 }
 
 var WarBear Unit = Unit{
@@ -1784,6 +1812,7 @@ var WarBear Unit = Unit{
     MovementSpeed: 2,
     Abilities: []data.Ability{data.MakeAbility(data.AbilityForester)},
     Race: data.RaceFantastic,
+    CastingCost: 70,
 }
 
 var Sprite Unit = Unit{
@@ -1810,6 +1839,7 @@ var Sprite Unit = Unit{
     Flying: true,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbility(data.AbilityForester)},
     Race: data.RaceFantastic,
+    CastingCost: 100,
 }
 
 var Cockatrice Unit = Unit{
@@ -1831,6 +1861,7 @@ var Cockatrice Unit = Unit{
     HitPoints: 3,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbilityValue(data.AbilityStoningTouch, -3)},
     Race: data.RaceFantastic,
+    CastingCost: 275,
 }
 
 var Basilisk Unit = Unit{
@@ -1851,6 +1882,7 @@ var Basilisk Unit = Unit{
     HitPoints: 30,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbilityValue(data.AbilityStoningGaze, -1)},
     Race: data.RaceFantastic,
+    CastingCost: 325,
 }
 
 var GiantSpider Unit = Unit{
@@ -1871,6 +1903,7 @@ var GiantSpider Unit = Unit{
     HitPoints: 10,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 10), data.MakeAbilityValue(data.AbilityWebSpell, 1), data.MakeAbilityValue(data.AbilityPoisonTouch, 4)},
     Race: data.RaceFantastic,
+    CastingCost: 200,
 }
 
 var StoneGiant Unit = Unit{
@@ -1902,6 +1935,7 @@ var StoneGiant Unit = Unit{
         data.MakeAbility(data.AbilityWallCrusher),
     },
     Race: data.RaceFantastic,
+    CastingCost: 450,
 }
 
 var Colossus Unit = Unit{
@@ -1933,6 +1967,7 @@ var Colossus Unit = Unit{
         data.MakeAbility(data.AbilityFirstStrike),
     },
     Race: data.RaceFantastic,
+    CastingCost: 800,
 }
 
 var Gorgon Unit = Unit{
@@ -1957,6 +1992,7 @@ var Gorgon Unit = Unit{
         data.MakeAbilityValue(data.AbilityStoningGaze, -2),
     },
     Race: data.RaceFantastic,
+    CastingCost: 600,
 }
 
 var EarthElemental Unit = Unit{
@@ -1981,6 +2017,7 @@ var EarthElemental Unit = Unit{
         data.MakeAbility(data.AbilityStoningImmunity),
         data.MakeAbility(data.AbilityWallCrusher),
     },
+    CastingCost: 60,
 }
 
 var Behemoth Unit = Unit{
@@ -2001,6 +2038,7 @@ var Behemoth Unit = Unit{
     HitPoints: 45,
     Race: data.RaceFantastic,
     Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityToHit, 20)},
+    CastingCost: 700,
 }
 
 var GreatWyrm Unit = Unit{
@@ -2025,6 +2063,7 @@ var GreatWyrm Unit = Unit{
         data.MakeAbility(data.AbilityMerging),
     },
     Race: data.RaceFantastic,
+    CastingCost: 1000,
 }
 
 var FloatingIsland Unit = Unit{
@@ -2049,6 +2088,7 @@ var FloatingIsland Unit = Unit{
     },
     Race: data.RaceFantastic,
     Realm: data.SorceryMagic,
+    CastingCost: 50,
 }
 
 var PhantomBeast Unit = Unit{
@@ -2075,6 +2115,7 @@ var PhantomBeast Unit = Unit{
         data.MakeAbility(data.AbilityNonCorporeal),
         data.MakeAbility(data.AbilityIllusion),
     },
+    CastingCost: 35,
 }
 
 var PhantomWarrior Unit = Unit{
@@ -2100,6 +2141,7 @@ var PhantomWarrior Unit = Unit{
         data.MakeAbility(data.AbilityIllusion),
     },
     Race: data.RaceFantastic,
+    CastingCost: 10,
 }
 
 var StormGiant Unit = Unit{
@@ -2130,6 +2172,7 @@ var StormGiant Unit = Unit{
         data.MakeAbility(data.AbilityArmorPiercing),
     },
     Race: data.RaceFantastic,
+    CastingCost: 500,
 }
 
 var AirElemental Unit = Unit{
@@ -2156,6 +2199,7 @@ var AirElemental Unit = Unit{
         data.MakeAbility(data.AbilityWeaponImmunity),
         data.MakeAbility(data.AbilityInvisibility),
     },
+    CastingCost: 50,
 }
 
 var Djinn Unit = Unit{
@@ -2198,6 +2242,7 @@ var Djinn Unit = Unit{
         data.MakeAbility(data.AbilityWindWalking),
     },
     Race: data.RaceFantastic,
+    CastingCost: 650,
 }
 
 var SkyDrake Unit = Unit{
@@ -2224,6 +2269,7 @@ var SkyDrake Unit = Unit{
         data.MakeAbility(data.AbilityMagicImmunity),
         data.MakeAbility(data.AbilityIllusionsImmunity),
     },
+    CastingCost: 1000,
 }
 
 var Nagas Unit = Unit{
@@ -2248,6 +2294,7 @@ var Nagas Unit = Unit{
         data.MakeAbilityValue(data.AbilityPoisonTouch, 4),
         data.MakeAbility(data.AbilityFirstStrike),
     },
+    CastingCost: 100,
 }
 
 var HeroBrax Unit = Unit{

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -3107,6 +3107,7 @@ func createScenario37(cache *lbx.LbxCache) *gamelib.Game {
     player.Gold = 830
     player.Mana = 26557
     player.CastingSkillPower = 10000
+    player.Fame = 10
     player.LiftFog(node.X, node.Y, 3, data.PlaneArcanus)
 
     unit := player.AddUnit(units.MakeOverworldUnitFromUnit(units.SkyDrake, node.X + 1, node.Y + 1, data.PlaneArcanus, wizard.Banner, nil))
@@ -3131,7 +3132,6 @@ func createScenario38(cache *lbx.LbxCache) *gamelib.Game {
         Base: data.WizardRjak,
         Banner: data.BannerPurple,
     }
-
 
     player1 := game.AddPlayer(wizard1, true)
     player1.Gold = 830


### PR DESCRIPTION
Adds some [sources for fame](https://masterofmagic.fandom.com/wiki/Fame#Sources_for_Fame):
- from Famous ability
- from battle
  - ±1 for 4+ enemies
  - ±1 for fantastic creatures with spell cost ≥ 600 MP. I moved the costs from `nodes` to `units` and added the missing costs (based on the [wiki](https://masterofmagic.fandom.com/wiki/Fantastic_Unit#List_of_Summoned_Units)). Theoretically, these costs could differ in the `spelldat.lbx` but I don't think it make much sense to adjust these when loading the lbx, right?
  - -1 for every two hero levels of a dead hero (starting from Myrmidon)

The following are still missing:
- from razing cities (added fixmes)
- from just cause spell (added a fixme)
- from defeated enemy wizard (that's not implemented yet, right?)

The gained / lost fame is now displayed in the combat end screen:
<img width="634" alt="Bildschirmfoto 2025-01-31 um 21 13 08" src="https://github.com/user-attachments/assets/65ce3ed7-e158-4670-940c-0d824deb0375" />
