### PR TITLE
cast: add pestilence

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -839,6 +839,10 @@ func (city *City) ComputeUnrest(garrison []units.StackUnit) int {
         unrestAbsolute += 1
     }
 
+    if city.HasEnchantment(data.CityEnchantmentPestilence) {
+        unrestAbsolute += 2
+    }
+
     // capital race vs town race modifier
     // unrest from spells
     // supression from units

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -1428,6 +1428,13 @@ func (city *City) DoNextTurn(garrison []units.StackUnit) []CityEvent {
 
         oldPopulation := city.Population
         city.Population += city.PopulationGrowthRate()
+
+        if city.HasEnchantment(data.CityEnchantmentPestilence) {
+            if city.Citizens() >= 11 || city.Citizens() > (rand.IntN(10) + 1) {
+                city.Population -= 1000
+            }
+        }
+
         if city.Population > city.MaximumCitySize() * 1000 {
             city.Population = city.MaximumCitySize() * 1000
         }

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -338,6 +338,34 @@ func TestEnchantments(test *testing.T){
         // 5 * (5 - 10) food surplus
         test.Errorf("City PopulationGrowthRate is not correct: %v", city.PopulationGrowthRate())
     }
+
+    // Pestilence
+    city.AddEnchantment(data.CityEnchantmentPestilence, banner)
+
+    if city.FoodProductionRate() != 5 {
+        // ((5 * 2 farmer + 0.2 * 10) with halved excess) / 2  = 5.25
+        test.Errorf("City FoodProductionRate is not correct: %v", city.FoodProductionRate())
+    }
+
+    if int(city.WorkProductionRate()) != int(math.Floor(15.75)) {
+        // (2 x (3 x 2 worker + 5 x 0.5 farmer) + 13.5 terrain) / 2 = 12.375
+        test.Errorf("City WorkProductionRate is not correct: %v", city.WorkProductionRate())
+    }
+
+    if city.GoldSurplus() != 23 {
+        // 2 x 8 taxation + 15.75/2 trade goods
+        test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
+    }
+
+    if city.ComputeUnrest(stack) != 5 {
+        // (0.2 race + 0.25 famine) * 10 + 1 cursed lands - 2 gaias blessing + 2 pestilence
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+    }
+
+    if city.PopulationGrowthRate() != -250 {
+        // 5 * (5 - 10) food surplus
+        test.Errorf("City PopulationGrowthRate is not correct: %v", city.PopulationGrowthRate())
+    }
 }
 
 

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -367,7 +367,6 @@ func (enchantment CityEnchantment) LbxIndex() int {
         case CityEnchantmentEvilPresence: return 82
         case CityEnchantmentInspirations: return 100
         case CityEnchantmentNaturesEye: return 99
-        // case CityEnchantmentPestilence: FIXME: How is this displayed?
         case CityEnchantmentProsperity: return 101
         case CityEnchantmentLifeWard: return 96
         case CityEnchantmentSorceryWard: return 97
@@ -391,7 +390,7 @@ func (enchantment CityEnchantment) SoundIndex() int {
         // case CityEnchantmentAstralGate: return 0
         // case CityEnchantmentChaosRift: return 0
         case CityEnchantmentCloudOfShadow, CityEnchantmentEvilPresence, CityEnchantmentFamine,
-            CityEnchantmentWallOfDarkness:
+            CityEnchantmentPestilence, CityEnchantmentWallOfDarkness:
             return 32
         // case CityEnchantmentConsecration: return 0
         case CityEnchantmentCursedLands: return 61
@@ -399,7 +398,6 @@ func (enchantment CityEnchantment) SoundIndex() int {
         // case CityEnchantmentEarthGate: return 0
         // case CityEnchantmentFlyingFortress: return 0
         case CityEnchantmentGaiasBlessing, CityEnchantmentNaturesEye: return 28
-        // case CityEnchantmentPestilence: return 0
         // case CityEnchantmentLifeWard: return 0
         // case CityEnchantmentSorceryWard: return 0
         // case CityEnchantmentNatureWard: return 0
@@ -418,7 +416,6 @@ func (enchantment CityEnchantment) IconOffset() int {
         // case CityEnchantmentConsecration: return 0
         case CityEnchantmentInspirations: return 134
         case CityEnchantmentNaturesEye: return 114
-        // case CityEnchantmentPestilence: return 0
         case CityEnchantmentProsperity: return 153
         // case CityEnchantmentLifeWard: return 0
         // case CityEnchantmentSorceryWard: return 0

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -119,6 +119,12 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             }
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
+        case "Pestilence":
+            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentPestilence)
+            }
+
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
         case "Change Terrain":
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeChangeTerrain, SelectedFunc: game.doCastChangeTerrain}
         case "Transmute":

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6004,19 +6004,6 @@ func (game *Game) doCityEnchantments(player *playerlib.Player) {
             }
         }
 
