### PR TITLE
city: remove city if shrunk to zero

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -26,6 +26,9 @@ type CityEventPopulationGrowth struct {
     Grow bool
 }
 
+type CityEventCityAbandoned struct {
+}
+
 type CityEventNewUnit struct {
     Unit units.Unit
     WeaponBonus data.WeaponBonus
@@ -1435,6 +1438,10 @@ func (city *City) DoNextTurn(garrison []units.StackUnit, mapObject *maplib.Map) 
             }
         }
 
+        if math.Abs(float64(city.Population/1000 - oldPopulation/1000)) > 0 {
+            cityEvents = append(cityEvents, &CityEventPopulationGrowth{Size: (city.Population - oldPopulation)/1000, Grow: city.Population > oldPopulation})
+        }
+
         buildingCost := city.BuildingInfo.ProductionCost(city.ProducingBuilding)
 
         if buildingCost != 0 || !city.ProducingUnit.Equals(units.UnitNone) {
@@ -1462,8 +1469,8 @@ func (city *City) DoNextTurn(garrison []units.StackUnit, mapObject *maplib.Map) 
             city.Population = city.MaximumCitySize() * 1000
         }
 
-        if math.Abs(float64(city.Population/1000 - oldPopulation/1000)) > 0 {
-            cityEvents = append(cityEvents, &CityEventPopulationGrowth{Size: (city.Population - oldPopulation)/1000, Grow: city.Population > oldPopulation})
+        if city.Population < 1000 {
+            cityEvents = append(cityEvents, &CityEventCityAbandoned{})
         }
 
     }

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -1435,14 +1435,6 @@ func (city *City) DoNextTurn(garrison []units.StackUnit, mapObject *maplib.Map) 
             }
         }
 
-        if city.Population > city.MaximumCitySize() * 1000 {
-            city.Population = city.MaximumCitySize() * 1000
-        }
-
-        if math.Abs(float64(city.Population/1000 - oldPopulation/1000)) > 0 {
-            cityEvents = append(cityEvents, &CityEventPopulationGrowth{Size: (city.Population - oldPopulation)/1000, Grow: city.Population > oldPopulation})
-        }
-
         buildingCost := city.BuildingInfo.ProductionCost(city.ProducingBuilding)
 
         if buildingCost != 0 || !city.ProducingUnit.Equals(units.UnitNone) {
@@ -1465,6 +1457,15 @@ func (city *City) DoNextTurn(garrison []units.StackUnit, mapObject *maplib.Map) 
                 }
             }
         }
+
+        if city.Population > city.MaximumCitySize() * 1000 {
+            city.Population = city.MaximumCitySize() * 1000
+        }
+
+        if math.Abs(float64(city.Population/1000 - oldPopulation/1000)) > 0 {
+            cityEvents = append(cityEvents, &CityEventPopulationGrowth{Size: (city.Population - oldPopulation)/1000, Grow: city.Population > oldPopulation})
+        }
+
     }
 
     if city.HasEnchantment(data.CityEnchantmentGaiasBlessing) {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6065,22 +6065,14 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
         for _, event := range cityEvents {
             switch event.(type) {
             case *citylib.CityEventPopulationGrowth:
-                growthEvent := event.(*citylib.CityEventPopulationGrowth)
+                if player.IsHuman() {
+                    growthEvent := event.(*citylib.CityEventPopulationGrowth)
 
-                verb := "grown"
-                if !growthEvent.Grow {
-                    verb = "shrunk"
-                }
-
-                if growthEvent.Size == 0 {
-                    removeCities = append(removeCities, city)
-                    if player.IsHuman() {
-                        select {
-                            case game.Events<- &GameEventNotice{Message: fmt.Sprintf("The city of %v has been abandoned.", city.Name)}:
-                            default:
-                        }
+                    verb := "grown"
+                    if !growthEvent.Grow {
+                        verb = "shrunk"
                     }
-                } else if player.IsHuman() {
+
                     scrollEvent := GameEventScroll{
                         Title: "CITY GROWTH",
                         Text: fmt.Sprintf("%v has %v to a population of %v.", city.Name, verb, city.Citizens()),
@@ -6088,6 +6080,14 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
 
                     select {
                         case game.Events<- &scrollEvent:
+                        default:
+                    }
+                }
+            case *citylib.CityEventCityAbandoned:
+                removeCities = append(removeCities, city)
+                if player.IsHuman() {
+                    select {
+                        case game.Events<- &GameEventNotice{Message: fmt.Sprintf("The city of %v has been abandoned.", city.Name)}:
                         default:
                     }
                 }

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -354,6 +354,7 @@ func createScenario4(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// city growth message
 func createScenario5(cache *lbx.LbxCache) *gamelib.Game {
     log.Printf("Running scenario 5")
     wizard := setup.WizardCustom{
@@ -3397,6 +3398,48 @@ func createScenario40(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// shrink city to zero
+func createScenario41(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 41")
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerRed,
+        Race: data.RaceTroll,
+        Abilities: []setup.WizardAbility{},
+        Books: []data.WizardBook{},
+    }
+
+    game := gamelib.MakeGame(cache, setup.NewGameSettings{
+        Magic: data.MagicSettingNormal,
+        Difficulty: data.DifficultyAverage,
+    })
+
+    game.Plane = data.PlaneArcanus
+
+    player := game.AddPlayer(wizard, true)
+
+    x, y, _ := game.FindValidCityLocation(game.Plane)
+
+    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game)
+    city.Population = 1000
+    city.Plane = data.PlaneArcanus
+    city.Banner = wizard.Banner
+    city.ProducingUnit = units.TrollSettlers
+    city.Production = float32(city.ProducingUnit.ProductionCost)
+    city.Farmers = 1
+    city.ResetCitizens(nil)
+
+    player.AddCity(city)
+    player.Gold = 1000
+    player.Mana = 1000
+
+    player.LiftFog(x, y, 4, data.PlaneArcanus)
+
+    game.Camera.Center(x, y)
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -3443,6 +3486,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 38: game = createScenario38(cache)
         case 39: game = createScenario39(cache)
         case 40: game = createScenario40(cache)
+        case 41: game = createScenario41(cache)
         default: game = createScenario1(cache)
     }
 


### PR DESCRIPTION
I tested with Dos MoM (v 1.60) and it's actually possible to shrink a city to zero by building / buying a settler.

Dos MoM doesn't show any notification, but I think it might be better to show something similar to the deserted outpost, what dou you think?

<img width="579" alt="Bildschirmfoto 2025-02-09 um 07 06 55" src="https://github.com/user-attachments/assets/962a7351-8805-4e5a-8436-dabbc583634f" />

I also moved city capping and growth message generation below the unit production part because building settler will also influence the population.