### PR TITLE
city: fix some issues with food icons/workers

### DIFF
--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -712,6 +712,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             workerElements = nil
             citizenX := 6 * data.ScreenScale
 
+            // the city might not have enough the required subsistence farmers, so only show what is available
             subsistenceFarmers := min(cityScreen.City.ComputeSubsistenceFarmers(), cityScreen.City.Farmers)
 
             for i := 0; i < subsistenceFarmers; i++ {

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -712,7 +712,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             workerElements = nil
             citizenX := 6 * data.ScreenScale
 
-            subsistenceFarmers := cityScreen.City.ComputeSubsistenceFarmers()
+            subsistenceFarmers := min(cityScreen.City.ComputeSubsistenceFarmers(), cityScreen.City.Farmers)
 
             for i := 0; i < subsistenceFarmers; i++ {
                 posX := citizenX

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -550,6 +550,8 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
 
             yes := func(){
                 cityScreen.SellBuilding(toSell)
+                // update the ui
+                cityScreen.UI = cityScreen.MakeUI(buildinglib.BuildingNone)
             }
 
             no := func(){


### PR DESCRIPTION
When a building is sold, recreate the UI to show the updated resource icons in case the building affected resources (such as granary adding +2 food).

Also don't show more subsistence farmers than the number of actual farmers.