-        // lose city population due to pestilence
-        if city.HasEnchantment(data.CityEnchantmentPestilence) {
-            if city.Citizens() >= 11 || city.Citizens() > (rand.IntN(10) + 1) {
-                city.Population -= 1000
-                var garrison []units.StackUnit
-                stack := player.FindStack(city.X, city.Y, city.Plane)
-                if stack != nil {
-                    garrison = stack.Units()
-                }
-                city.ResetCitizens(garrison)
-            }
-        }
-
         // FIXME: Add chaos rift etc.
     }
 }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5965,9 +5965,10 @@ func (game *Game) DissipateEnchantments(player *playerlib.Player, power int) {
     // FIXME: dissipate unit enchantments
 }
 
-// apply automatic terraforming and purification to all cities of a player with gaias blessing
-func (game *Game) doGaiasBlessing(player *playerlib.Player) {
+// apply the effects of city enchantments
+func (game *Game) doCityEnchantments(player *playerlib.Player) {
     for _, city := range player.Cities {
+        // apply automatic terraforming and purification to all cities of a player with gaias blessing
         if city.HasEnchantment(data.CityEnchantmentGaiasBlessing) {
 
             mapObject := game.GetMap(city.Plane)
@@ -6002,6 +6003,21 @@ func (game *Game) doGaiasBlessing(player *playerlib.Player) {
                 }
             }
         }
+
+        // lose city population due to pestilence
+        if city.HasEnchantment(data.CityEnchantmentPestilence) {
+            if city.Citizens() >= 11 || city.Citizens() > (rand.IntN(10) + 1) {
+                city.Population -= 1000
+                var garrison []units.StackUnit
+                stack := player.FindStack(city.X, city.Y, city.Plane)
+                if stack != nil {
+                    garrison = stack.Units()
+                }
+                city.ResetCitizens(garrison)
+            }
+        }
+
+        // FIXME: Add chaos rift etc.
     }
 }
 
@@ -6214,7 +6230,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
         player.RemoveCity(city)
     }
 
-    game.doGaiasBlessing(player)
+    game.doCityEnchantments(player)
 
     game.maybeHireHero(player)
     game.maybeHireMercenaries(player)

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -166,6 +166,7 @@ func (engine *Engine) Update() error {
             case ebiten.Key5: engine.toggleEnchantment(data.CityEnchantmentChaosRift)
             case ebiten.Key6: engine.toggleEnchantment(data.CityEnchantmentHeavenlyLight)
             case ebiten.Key7: engine.toggleEnchantment(data.CityEnchantmentCloudOfShadow)
+            case ebiten.Key8: engine.toggleEnchantment(data.CityEnchantmentPestilence)
         }
     }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -996,6 +996,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Gaia's Blessing"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Cursed Lands"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Famine"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Pestilence"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Nature Awareness"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Change Terrain"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Transmute"))
@@ -1052,8 +1053,8 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
     city2.ProducingUnit = units.UnitNone
-    city2.Farmers = 5
-    city2.Workers = 5
+    city2.Farmers = 10
+    city2.Workers = 4
     city2.Wall = false
     city2.ResetCitizens(nil)
     enemy.AddCity(city2)


### PR DESCRIPTION
Adds [pestilence](https://masterofmagic.fandom.com/wiki/Pestilence) spell and enchantment.

Pestilence:
1. Adds +2 unrest
2. Removes 1000 population if a city contains 11 or more citizen
3. Randomly removes 1000 population if a city contains 10 or less citizen with a chance of `citizens > rand.IntN(10) + 1`

Pestilence seems to have no visual indication in the city screen and the original dos mom only shows the city screen when casting, so I done that.

(The wiki talks of 9 or less citizen for the third effect but that would create a stop a 10 citizens which the the original game clearly does not have.)


