### PR TITLE
cast: implement nature's eye spell

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -1234,7 +1234,9 @@ func (city *City) AllowedUnits(what buildinglib.Building) []units.Unit {
 }
 
 func (city *City) GetSightRange() int {
-    // FIXME: nature's eye: 5
+    if city.HasEnchantment(data.CityEnchantmentNaturesEye) {
+        return 5
+    }
 
     if city.Buildings.Contains(buildinglib.BuildingOracle) {
         return 4

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1121,6 +1121,14 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
                 images, _ := imageCache.GetImages("cityscap.lbx", enchantment.Enchantment.LbxIndex(data.PlaneArcanus))
                 index := animationCounter % uint64(len(images))
                 screen.DrawImage(images[index], &options)
+            case data.CityEnchantmentNaturesEye:
+                var options ebiten.DrawImageOptions
+                options.ColorScale.ScaleAlpha(alphaScale)
+                options.GeoM = baseGeoM
+                options.GeoM.Translate(float64(114 * data.ScreenScale), float64(82 * data.ScreenScale))
+                // FIXME: Consider plane
+                image, _ := imageCache.GetImage("cityscap.lbx", enchantment.Enchantment.LbxIndex(data.PlaneArcanus), 0)
+                screen.DrawImage(image, &options)
         }
     }
 

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -424,7 +424,7 @@ func (enchantment CityEnchantment) SoundIndex() int {
         // case CityEnchantmentGaiasBlessing: return 0
         // case CityEnchantmentHeavenlyLight: return 0
         // case CityEnchantmentInspirations: return 0
-        // case CityEnchantmentNaturesEye: return 0
+        case CityEnchantmentNaturesEye: return 28
         // case CityEnchantmentPestilence: return 0
         // case CityEnchantmentProsperity: return 0
         // case CityEnchantmentLifeWard: return 0

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -82,6 +82,13 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             }
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+        case "Nature's Eye":
+            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentNaturesEye)
+                player.UpdateFogVisibility()
+            }
+
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
         case "Change Terrain":
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeChangeTerrain, SelectedFunc: game.doCastChangeTerrain}
         case "Transmute":

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -90,6 +90,7 @@ func NewEngine() (*Engine, error) {
 
     city.AddEnchantment(data.CityEnchantmentWallOfFire, data.BannerRed)
     // city.AddEnchantment(data.CityEnchantmentWallOfDarkness, data.BannerGreen)
+    city.AddEnchantment(data.CityEnchantmentNaturesEye, data.BannerRed)
 
     var garrison []units.StackUnit
     for i := 0; i < 2; i++ {

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -990,6 +990,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Wraiths"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Wall of Fire"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Wall of Darkness"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Nature's Eye"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Nature Awareness"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Change Terrain"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Transmute"))


### PR DESCRIPTION
Adds nature's eye spell.

The drawing order is like in the original: City walls, enchantment icon(s), magic walls. Due to the sorting by name this should also work for the other icons (prosperity etc.).
<img width="953" alt="Bildschirmfoto 2025-02-03 um 05 09 22" src="https://github.com/user-attachments/assets/2ffdfba3-cd6c-4aef-9264-ea71d09328f0" />
