### PR TITLE
cityview: don't render replaced buildings

### DIFF
--- a/game/magic/building/building.go
+++ b/game/magic/building/building.go
@@ -130,3 +130,25 @@ func GetBuildingIndex(building Building) int {
 
     return -1
 }
+
+// the building which is shown in the city scape instead
+func (building Building) ReplacedBy() Building {
+    switch building {
+        case BuildingBarracks: return BuildingArmory
+        case BuildingFightersGuild: return BuildingArmorersGuild
+        case BuildingArmorersGuild: return BuildingWarCollege
+        case BuildingStables: return BuildingFantasticStable
+        case BuildingLibrary: return BuildingUniversity
+        case BuildingAlchemistsGuild: return BuildingWizardsGuild
+        case BuildingShrine: return BuildingTemple
+        case BuildingTemple: return BuildingParthenon
+        case BuildingParthenon: return BuildingCathedral
+        case BuildingMarketplace: return BuildingBank
+        case BuildingBank: return BuildingMerchantsGuild
+        case BuildingGranary: return BuildingFarmersMarket
+        case BuildingShipwrightsGuild: return BuildingShipYard
+        case BuildingShipYard: return BuildingMaritimeGuild
+    }
+
+    return BuildingNone
+}

--- a/game/magic/building/building.go
+++ b/game/magic/building/building.go
@@ -164,7 +164,7 @@ func (building Building) Size() (int, int) {
         case BuildingSmithy: return 2, 2
         case BuildingStables: return 3, 3
         case BuildingFantasticStable: return 3, 3
-        case BuildingAnimistsGuild: return 0, 0
+        case BuildingAnimistsGuild: return 2, 2
         case BuildingSawmill: return 2, 2
         case BuildingLibrary: return 3, 2
         case BuildingUniversity: return 3, 2

--- a/game/magic/building/building.go
+++ b/game/magic/building/building.go
@@ -89,7 +89,7 @@ func Buildings() []Building {
 }
 
 // the index in cityscap.lbx for the picture of this building
-func GetBuildingIndex(building Building) int {
+func (building Building) Index() int {
     switch building {
         case BuildingBarracks: return 45
         case BuildingArmory: return 46

--- a/game/magic/building/building.go
+++ b/game/magic/building/building.go
@@ -152,3 +152,42 @@ func (building Building) ReplacedBy() Building {
 
     return BuildingNone
 }
+
+// the size of the picture for this building (in squares)
+func (building Building) Size() (int, int) {
+    switch building {
+        case BuildingBarracks: return 2, 3
+        case BuildingArmory: return 2, 2
+        case BuildingFightersGuild: return 3, 2
+        case BuildingArmorersGuild: return 4, 2
+        case BuildingWarCollege: return 3, 2
+        case BuildingSmithy: return 2, 2
+        case BuildingStables: return 3, 3
+        case BuildingFantasticStable: return 3, 3
+        case BuildingAnimistsGuild: return 0, 0
+        case BuildingSawmill: return 2, 2
+        case BuildingLibrary: return 3, 2
+        case BuildingUniversity: return 3, 2
+        case BuildingSagesGuild: return 2, 2
+        case BuildingOracle: return 2, 2
+        case BuildingAlchemistsGuild: return 1, 1
+        case BuildingWizardsGuild: return 2, 2
+        case BuildingShrine: return 2, 2
+        case BuildingTemple: return 3, 3
+        case BuildingParthenon: return 3, 3
+        case BuildingCathedral: return 3, 3
+        case BuildingMarketplace: return 2, 2
+        case BuildingBank: return 2, 2
+        case BuildingMerchantsGuild: return 2, 2
+        case BuildingGranary: return 2, 2
+        case BuildingFarmersMarket: return 2, 2
+        case BuildingForestersGuild: return 2, 2
+        case BuildingBuildersHall: return 2, 2
+        case BuildingMechaniciansGuild: return 2, 2
+        case BuildingMinersGuild: return 2, 1
+        case BuildingFortress: return 3, 3
+        case BuildingSummoningCircle: return 3, 2
+    }
+
+    return 0, 0
+}

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -582,6 +582,16 @@ func (city *City) PowerMinerals() int {
     return extra
 }
 
+func (city *City) PowerFortress(spellBooks int) int {
+    power := spellBooks
+    if city.Plane == data.PlaneMyrror {
+        power += 5
+    }
+
+    return power
+}
+
+
 /* power production from buildings and citizens
  */
 func (city *City) ComputePower(spellBooks int) int {
@@ -597,11 +607,7 @@ func (city *City) ComputePower(spellBooks int) int {
             case buildinglib.BuildingCathedral: religiousPower += 4
             case buildinglib.BuildingAlchemistsGuild: power += 3
             case buildinglib.BuildingWizardsGuild: power -= 3
-            case buildinglib.BuildingFortress:
-                power += spellBooks
-                if city.Plane == data.PlaneMyrror {
-                    power += 5
-                }
+            case buildinglib.BuildingFortress: power += city.PowerFortress(spellBooks)
         }
     }
 

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1007,7 +1007,7 @@ func (cityScreen *CityScreen) Update() CityScreenState {
 
 // the index in cityscap.lbx for the picture of this building
 func GetBuildingIndex(building buildinglib.Building) int {
-    index := buildinglib.GetBuildingIndex(building)
+    index := building.Index()
 
     if index != -1 {
         return index

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -419,7 +419,7 @@ func wasBuildingReplaced(building buildinglib.Building, city *citylib.City) bool
     }
 
     replacedBy := building.ReplacedBy()
-    return replacedBy != buildinglib.BuildingNone && city.Buildings.Contains(replacedBy)
+    return replacedBy != buildinglib.BuildingNone && (city.Buildings.Contains(replacedBy) || wasBuildingReplaced(replacedBy, city))
 }
 
 func (cityScreen *CityScreen) SellBuilding(building buildinglib.Building) {

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -46,6 +46,9 @@ const (
 
 // buildings can appear in certain well-defined places around the city
 func buildingSlots() []image.Point {
+
+    // FIXME: Use a more fine-grained grid and layout buildings according to building.Size()
+
     return []image.Point{
         // row 1
         image.Pt(30, 23),

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1216,7 +1216,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
     // river / shore
     // FIXME: make this configurable
     // FIXME: 4/116 is shore
-    spriteIndex = 4
+    spriteIndex = 3
     if onMyrror {
         spriteIndex = 115
     }

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -557,6 +557,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     var elements []*uilib.UIElement
 
     sellBuilding := func (toSell buildinglib.Building) {
+        // FIXME: Check if building is needed for other building
         if cityScreen.City.SoldBuilding {
             ui.AddElement(uilib.MakeErrorElement(ui, cityScreen.LbxCache, &cityScreen.ImageCache, "You can only sell back one building per turn.", func(){}))
         } else {
@@ -1452,6 +1453,7 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
         }
     }
 
+    // FIXME: There can be a second page and a "More" button on the bottom right
     infoElement := &uilib.UIElement{
         // Rect: image.Rect(infoX, infoY, infoX + infoWidth, infoY + infoHeight),
         Rect: image.Rect(0, 0, data.ScreenWidth, data.ScreenHeight),

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -307,6 +307,8 @@ func makeBuildingSlots(city *citylib.City) []BuildingSlot {
             continue
         }
 
+        // FIXME: BuildingShipwrightsGuild, BuildingShipYard and BuildingMaritimeGuild are always at in the middle left
+
         if wasBuildingReplaced(building, city) {
             continue
         }
@@ -1179,6 +1181,8 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
 
     // buildings
     for _, building := range buildings {
+
+        // FIXME: BuildingShipwrightsGuild, BuildingShipYard and BuildingMaritimeGuild are always at in the middle left
 
         index := GetBuildingIndex(building.Building)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1194,7 +1194,7 @@ func (game *Game) showNewBuilding(yield coroutine.YieldFunc, city *citylib.City,
 
     getAlpha := util.MakeFadeIn(7, &game.Counter)
 
-    buildingPics, err := game.ImageCache.GetImagesTransform("cityscap.lbx", buildinglib.GetBuildingIndex(building), "crop", util.AutoCrop)
+    buildingPics, err := game.ImageCache.GetImagesTransform("cityscap.lbx", building.Index(), "crop", util.AutoCrop)
 
     if err != nil {
         log.Printf("Error: Unable to get building picture for %v: %v", game.BuildingInfo.Name(building), err)

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -95,7 +95,9 @@ func NewEngine() (*Engine, error) {
     city.AddBuilding(buildinglib.BuildingSummoningCircle)
     city.AddBuilding(buildinglib.BuildingOracle)
     city.AddBuilding(buildinglib.BuildingShrine)
-    city.AddBuilding(buildinglib.BuildingTemple)
+    // city.AddBuilding(buildinglib.BuildingTemple)
+    // city.AddBuilding(buildinglib.BuildingParthenon)
+    city.AddBuilding(buildinglib.BuildingCathedral)
 
     city.ProducingBuilding = buildinglib.BuildingHousing
     // city.ProducingUnit = units.HighElfSpearmen

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -81,15 +81,22 @@ func NewEngine() (*Engine, error) {
     city.Production = 18
     city.ProducingBuilding = buildinglib.BuildingNone
     city.Banner = data.BannerBlue
-    city.Buildings.Insert(buildinglib.BuildingFortress)
-    city.Buildings.Insert(buildinglib.BuildingGranary)
-    city.Buildings.Insert(buildinglib.BuildingFarmersMarket)
-    city.Buildings.Insert(buildinglib.BuildingMarketplace)
-    city.Buildings.Insert(buildinglib.BuildingMinersGuild)
-    city.Buildings.Insert(buildinglib.BuildingSawmill)
-    city.Buildings.Insert(buildinglib.BuildingMechaniciansGuild)
-    city.Buildings.Insert(buildinglib.BuildingBuildersHall)
-    city.Buildings.Insert(buildinglib.BuildingCityWalls)
+    city.AddBuilding(buildinglib.BuildingFortress)
+    city.AddBuilding(buildinglib.BuildingGranary)
+    city.AddBuilding(buildinglib.BuildingFarmersMarket)
+    city.AddBuilding(buildinglib.BuildingMarketplace)
+    city.AddBuilding(buildinglib.BuildingMinersGuild)
+    city.AddBuilding(buildinglib.BuildingSawmill)
+    city.AddBuilding(buildinglib.BuildingMechaniciansGuild)
+    city.AddBuilding(buildinglib.BuildingBuildersHall)
+    city.AddBuilding(buildinglib.BuildingCityWalls)
+    city.AddBuilding(buildinglib.BuildingWizardsGuild)
+    city.AddBuilding(buildinglib.BuildingSmithy)
+    city.AddBuilding(buildinglib.BuildingSummoningCircle)
+    city.AddBuilding(buildinglib.BuildingOracle)
+    city.AddBuilding(buildinglib.BuildingShrine)
+    city.AddBuilding(buildinglib.BuildingTemple)
+
     city.ProducingBuilding = buildinglib.BuildingHousing
     // city.ProducingUnit = units.HighElfSpearmen
     city.ResetCitizens(nil)
@@ -114,14 +121,6 @@ func NewEngine() (*Engine, error) {
     }
 
     city.UpdateUnrest(garrison)
-
-    city.AddBuilding(buildinglib.BuildingWizardsGuild)
-    city.AddBuilding(buildinglib.BuildingSmithy)
-    city.AddBuilding(buildinglib.BuildingSummoningCircle)
-    city.AddBuilding(buildinglib.BuildingOracle)
-    city.AddBuilding(buildinglib.BuildingFortress)
-    city.AddBuilding(buildinglib.BuildingShrine)
-    city.AddBuilding(buildinglib.BuildingTemple)
 
     cityScreen := cityview.MakeCityScreen(cache, city, &player, buildinglib.BuildingShrine)
 


### PR DESCRIPTION
Dos MoM doesn't render some of the buildings and shows them as "Replaced" in the resource dialog.

<img width="648" alt="Replaced buildings" src="https://github.com/user-attachments/assets/4a7b8690-198e-4878-a86f-301858655a1f" />

This will free up some city slots. I think at some point it might be required to switch to a more fine-grained grid layout similar to what Dos MoM does, as the building slots will still run out quickly for bigger cities. I've added some screen shots for reference #306.