### PR TITLE
cityview: fix myrror city display

### DIFF
--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1440,6 +1440,7 @@ func (cityScreen *CityScreen) WorkProducers() []ResourceUsage {
     add(int(cityScreen.City.ProductionForestersGuild()), "Forester's Guild")
     add(int(cityScreen.City.ProductionMinersGuild()), "Miner's Guild")
     add(int(cityScreen.City.ProductionMechaniciansGuild()), "Mechanician's Guild")
+    add(int(cityScreen.City.ProductionInspirations()), "Inspirations")
 
     return usage
 }

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1077,8 +1077,12 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
     roadX := float64(0.0 * data.ScreenScale)
     roadY := float64(18.0 * data.ScreenScale)
 
-    // FIXME: this is probably animated in case of enchanted road?
-    normalRoad, err := imageCache.GetImage("cityscap.lbx", 5, 0)
+    animationIndex = 0
+    if onMyrror {
+        animationIndex = 4
+    }
+
+    normalRoad, err := imageCache.GetImage("cityscap.lbx", 5, animationIndex)
     if err == nil {
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(alphaScale)

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -456,7 +456,7 @@ func makeCityScapeElement(cache *lbx.LbxCache, ui *uilib.UI, city *citylib.City,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
             var geom ebiten.GeoM
             geom.Translate(float64(x1), float64(y1))
-            drawCityScape(screen, buildings, buildingLook, newBuilding, ui.Counter / 8, imageCache, fonts, city.BuildingInfo, player, city.Enchantments.Values(), geom, (*getAlpha)())
+            drawCityScape(screen, city, buildings, buildingLook, newBuilding, ui.Counter / 8, imageCache, fonts, player, geom, (*getAlpha)())
             // vector.StrokeRect(screen, float32(buildingView.Min.X), float32(buildingView.Min.Y), float32(buildingView.Dx()), float32(buildingView.Dy()), 1, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff}, true)
         },
         RightClick: func(element *uilib.UIElement) {
@@ -1015,10 +1015,26 @@ func getRaceRebelIndex(race data.Race) int {
     return -1
 }
 
-func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook buildinglib.Building, newBuilding buildinglib.Building, animationCounter uint64, imageCache *util.ImageCache, fonts *Fonts, buildingInfo buildinglib.BuildingInfos, player *playerlib.Player, enchantments []citylib.Enchantment, baseGeoM ebiten.GeoM, alphaScale float32) {
-    // 5 is grasslands
-    // FIXME: make the land type and sky configurable
-    landBackground, err := imageCache.GetImage("cityscap.lbx", 0, 4)
+func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []BuildingSlot, buildingLook buildinglib.Building, newBuilding buildinglib.Building, animationCounter uint64, imageCache *util.ImageCache, fonts *Fonts, player *playerlib.Player, baseGeoM ebiten.GeoM, alphaScale float32) {
+    onMyrror := city.Plane == data.PlaneMyrror
+
+    // background
+    spriteIndex := 0
+    if onMyrror {
+        spriteIndex = 8
+    }
+
+    animationIndex := 4
+    // FIXME: validate how flying fortress is rendered
+    hasFlyingFortress := city.HasEnchantment(data.CityEnchantmentFlyingFortress)
+    switch {
+        case hasFlyingFortress: animationIndex = 1
+        case city.HasEnchantment(data.CityEnchantmentFamine): animationIndex = 2
+        case city.HasEnchantment(data.CityEnchantmentCursedLands): animationIndex = 0
+        case city.HasEnchantment(data.CityEnchantmentGaiasBlessing): animationIndex = 3
+    }
+
+    landBackground, err := imageCache.GetImage("cityscap.lbx", spriteIndex, animationIndex)
     if err == nil {
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(alphaScale)
@@ -1026,18 +1042,40 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
         screen.DrawImage(landBackground, &options)
     }
 
-    hills1, err := imageCache.GetImage("cityscap.lbx", 7, 0)
-    if err == nil {
-        var options ebiten.DrawImageOptions
-        options.ColorScale.ScaleAlpha(alphaScale)
-        options.GeoM = baseGeoM
-        options.GeoM.Translate(0, -1)
-        screen.DrawImage(hills1, &options)
+    // horizon
+    spriteIndex = 7
+    hasChaosRift := city.HasEnchantment(data.CityEnchantmentChaosRift)
+    hasHeavenlyLight := city.HasEnchantment(data.CityEnchantmentHeavenlyLight)
+    switch {
+        case hasFlyingFortress: spriteIndex = -1
+        case hasChaosRift && onMyrror: spriteIndex = 112
+        case hasChaosRift: spriteIndex = 92
+        case hasHeavenlyLight && onMyrror: spriteIndex = 113
+        case hasHeavenlyLight: spriteIndex = 93
+        // FIXME: sprite 91 / 111?
+        // FIXME: hills && onMyrror: 9
+        // FIXME: hills: 1
+        // FIXME: mountains && onMyrror: 10
+        // FIXME: mountains: 2
+        case onMyrror: spriteIndex = 11
     }
 
+    if spriteIndex > 0 {
+        horizon, err := imageCache.GetImage("cityscap.lbx", spriteIndex, 0)
+        if err == nil {
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(alphaScale)
+            options.GeoM = baseGeoM
+            options.GeoM.Translate(0, -1)
+            screen.DrawImage(horizon, &options)
+        }
+    }
+
+    // roads
     roadX := float64(0.0 * data.ScreenScale)
     roadY := float64(18.0 * data.ScreenScale)
 
+    // FIXME: this is probably animated in case of enchanted road?
     normalRoad, err := imageCache.GetImage("cityscap.lbx", 5, 0)
     if err == nil {
         var options ebiten.DrawImageOptions
@@ -1050,6 +1088,7 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
     drawName := func(){
     }
 
+    // buildings
     for _, building := range buildings {
 
         index := GetBuildingIndex(building.Building)
@@ -1082,7 +1121,7 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
             if buildingLook == building.Building {
                 drawName = func(){
                     useFont := fonts.SmallFont
-                    text := buildingInfo.Name(building.Building)
+                    text := city.BuildingInfo.Name(building.Building)
                     if building.IsRubble {
                         text = "Destroyed " + text
                         useFont = fonts.RubbleFont
@@ -1100,6 +1139,7 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
         }
     }
 
+    // river
     // FIXME: make this configurable
     river, err := imageCache.GetImages("cityscap.lbx", 3)
     if err == nil {
@@ -1111,6 +1151,8 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
         screen.DrawImage(river[index], &options)
     }
 
+    // magic walls and enchantment icons
+    enchantments := city.Enchantments.Values()
     for _, enchantment := range slices.SortedFunc(slices.Values(enchantments), func (a citylib.Enchantment, b citylib.Enchantment) int {
         return cmp.Compare(a.Enchantment.Name(), b.Enchantment.Name())
     }) {
@@ -1120,17 +1162,15 @@ func drawCityScape(screen *ebiten.Image, buildings []BuildingSlot, buildingLook 
                 options.ColorScale.ScaleAlpha(alphaScale)
                 options.GeoM = baseGeoM
                 options.GeoM.Translate(0, float64(85 * data.ScreenScale))
-                // FIXME: Consider plane
-                images, _ := imageCache.GetImages("cityscap.lbx", enchantment.Enchantment.LbxIndex(data.PlaneArcanus))
+                images, _ := imageCache.GetImages("cityscap.lbx", enchantment.Enchantment.LbxIndex())
                 index := animationCounter % uint64(len(images))
                 screen.DrawImage(images[index], &options)
-            case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity, data.CityEnchantmentInspirations:
+            case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity:
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(alphaScale)
                 options.GeoM = baseGeoM
                 options.GeoM.Translate(float64(enchantment.Enchantment.IconOffset() * data.ScreenScale), float64(82 * data.ScreenScale))
-                // FIXME: Consider plane
-                image, _ := imageCache.GetImage("cityscap.lbx", enchantment.Enchantment.LbxIndex(data.PlaneArcanus), 0)
+                image, _ := imageCache.GetImage("cityscap.lbx", enchantment.Enchantment.LbxIndex(), 0)
                 screen.DrawImage(image, &options)
         }
     }
@@ -1392,7 +1432,6 @@ func (cityScreen *CityScreen) WorkProducers() []ResourceUsage {
     add(int(cityScreen.City.ProductionForestersGuild()), "Forester's Guild")
     add(int(cityScreen.City.ProductionMinersGuild()), "Miner's Guild")
     add(int(cityScreen.City.ProductionMechaniciansGuild()), "Mechanician's Guild")
-    add(int(cityScreen.City.ProductionInspirations()), "Inspirations")
 
     return usage
 }

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1025,7 +1025,6 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
     }
 
     animationIndex := 4
-    // FIXME: validate how flying fortress is rendered
     hasFlyingFortress := city.HasEnchantment(data.CityEnchantmentFlyingFortress)
     switch {
         case hasFlyingFortress: animationIndex = 1
@@ -1046,17 +1045,20 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
     spriteIndex = 7
     hasChaosRift := city.HasEnchantment(data.CityEnchantmentChaosRift)
     hasHeavenlyLight := city.HasEnchantment(data.CityEnchantmentHeavenlyLight)
+    hasCloudOfShadow := city.HasEnchantment(data.CityEnchantmentCloudOfShadow)
     switch {
         case hasFlyingFortress: spriteIndex = -1
         case hasChaosRift && onMyrror: spriteIndex = 112
         case hasChaosRift: spriteIndex = 92
         case hasHeavenlyLight && onMyrror: spriteIndex = 113
         case hasHeavenlyLight: spriteIndex = 93
-        // FIXME: sprite 91 / 111?
-        // FIXME: hills && onMyrror: 9
-        // FIXME: hills: 1
-        // FIXME: mountains && onMyrror: 10
-        // FIXME: mountains: 2
+        case hasCloudOfShadow && onMyrror: spriteIndex = 111
+        case hasCloudOfShadow: spriteIndex = 91
+        // FIXME: hills and mountains seem to depend on the tiles north of the town
+        //      hills && onMyrror: 9
+        //      hills: 1
+        //      mountains && onMyrror: 10
+        //      mountains: 2
         case onMyrror: spriteIndex = 11
     }
 
@@ -1139,9 +1141,15 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
         }
     }
 
-    // river
+    // river / shore
     // FIXME: make this configurable
-    river, err := imageCache.GetImages("cityscap.lbx", 3)
+    // FIXME: 4/116 is shore
+    spriteIndex = 4
+    if onMyrror {
+        spriteIndex = 115
+    }
+
+    river, err := imageCache.GetImages("cityscap.lbx", spriteIndex)
     if err == nil {
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(alphaScale)

--- a/game/magic/cityview/enchantment.go
+++ b/game/magic/cityview/enchantment.go
@@ -59,7 +59,7 @@ func MakeEnchantmentView(cache *lbx.LbxCache, city *citylib.City, player *player
 
             geom2 := geom
             geom2.Translate(float64(5 * data.ScreenScale), float64(28 * data.ScreenScale))
-            drawCityScape(screen, buildingSlots, buildinglib.BuildingNone, buildinglib.BuildingNone, ui.Counter / 8, &imageCache, fonts, city.BuildingInfo, player, city.Enchantments.Values(), geom2, getAlpha())
+            drawCityScape(screen, city, buildingSlots, buildinglib.BuildingNone, buildinglib.BuildingNone, ui.Counter / 8, &imageCache, fonts, player, geom2, getAlpha())
         },
     }
 

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -357,38 +357,15 @@ func (enchantment CityEnchantment) UpkeepMana() int {
     return 0
 }
 
-func (enchantment CityEnchantment) LbxIndex(plane Plane) int {
+func (enchantment CityEnchantment) LbxIndex() int {
     switch enchantment {
         case CityEnchantmentAltarOfBattle: return 12
         case CityEnchantmentAstralGate: return 85
-        case CityEnchantmentChaosRift:
-            if plane == PlaneMyrror {
-                return 112
-            }
-            return 92
         // case CityEnchantmentCloudOfShadow: return // FIXME: Some sort of dark icon
         case CityEnchantmentConsecration: return 102
-        case CityEnchantmentCursedLands:
-            if plane == PlaneMyrror {
-                return 8
-            }
-            return 0
         case CityEnchantmentDarkRituals: return 81
         case CityEnchantmentEarthGate: return 83
         case CityEnchantmentEvilPresence: return 82
-        case CityEnchantmentFamine:
-            if plane == PlaneMyrror {
-                return 8
-            }
-            return 0
-        // case CityEnchantmentFlyingFortress: FIXME: Clouds city background
-        // case CityEnchantmentGaiasBlessing: FIXME: Green city background
-        case CityEnchantmentHeavenlyLight:
-            // FIXME: is this right?
-            if plane == PlaneMyrror {
-                return 112
-            }
-            return 93
         case CityEnchantmentInspirations: return 100
         case CityEnchantmentNaturesEye: return 99
         // case CityEnchantmentPestilence: FIXME: How is this displayed?

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -361,7 +361,6 @@ func (enchantment CityEnchantment) LbxIndex() int {
     switch enchantment {
         case CityEnchantmentAltarOfBattle: return 12
         case CityEnchantmentAstralGate: return 85
-        // case CityEnchantmentCloudOfShadow: return // FIXME: Some sort of dark icon
         case CityEnchantmentConsecration: return 102
         case CityEnchantmentDarkRituals: return 81
         case CityEnchantmentEarthGate: return 83
@@ -386,10 +385,13 @@ func (enchantment CityEnchantment) LbxIndex() int {
 func (enchantment CityEnchantment) SoundIndex() int {
     // FIXME: Add other sound indexes
     switch enchantment {
-        case CityEnchantmentAltarOfBattle: return 31
+        case CityEnchantmentAltarOfBattle, CityEnchantmentHeavenlyLight, CityEnchantmentInspirations,
+            CityEnchantmentProsperity, CityEnchantmentStreamOfLife:
+            return 31
         // case CityEnchantmentAstralGate: return 0
         // case CityEnchantmentChaosRift: return 0
-        // case CityEnchantmentCloudOfShadow: return 0
+        case CityEnchantmentCloudOfShadow, CityEnchantmentWallOfDarkness:
+            return 32
         // case CityEnchantmentConsecration: return 0
         // case CityEnchantmentCursedLands: return 0
         // case CityEnchantmentDarkRituals: return 0
@@ -398,18 +400,13 @@ func (enchantment CityEnchantment) SoundIndex() int {
         // case CityEnchantmentFamine: return 0
         // case CityEnchantmentFlyingFortress: return 0
         // case CityEnchantmentGaiasBlessing: return 0
-        case CityEnchantmentHeavenlyLight: return 31
-        case CityEnchantmentInspirations: return 31
         case CityEnchantmentNaturesEye: return 28
         // case CityEnchantmentPestilence: return 0
-        case CityEnchantmentProsperity: return 31
         // case CityEnchantmentLifeWard: return 0
         // case CityEnchantmentSorceryWard: return 0
         // case CityEnchantmentNatureWard: return 0
         // case CityEnchantmentDeathWard: return 0
         // case CityEnchantmentChaosWard: return 0
-        case CityEnchantmentStreamOfLife: return 31
-        case CityEnchantmentWallOfDarkness: return 32
         case CityEnchantmentWallOfFire: return 30
     }
 

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -126,14 +126,37 @@ func NewEngine() (*Engine, error) {
     }, nil
 }
 
+func (engine *Engine) togglePlane() {
+    if engine.CityScreen.City.Plane == data.PlaneArcanus {
+        engine.CityScreen.City.Plane = data.PlaneMyrror
+    } else {
+        engine.CityScreen.City.Plane = data.PlaneArcanus
+    }
+}
+
+func (engine *Engine) toggleEnchantment(enchantment data.CityEnchantment) {
+    if engine.CityScreen.City.HasEnchantment(enchantment) {
+        engine.CityScreen.City.RemoveEnchantment(enchantment, data.BannerBlue)
+    } else {
+        engine.CityScreen.City.AddEnchantment(enchantment, data.BannerBlue)
+    }
+}
+
 func (engine *Engine) Update() error {
 
     keys := make([]ebiten.Key, 0)
     keys = inpututil.AppendJustPressedKeys(keys)
 
     for _, key := range keys {
-        if key == ebiten.KeyEscape || key == ebiten.KeyCapsLock {
-            return ebiten.Termination
+        switch key {
+            case ebiten.KeyEscape, ebiten.KeyCapsLock: return ebiten.Termination
+            case ebiten.KeyP: engine.togglePlane()
+            case ebiten.Key1: engine.toggleEnchantment(data.CityEnchantmentFlyingFortress)
+            case ebiten.Key2: engine.toggleEnchantment(data.CityEnchantmentFamine)
+            case ebiten.Key3: engine.toggleEnchantment(data.CityEnchantmentCursedLands)
+            case ebiten.Key4: engine.toggleEnchantment(data.CityEnchantmentGaiasBlessing)
+            case ebiten.Key5: engine.toggleEnchantment(data.CityEnchantmentChaosRift)
+            case ebiten.Key6: engine.toggleEnchantment(data.CityEnchantmentHeavenlyLight)
         }
     }
 

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -140,6 +140,7 @@ func (engine *Engine) toggleEnchantment(enchantment data.CityEnchantment) {
     } else {
         engine.CityScreen.City.AddEnchantment(enchantment, data.BannerBlue)
     }
+    engine.CityScreen.UI = engine.CityScreen.MakeUI(buildinglib.BuildingNone)
 }
 
 func (engine *Engine) Update() error {

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -157,6 +157,7 @@ func (engine *Engine) Update() error {
             case ebiten.Key4: engine.toggleEnchantment(data.CityEnchantmentGaiasBlessing)
             case ebiten.Key5: engine.toggleEnchantment(data.CityEnchantmentChaosRift)
             case ebiten.Key6: engine.toggleEnchantment(data.CityEnchantmentHeavenlyLight)
+            case ebiten.Key7: engine.toggleEnchantment(data.CityEnchantmentCloudOfShadow)
         }
     }
 


### PR DESCRIPTION
Adds the sprite indexes for myrror cities:
<img width="620" alt="Bildschirmfoto 2025-02-04 um 18 44 30" src="https://github.com/user-attachments/assets/a61abd56-8716-4153-9262-54e361ef9e1e" />

Also renders enchantments changing the background of the city (for both planes; in the order of precedence):
- flying fortress
- famine
- cursed lands
- gaias blessing

Or the horizon (for both planes; in the order of precedence):
- Chaos rift
- Heavily Light
- Cloud of Shadow

I also added some fixme's (where I'm quite sure but not 100%):
- hills and moutain horizon seem to depend on the tiles north of the city
- besides river there is also shore (I think an any sourrounding tile)

`test/cityview` allows to now to toggle plane (`p`-key) and the enchantments mentioned above (keys `1`-`7`).
