### PR TITLE
game: implement range of sight

### DIFF
--- a/game/magic/ai/raider.go
+++ b/game/magic/ai/raider.go
@@ -42,7 +42,8 @@ func (raider *RaiderAI) MoveStacks(player *playerlib.Player, enemies []*playerli
                     }
 
                     // don't know about the city
-                    if !fog[city.X][city.Y] {
+                    // FIXME: how should this behave for different fog types?
+                    if fog[city.X][city.Y] == data.FogTypeUnexplored {
                         continue
                     }
 

--- a/game/magic/armyview/view.go
+++ b/game/magic/armyview/view.go
@@ -35,10 +35,10 @@ type ArmyScreen struct {
     ShowVault func()
     FirstRow int
     UI *uilib.UI
-    DrawMinimap func(*ebiten.Image, int, int, [][]bool, uint64)
+    DrawMinimap func(*ebiten.Image, int, int, data.FogMap, uint64)
 }
 
-func MakeArmyScreen(cache *lbx.LbxCache, player *playerlib.Player, drawMinimap func(*ebiten.Image, int, int, [][]bool, uint64), showVault func()) *ArmyScreen {
+func MakeArmyScreen(cache *lbx.LbxCache, player *playerlib.Player, drawMinimap func(*ebiten.Image, int, int, data.FogMap, uint64), showVault func()) *ArmyScreen {
     view := &ArmyScreen{
         Cache: cache,
         ImageCache: util.MakeImageCache(cache),

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -583,6 +583,7 @@ func parthenonPacification(race data.Race) int {
     }
 }
 
+// FIXME: Fix spelling
 func cathedralPaclification(race data.Race) int {
     switch race {
         case data.RaceBarbarian, data.RaceGnoll, data.RaceHighElf,
@@ -1218,6 +1219,16 @@ func (city *City) AllowedUnits(what buildinglib.Building) []units.Unit {
     }
 
     return out
+}
+
+func (city *City) GetSightRange() int {
+    // FIXME: nature's eye: 5
+
+    if city.Buildings.Contains(buildinglib.BuildingOracle) {
+        return 4
+    }
+
+    return 2
 }
 
 func ReadCityNames(cache *lbx.LbxCache) ([]string, error) {

--- a/game/magic/data/data.go
+++ b/game/magic/data/data.go
@@ -304,3 +304,13 @@ func (treaty TreatyType) String() string {
 
     return ""
 }
+
+type FogType int
+
+const (
+    FogTypeUnexplored FogType = iota
+    FogTypeExplored
+    FogTypeVisible
+)
+
+type FogMap [][]FogType

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -312,7 +312,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     var cities []*citylib.City
     var citiesMiniMap []maplib.MiniMapCity
     var stacks []*playerlib.UnitStack
-    var fog [][]bool
+    var fog data.FogMap
 
     for i, player := range game.Players {
         for _, city := range player.Cities {
@@ -505,7 +505,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                     case LocationTypeLand:
                         if tileY >= 0 && tileY < overworld.Map.Map.Rows() {
                             tileX = overworld.Map.WrapX(tileX)
-                            if player.IsTileVisible(tileX, tileY, game.Plane) {
+                            if player.IsTileExplored(tileX, tileY, game.Plane) {
                                 if overworld.Map.GetTile(tileX, tileY).Tile.IsLand() {
                                     return tileX, tileY, false
                                 }
@@ -520,7 +520,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                         if tileY >= 0 && tileY < overworld.Map.Map.Rows() {
                             tileX = overworld.Map.WrapX(tileX)
 
-                            if player.IsTileVisible(tileX, tileY, game.Plane) {
+                            if player.IsTileExplored(tileX, tileY, game.Plane) {
                                 terrainType := overworld.Map.GetTile(tileX, tileY).Tile.TerrainType()
                                 switch terrainType {
                                     case terrain.Desert, terrain.Forest, terrain.Hill,
@@ -534,7 +534,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                         if tileY >= 0 && tileY < overworld.Map.Map.Rows() {
                             tileX = overworld.Map.WrapX(tileX)
 
-                            if player.IsTileVisible(tileX, tileY, game.Plane) {
+                            if player.IsTileExplored(tileX, tileY, game.Plane) {
                                 bonusType := overworld.Map.GetBonusTile(tileX, tileY)
                                 switch bonusType {
                                     case data.BonusCoal, data.BonusGem, data.BonusIronOre,
@@ -547,7 +547,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                         if tileY >= 0 && tileY < overworld.Map.Map.Rows() {
                             tileX = overworld.Map.WrapX(tileX)
 
-                            if player.IsTileVisible(tileX, tileY, game.Plane) {
+                            if player.IsTileExplored(tileX, tileY, game.Plane) {
                                 terrainType := overworld.Map.GetTile(tileX, tileY).Tile.TerrainType()
                                 switch terrainType {
                                     case terrain.Desert, terrain.Forest, terrain.Swamp, terrain.Grass, terrain.Tundra:
@@ -559,7 +559,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                         if tileY >= 0 && tileY < overworld.Map.Map.Rows() {
                             tileX = overworld.Map.WrapX(tileX)
 
-                            if player.IsTileVisible(tileX, tileY, game.Plane) {
+                            if player.IsTileExplored(tileX, tileY, game.Plane) {
                                 node := overworld.Map.GetMagicNode(tileX, tileY)
                                 if node != nil && node.MeldingWizard != player {
                                     return tileX, tileY, false

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -462,6 +462,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
 
                     case LocationTypeEnemyUnit:
                         // TODO
+                        // FIXME: This should consider only tiles with FogTypeVisible
                 }
             }
         }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6035,6 +6035,15 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
 
     // log.Printf("fog min %v, %v max %v, %v", minX, minY, maxX, maxY)
 
+    black := ebiten.ColorScale{}
+    black.Scale(1, 1, 1, 1)
+
+    lightTransparent := ebiten.ColorScale{}
+    lightTransparent.Scale(1, 1, 1, 0.3)
+
+    darkTransparent := ebiten.ColorScale{}
+    darkTransparent.Scale(1, 1, 1, 0.5)
+
     for x := minX; x < maxX; x++ {
         for y := minY; y < maxY; y++ {
             tileX := overworld.Map.WrapX(x)
@@ -6043,15 +6052,6 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
             options.GeoM.Reset()
             options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
             options.GeoM.Concat(geom)
-
-            black := ebiten.ColorScale{}
-            black.Scale(1, 1, 1, 1)
-
-            lightTransparent := ebiten.ColorScale{}
-            lightTransparent.Scale(1, 1, 1, 0.3)
-
-            darkTransparent := ebiten.ColorScale{}
-            darkTransparent.Scale(1, 1, 1, 0.5)
 
             if tileX >= 0 && tileY >= 0 && tileX < len(fog) && tileY < len(fog[tileX]) {
                 switch fog[tileX][tileY] {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6116,6 +6116,10 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
             continue
         }
 
+        if overworld.Fog[stack.X()][stack.Y()] != data.FogTypeVisible {
+            continue
+        }
+
         location := image.Point{stack.X(), stack.Y()}
         _, hasCity := cityPositions[location]
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1837,7 +1837,7 @@ func (game *Game) FindPath(oldX int, oldY int, newX int, newY int, stack *player
 
         // don't know what the cost is, assume we can move there
         // FIXME: how should this behave for different FogTypes?
-        if x2 >= 0 && x2 < len(fog) && y2 >= 0 && y2 < len(fog[x2]) && fog[x2][y2] != data.FogTypeUnexplored {
+        if x2 >= 0 && x2 < len(fog) && y2 >= 0 && y2 < len(fog[x2]) && fog[x2][y2] == data.FogTypeUnexplored {
             // increase cost of unknown tile very slightly so we prefer to move to known tiles
             return baseCost + 0.1
         }

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -86,7 +86,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
         var cities []*citylib.City
         var stacks []*playerlib.UnitStack
-        var fog [][]bool
+        var fog data.FogMap
 
         for i, player := range game.Players {
             for _, city := range player.Cities {
@@ -166,7 +166,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
             surveyorFont.PrintCenter(screen, float64(280 * data.ScreenScale), float64(81 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Surveyor")
 
             if selectedPoint.X >= 0 && selectedPoint.X < game.CurrentMap().Width() && selectedPoint.Y >= 0 && selectedPoint.Y < game.CurrentMap().Height() {
-                if overworld.Fog[selectedPoint.X][selectedPoint.Y] {
+                if overworld.Fog[selectedPoint.X][selectedPoint.Y] != data.FogTypeUnexplored {
                     mapObject := game.CurrentMap()
                     tile := mapObject.GetTile(selectedPoint.X, selectedPoint.Y)
                     node := mapObject.GetMagicNode(selectedPoint.X, selectedPoint.Y)
@@ -279,6 +279,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                         y += float64(whiteFont.Height() * data.ScreenScale)
                     }
 
+                    // FIXME: how should this behave for different fog types?
                     if cityMap[selectedPoint] != nil {
                         city := cityMap[selectedPoint]
                         yellowFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, city.String())

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -1489,3 +1489,7 @@ func (hero *Hero) GetArtifactSlots() []artifact.ArtifactSlot {
 
     return []artifact.ArtifactSlot{artifact.ArtifactSlotMeleeWeapon, artifact.ArtifactSlotArmor, artifact.ArtifactSlotArmor}
 }
+
+func (hero *Hero) GetSightRange() int {
+    return hero.Unit.GetSightRange()
+}

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -247,7 +247,7 @@ func initializePlayer(game *gamelib.Game, wizard setup.WizardCustom, isHuman boo
         player.AddUnit(units.MakeOverworldUnitFromUnit(unit, cityX, cityY, startingPlane, wizard.Banner, player.MakeExperienceInfo()))
     }
 
-    player.LiftFog(cityX, cityY, 2, introCity.Plane)
+    player.LiftFog(cityX, cityY, 3, introCity.Plane)
 
     if isHuman {
         game.Events <- gamelib.StartingCityEvent(introCity)

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -1518,6 +1518,71 @@ func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, ce
         }
     }
 
+    type ColorKey struct {
+        terrain terrain.TerrainType
+        explored data.FogType
+    }
+
+    colorCache := make(map[ColorKey]color.RGBA)
+
+    getMapColor := func (kind terrain.TerrainType, explored data.FogType) color.RGBA {
+        key := ColorKey{terrain: kind, explored: explored}
+        if cached, ok := colorCache[key]; ok {
+            return cached
+        }
+
+        var use color.RGBA
+
+        landColor := color.RGBA{R: 0, G: 0xad, B: 0x00, A: 255}
+
+        switch kind {
+            case terrain.Grass: use = landColor
+            case terrain.Ocean: use = color.RGBA{R: 0, G: 0, B: 255, A: 255}
+            case terrain.River: use = color.RGBA{R: 0x3f, G: 0x88, B: 0xd3, A: 255}
+            case terrain.Shore: use = landColor
+            case terrain.Mountain: use = color.RGBA{R: 0xbc, G: 0xd0, B: 0xe4, A: 255}
+            case terrain.Hill: use = landColor
+            case terrain.Swamp: use = landColor
+            case terrain.Forest: use = landColor
+            case terrain.Desert: use = color.RGBA{R: 0xdb, G: 0xbd, B: 0x29, A: 255}
+            case terrain.Tundra: use = color.RGBA{R: 0xd6, G: 0xd4, B: 0xc9, A: 255}
+            case terrain.Volcano: use = color.RGBA{R: 0xff, G: 0x00, B: 0x00, A: 255}
+            case terrain.Lake: use = color.RGBA{R: 0x3f, G: 0x88, B: 0xd3, A: 255}
+            case terrain.NatureNode: use = color.RGBA{R: 0, G: 255, B: 0, A: 255}
+            case terrain.SorceryNode: use = color.RGBA{R: 0, G: 0, B: 255, A: 255}
+            case terrain.ChaosNode: use = color.RGBA{R: 0xff, G: 0x00, B: 0x00, A: 255}
+            default: use = color.RGBA{R: 64, G: 64, B: 64, A: 255}
+        }
+
+        if explored == data.FogTypeExplored {
+            use = util.ToRGBA(util.Lighten(use, -50))
+        }
+
+        colorCache[key] = use
+        return use
+    }
+
+    type CityColorKey struct {
+        cityColor color.RGBA
+        explored data.FogType
+    }
+
+    cityColorCache := make(map[CityColorKey]color.RGBA)
+
+    getCityColor := func (cityColor color.RGBA, explored data.FogType) color.RGBA {
+        key := CityColorKey{cityColor: cityColor, explored: explored}
+        if cached, ok := cityColorCache[key]; ok {
+            return cached
+        }
+
+        use := cityColor
+        if explored == data.FogTypeExplored {
+            use = util.ToRGBA(util.Lighten(use, -50))
+        }
+        cityColorCache[key] = use
+        return use
+    }
+
     for x := 0; x < screen.Bounds().Dx(); x++ {
         for y := 0; y < screen.Bounds().Dy(); y++ {
             tileX := mapObject.WrapX((x + cameraX) / data.ScreenScale)
@@ -1528,36 +1593,10 @@ func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, ce
                 continue
             }
 
-            var use color.RGBA
-
-            landColor := color.RGBA{R: 0, G: 0xad, B: 0x00, A: 255}
-
-            switch terrain.GetTile(mapObject.Map.Terrain[tileX][tileY]).TerrainType() {
-                case terrain.Grass: use = landColor
-                case terrain.Ocean: use = color.RGBA{R: 0, G: 0, B: 255, A: 255}
-                case terrain.River: use = color.RGBA{R: 0x3f, G: 0x88, B: 0xd3, A: 255}
-                case terrain.Shore: use = landColor
-                case terrain.Mountain: use = color.RGBA{R: 0xbc, G: 0xd0, B: 0xe4, A: 255}
-                case terrain.Hill: use = landColor
-                case terrain.Swamp: use = landColor
-                case terrain.Forest: use = landColor
-                case terrain.Desert: use = color.RGBA{R: 0xdb, G: 0xbd, B: 0x29, A: 255}
-                case terrain.Tundra: use = color.RGBA{R: 0xd6, G: 0xd4, B: 0xc9, A: 255}
-                case terrain.Volcano: use = color.RGBA{R: 0xff, G: 0x00, B: 0x00, A: 255}
-                case terrain.Lake: use = color.RGBA{R: 0x3f, G: 0x88, B: 0xd3, A: 255}
-                case terrain.NatureNode: use = color.RGBA{R: 0, G: 255, B: 0, A: 255}
-                case terrain.SorceryNode: use = color.RGBA{R: 0, G: 0, B: 255, A: 255}
-                case terrain.ChaosNode: use = color.RGBA{R: 0xff, G: 0x00, B: 0x00, A: 255}
-                default: use = color.RGBA{R: 64, G: 64, B: 64, A: 255}
-            }
+            use := getMapColor(terrain.GetTile(mapObject.Map.Terrain[tileX][tileY]).TerrainType(), fog[tileX][tileY])
 
             if cityColor, ok := cityLocations[image.Pt(tileX, tileY)]; ok {
-                use = cityColor
-            }
-
-            // FIXME: make this drawing fog of war configurable?
-            if fog[tileX][tileY] == data.FogTypeExplored {
-                use =  util.ToRGBA(util.Lighten(use, -50))
+                use = getCityColor(cityColor, fog[tileX][tileY])
             }
 
             set(x, y, use)

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -1555,7 +1555,7 @@ func (mapObject *Map) DrawMinimap(screen *ebiten.Image, cities []MiniMapCity, ce
                 use = cityColor
             }
 
-            // FIXME: make this configurable?
+            // FIXME: make this drawing fog of war configurable?
             if fog[tileX][tileY] == data.FogTypeExplored {
                 use =  util.ToRGBA(util.Lighten(use, -50))
             }

--- a/game/magic/player/stack.go
+++ b/game/magic/player/stack.go
@@ -346,3 +346,11 @@ func (stack *UnitStack) SetY(y int) {
         unit.SetY(y)
     }
 }
+
+func (stack *UnitStack) GetSightRange() int {
+    sightRange := 0
+    for _, unit := range stack.units {
+        sightRange = max(sightRange, unit.GetSightRange())
+    }
+    return sightRange
+}

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -499,3 +499,16 @@ func (unit *OverworldUnit) GetArtifactSlots() []artifact.ArtifactSlot {
 func (unit *OverworldUnit) GetArtifacts() []*artifact.Artifact {
     return nil
 }
+
+func (unit *OverworldUnit) GetSightRange() int {
+    scouting := unit.GetAbilityValue(data.AbilityScouting)
+    if scouting >= 2 {
+        return int(scouting)
+    }
+
+    if unit.IsFlying() {
+        return 2
+    }
+
+    return 1
+}

--- a/game/magic/units/stack-unit.go
+++ b/game/magic/units/stack-unit.go
@@ -79,5 +79,6 @@ type StackUnit interface {
     GetSpellChargeSpells() map[spellbook.Spell]int
     GetBusy() BusyStatus
     SetBusy(BusyStatus)
+    GetSightRange() int
 }
 

--- a/game/magic/units/unit.go
+++ b/game/magic/units/unit.go
@@ -3618,7 +3618,7 @@ var Manticore Unit = Unit{
     Defense: 3,
     Resistance: 6,
     HitPoints: 7,
-    Abilities: []data.Ability{data.MakeAbility(data.AbilityScouting), data.MakeAbilityValue(data.AbilityPoisonTouch, 6)},
+    Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityScouting, 2), data.MakeAbilityValue(data.AbilityPoisonTouch, 6)},
     RequiredBuildings: []building.Building{building.BuildingBarracks, building.BuildingAnimistsGuild},
     Race: data.RaceBeastmen,
 }
@@ -3873,7 +3873,7 @@ var Nightmares Unit = Unit{
     Defense: 4,
     Resistance: 8,
     HitPoints: 10,
-    Abilities: []data.Ability{data.MakeAbility(data.AbilityScouting)},
+    Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityScouting, 2)},
     RequiredBuildings: []building.Building{building.BuildingFantasticStable},
     Race: data.RaceDarkElf,
 }
@@ -4080,7 +4080,7 @@ var DoomDrake Unit = Unit{
     Defense: 3,
     Resistance: 9,
     HitPoints: 10,
-    Abilities: []data.Ability{data.MakeAbility(data.AbilityScouting), data.MakeAbilityValue(data.AbilityFireBreath, 6)},
+    Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityScouting, 2), data.MakeAbilityValue(data.AbilityFireBreath, 6)},
     RequiredBuildings: []building.Building{building.BuildingBarracks, building.BuildingStables},
     Race: data.RaceDraconian,
 }
@@ -4108,7 +4108,7 @@ var AirShip Unit = Unit{
     Defense: 5,
     Resistance: 8,
     HitPoints: 20,
-    Abilities: []data.Ability{data.MakeAbility(data.AbilityScouting), data.MakeAbility(data.AbilityWallCrusher)},
+    Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityScouting, 2), data.MakeAbility(data.AbilityWallCrusher)},
     RequiredBuildings: []building.Building{building.BuildingShipYard},
     Race: data.RaceDraconian,
 }
@@ -4756,6 +4756,7 @@ var Pegasai Unit = Unit{
     HitPoints: 5,
     RequiredBuildings: []building.Building{building.BuildingFantasticStable},
     Race: data.RaceHighElf,
+    Abilities: []data.Ability{data.MakeAbilityValue(data.AbilityScouting, 2), data.MakeAbilityValue(data.AbilityToHit, 10)},
 }
 
 var HighMenSpearmen Unit = Unit{

--- a/game/magic/util/graphics.go
+++ b/game/magic/util/graphics.go
@@ -163,6 +163,16 @@ func RotateHue(c color.Color, radian float64) color.Color {
     return rotate.Apply(c)
 }
 
+func ToRGBA(c color.Color) color.RGBA {
+    r, g, b, a := c.RGBA()
+    return color.RGBA{
+        R: uint8(r >> 8),
+        G: uint8(g >> 8),
+        B: uint8(b >> 8),
+        A: uint8(a >> 8),
+    }
+}
+
 /*
 func Lighten2(c color.RGBA, amount float64) color.Color {
     h, s, v := colorconv.ColorToHSV(c)

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -233,7 +233,7 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Lair",
             Banner: data.BannerBrown,
-        }, false, nil, nil)
+        }, false, 0, 0)
 
     // defendingArmy := createWarlockArmy(&defendingPlayer)
     defendingArmy := createHighMenBowmanArmyN(defendingPlayer, 3)
@@ -248,7 +248,7 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Merlin",
             Banner: data.BannerGreen,
-        }, true, nil, nil)
+        }, true, 0, 0)
 
     attackingPlayer.CastingSkillPower = 1000
     attackingPlayer.Mana = 1000
@@ -299,7 +299,7 @@ func makeScenario2(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Lair",
             Banner: data.BannerBlue,
-        }, false, nil, nil)
+        }, false, 0, 0)
 
     // defendingArmy := createWarlockArmy(&defendingPlayer)
     defendingArmy := createSettlerArmy(defendingPlayer, 3)
@@ -316,7 +316,7 @@ func makeScenario2(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Merlin",
             Banner: data.BannerRed,
-        }, true, nil, nil)
+        }, true, 0, 0)
 
     attackingPlayer.CastingSkillPower = 10
 
@@ -331,7 +331,7 @@ func makeScenario3(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Lair",
             Banner: data.BannerBlue,
-        }, false, nil, nil)
+        }, false, 0, 0)
 
     // defendingArmy := createWarlockArmy(&defendingPlayer)
     defendingArmy := createSettlerArmy(defendingPlayer, 3)
@@ -348,7 +348,7 @@ func makeScenario3(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Merlin",
             Banner: data.BannerRed,
-        }, true, nil, nil)
+        }, true, 0, 0)
 
     attackingPlayer.CastingSkillPower = 10
 
@@ -364,7 +364,7 @@ func makeScenario4(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Enemy",
             Banner: data.BannerBlue,
-        }, false, nil, nil)
+        }, false, 0, 0)
 
     // defendingArmy := createWarlockArmy(defendingPlayer)
     // defendingArmy := createSettlerArmy(defendingPlayer, 3)
@@ -381,7 +381,7 @@ func makeScenario4(cache *lbx.LbxCache) *combat.CombatScreen {
             Name: "Merlin",
             Banner: data.BannerRed,
             Race: data.RaceHighMen,
-        }, true, nil, nil)
+        }, true, 0, 0)
 
     attackingPlayer.CastingSkillPower = 10
 
@@ -408,7 +408,7 @@ func makeScenario5(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Enemy",
             Banner: data.BannerBlue,
-        }, false, nil, nil)
+        }, false, 0, 0)
 
     // defendingArmy := createWarlockArmy(&defendingPlayer)
     defendingArmy := createSettlerArmy(defendingPlayer, 3)
@@ -426,7 +426,7 @@ func makeScenario5(cache *lbx.LbxCache) *combat.CombatScreen {
             Name: "Merlin",
             Banner: data.BannerRed,
             Race: data.RaceHighMen,
-        }, true, nil, nil)
+        }, true, 0, 0)
 
     attackingPlayer.CastingSkillPower = 10
 
@@ -444,7 +444,7 @@ func makeScenario6(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Enemy",
             Banner: data.BannerBlue,
-        }, false, nil, nil)
+        }, false, 0, 0)
 
     // defendingArmy := createWarlockArmy(&defendingPlayer)
     defendingArmy := createSettlerArmy(defendingPlayer, 3)
@@ -462,7 +462,7 @@ func makeScenario6(cache *lbx.LbxCache) *combat.CombatScreen {
             Name: "Merlin",
             Banner: data.BannerRed,
             Race: data.RaceHighMen,
-        }, true, nil, nil)
+        }, true, 0, 0)
 
     attackingPlayer.CastingSkillPower = 10
 

--- a/util/combat-simulator/main.go
+++ b/util/combat-simulator/main.go
@@ -383,12 +383,12 @@ func (engine *Engine) EnterCombat(combatDescription CombatDescription) {
     cpuPlayer := playerlib.MakePlayer(setup.WizardCustom{
         Name: "CPU",
         Banner: data.BannerRed,
-    }, false, nil, nil)
+    }, false, 0, 0)
 
     humanPlayer := playerlib.MakePlayer(setup.WizardCustom{
         Name: "Human",
         Banner: data.BannerGreen,
-    }, true, nil, nil)
+    }, true, 0, 0)
 
     defendingArmy := combat.Army{
         Player: cpuPlayer,


### PR DESCRIPTION
Implements range of sight of units/cities and fog of war for units (but not terrain, cities etc.)

The fog map of a player can now have 3 values:
- unexplored: player has never seen the tile
- explored: player has once seen the tile
- visible: the tile is currently visible by a unit or city of a player

The wiki is very unclear about this topic. What I've found out from testing with the original and the wiki:
- Fog of war (explored tiles) hides enemy units
- Cities have a range of sight
  - normal cities have 2 square
  - cities with oracle have 4 square
  - cities with Nature's Eye spell have 5 square
- Units have a range of sight
  - normal units have 1 square
  - flying units have 2 square
  - units with scouting have 2 or 3 square (there seems to be no Scouting I, only II and III see [wiki](https://masterofmagic.fandom.com/wiki/Scouting), I changed the unit definitions accordingly)
- The start location gets an initial lift of 3 tile circle
- Nature's Awareness spell would make every tile visible

What I didn't change
- find path still considers explored tiles, not visible (not sure what the right strategy is here)
- surveyor still considers explored tiles, not visible (I think this is correct, maybe even for cities)
- spell location selection still consider explored tiles, not visible (I think this is correct)

I didn't implement anything regarding cities and terrain. This would be such a pain and probably also overkill and I'm not sure what the original does. To be honest, I would leave it like this and only do fog of war for units.

Fog of war is currently rendered with a transparent overlay both in the overworld and the minimap. Maybe add a setting for it?
<img width="957" alt="Bildschirmfoto 2025-02-01 um 16 05 07" src="https://github.com/user-attachments/assets/7c44e3c2-a8dd-414d-8e76-c887a8478eb8" />