### PR TITLE
cast: fix floating island summoning

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1237,7 +1237,7 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
     // spell
     elements = append(elements, makeButton(1, 0, 0, func(){
         doPlayerSpell := func(){
-            spellUI := spellbook.MakeSpellBookCastUI(ui, combat.Cache, player.KnownSpells, make(map[spellbook.Spell]int), player.ComputeCastingSkill(), spellbook.Spell{}, 0, false, func (spell spellbook.Spell, picked bool){
+            spellUI := spellbook.MakeSpellBookCastUI(ui, combat.Cache, player.KnownSpells.CombatSpells(), make(map[spellbook.Spell]int), player.ComputeCastingSkill(), spellbook.Spell{}, 0, false, func (spell spellbook.Spell, picked bool){
                 if picked {
                     // player mana and skill should go down accordingly
                     combat.InvokeSpell(player, spell, func(){

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -963,7 +963,7 @@ func (game *Game) doCastGlobalEnchantment(yield coroutine.YieldFunc, player *pla
 func (game *Game) doCastFloatingIsland(yield coroutine.YieldFunc, player *playerlib.Player, tileX int, tileY int) {
     update := func (x int, y int, frame int) {
         if frame == 5 {
-            overworldUnit := units.MakeOverworldUnitFromUnit(units.GetUnitByName("Floating Island"), tileX, tileY, game.CurrentMap().Plane, player.Wizard.Banner, player.MakeExperienceInfo())
+            overworldUnit := units.MakeOverworldUnitFromUnit(units.FloatingIsland, tileX, tileY, game.CurrentMap().Plane, player.Wizard.Banner, player.MakeExperienceInfo())
             player.AddUnit(overworldUnit)
             player.LiftFog(tileX, tileY, 1, game.Plane)
         }

--- a/game/magic/maplib/node.go
+++ b/game/magic/maplib/node.go
@@ -160,10 +160,10 @@ func computeNatureNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
     const (
         None Enemy = iota
         WarBear
-        Sprite
+        Sprites
         EarthElemental
-        Spiders
-        Cockatrice
+        GiantSpiders
+        Cockatrices
         Basilisk
         StoneGiant
         Gorgons
@@ -175,10 +175,10 @@ func computeNatureNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
     makeUnit := func(enemy Enemy) units.Unit {
         switch enemy {
             case WarBear: return units.WarBear
-            case Sprite: return units.Sprite
+            case Sprites: return units.Sprites
             case EarthElemental: return units.EarthElemental
-            case Spiders: return units.GiantSpider
-            case Cockatrice: return units.Cockatrice
+            case GiantSpiders: return units.GiantSpiders
+            case Cockatrices: return units.Cockatrices
             case Basilisk: return units.Basilisk
             case StoneGiant: return units.StoneGiant
             case Gorgons: return units.Gorgon
@@ -193,10 +193,10 @@ func computeNatureNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
     enemyCosts := map[Enemy]int{
         None: 0,
         WarBear: units.WarBear.CastingCost,
-        Sprite: units.Sprite.CastingCost,
+        Sprites: units.Sprites.CastingCost,
         EarthElemental: units.EarthElemental.CastingCost,
-        Spiders: units.GiantSpider.CastingCost,
-        Cockatrice: units.Cockatrice.CastingCost,
+        GiantSpiders: units.GiantSpiders.CastingCost,
+        Cockatrices: units.Cockatrices.CastingCost,
         Basilisk: units.Basilisk.CastingCost,
         StoneGiant: units.StoneGiant.CastingCost,
         Gorgons: units.Gorgon.CastingCost,
@@ -261,7 +261,7 @@ func computeDeathNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
         Werewolves
         ShadowDemons
         Wraiths
-        DeathKnight
+        DeathKnights
         DemonLord
     )
 
@@ -273,9 +273,9 @@ func computeDeathNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
             case Demons: return units.Demon
             case NightStalker: return units.NightStalker
             case Werewolves: return units.WereWolf
-            case ShadowDemons: return units.ShadowDemon
+            case ShadowDemons: return units.ShadowDemons
             case Wraiths: return units.Wraith
-            case DeathKnight: return units.DeathKnight
+            case DeathKnights: return units.DeathKnights
             case DemonLord: return units.DemonLord
         }
 
@@ -290,9 +290,9 @@ func computeDeathNodeEnemies(budget int) ([]units.Unit, []units.Unit) {
         Demons: units.Demon.CastingCost,
         NightStalker: units.NightStalker.CastingCost,
         Werewolves: units.WereWolf.CastingCost,
-        ShadowDemons: units.ShadowDemon.CastingCost,
+        ShadowDemons: units.ShadowDemons.CastingCost,
         Wraiths: units.Wraith.CastingCost,
-        DeathKnight: units.DeathKnight.CastingCost,
+        DeathKnights: units.DeathKnights.CastingCost,
         DemonLord: units.DemonLord.CastingCost,
     }
 

--- a/game/magic/summon/summon.go
+++ b/game/magic/summon/summon.go
@@ -143,8 +143,10 @@ func getMonsterIndex(unit units.Unit) int {
         monsterIndex = 14
     } else if unit.Equals(units.Wraith) {
         monsterIndex = 16
-    } else if unit.Equals(units.NightStalker) {
+    } else if unit.Equals(units.ShadowDemons) {
         monsterIndex = 17
+    } else if unit.Equals(units.DeathKnights) {
+        monsterIndex = 18
     } else if unit.Equals(units.DemonLord) {
         monsterIndex = 19
     } else if unit.Equals(units.Unicorn) {
@@ -157,13 +159,13 @@ func getMonsterIndex(unit units.Unit) int {
         monsterIndex = 24
     } else if unit.Equals(units.WarBear) {
         monsterIndex = 25
-    } else if unit.Equals(units.Sprite) {
+    } else if unit.Equals(units.Sprites) {
         monsterIndex = 26
-    } else if unit.Equals(units.Cockatrice) {
+    } else if unit.Equals(units.Cockatrices) {
         monsterIndex = 27
     } else if unit.Equals(units.Basilisk) {
         monsterIndex = 28
-    } else if unit.Equals(units.GiantSpider) {
+    } else if unit.Equals(units.GiantSpiders) {
         monsterIndex = 29
     } else if unit.Equals(units.StoneGiant) {
         monsterIndex = 30

--- a/game/magic/units/unit.go
+++ b/game/magic/units/unit.go
@@ -1543,7 +1543,7 @@ var Wraith Unit = Unit{
     CastingCost: 500,
 }
 
-var ShadowDemon Unit = Unit{
+var ShadowDemons Unit = Unit{
     LbxFile: "units2.lbx",
     Index: 51,
     CombatLbxFile: "figure12.lbx",
@@ -1580,7 +1580,7 @@ var ShadowDemon Unit = Unit{
     CastingCost: 325,
 }
 
-var DeathKnight Unit = Unit{
+var DeathKnights Unit = Unit{
     LbxFile: "units2.lbx",
     Index: 52,
     CombatLbxFile: "figure12.lbx",
@@ -1818,7 +1818,7 @@ var WarBear Unit = Unit{
     CastingCost: 70,
 }
 
-var Sprite Unit = Unit{
+var Sprites Unit = Unit{
     LbxFile: "units2.lbx",
     Name: "Sprites",
     Index: 60,
@@ -1845,10 +1845,10 @@ var Sprite Unit = Unit{
     CastingCost: 100,
 }
 
-var Cockatrice Unit = Unit{
+var Cockatrices Unit = Unit{
     LbxFile: "units2.lbx",
     Index: 61,
-    Name: "Cockatrice",
+    Name: "Cockatrices",
     CombatLbxFile: "figure13.lbx",
     CombatIndex: 8,
     UpkeepMana: 8,
@@ -1888,10 +1888,10 @@ var Basilisk Unit = Unit{
     CastingCost: 325,
 }
 
-var GiantSpider Unit = Unit{
+var GiantSpiders Unit = Unit{
     LbxFile: "units2.lbx",
     Index: 63,
-    Name: "Giant Spider",
+    Name: "Giant Spiders",
     CombatLbxFile: "figure13.lbx",
     CombatIndex: 24,
     Realm: data.NatureMagic,
@@ -5179,8 +5179,8 @@ var AllUnits []Unit = []Unit{
     WereWolf,
     Demon,
     Wraith,
-    ShadowDemon,
-    DeathKnight,
+    ShadowDemons,
+    DeathKnights,
     DemonLord,
     Zombie,
     Unicorn,
@@ -5188,10 +5188,10 @@ var AllUnits []Unit = []Unit{
     Angel,
     ArchAngel,
     WarBear,
-    Sprite,
-    Cockatrice,
+    Sprites,
+    Cockatrices,
     Basilisk,
-    GiantSpider,
+    GiantSpiders,
     StoneGiant,
     Colossus,
     Gorgon,

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -988,13 +988,65 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     allSpells, _ := spellbook.ReadSpellsFromCache(cache)
 
+    // summoning
+    player.KnownSpells.AddSpell(allSpells.FindByName("Guardian Spirit"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Unicorns"))
+    // player.KnownSpells.AddSpell(allSpells.FindByName("Incarnation"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Angel"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Arch Angel"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Floating Island"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Nagas"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Storm Giant"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Djinn"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Sky Drake"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Phantom Beast"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Phantom Warriors"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Air Elemental"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("War Bears"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Sprites"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Giant Spiders"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Cockatrices"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Basilisk"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Stone Giant"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Gorgons"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Behemoth"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Colossus"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Great Wyrm"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Earth Elemental"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Skeletons"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Ghouls"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Night Stalker"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Shadow Demons"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Wraiths"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Death Knights"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Demon Lord"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Hell Hounds"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Fire Giant"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Gargoyles"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Doom Bat"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Chimeras"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Chaos Spawn"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Efreet"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Hydra"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Great Drake"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Fire Elemental"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Magic Spirit"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Summon Champion"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
+
+    // special spells
     player.KnownSpells.AddSpell(allSpells.FindByName("Earth Lore"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Giant Strength"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Ice Bolt"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Enchant Item"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Create Artifact"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Magic Spirit"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Wraiths"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Enchant Road"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Raise Volcano"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Corruption"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Warp Node"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Call The Void"))
+
+    // city spells
     player.KnownSpells.AddSpell(allSpells.FindByName("Wall of Fire"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Wall of Darkness"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Nature's Eye"))
@@ -1009,13 +1061,6 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Nature Awareness"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Change Terrain"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Transmute"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Summon Champion"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Enchant Road"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Raise Volcano"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Corruption"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Warp Node"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Call The Void"))
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
@@ -1039,7 +1084,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.AddCity(city)
 
     player.Gold = 1000
-    player.Mana = 1000
+    player.Mana = 10000
 
     player.LiftFog(x, y, 4, data.PlaneArcanus)
 
@@ -1072,7 +1117,8 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city2.ResetCitizens(nil)
     enemy.AddCity(city2)
 
-    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y, data.PlaneArcanus, wizard.Banner, nil))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y, data.PlaneArcanus, enemy.Wizard.Banner, nil))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x + 2, y + 1, data.PlaneArcanus, enemy.Wizard.Banner, nil))
 
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.DragonTurtle, x + 2, y, data.PlaneArcanus, wizard.Banner, nil))
     player.LiftFog(x, y, 2, data.PlaneArcanus)
@@ -3178,7 +3224,7 @@ func createScenario37(cache *lbx.LbxCache) *gamelib.Game {
     player.Fame = 10
     player.LiftFog(node.X, node.Y, 3, data.PlaneArcanus)
 
-    player.AddUnit(units.MakeOverworldUnitFromUnit(units.Cockatrice, node.X, node.Y + 1, data.PlaneArcanus, wizard.Banner, nil))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.Cockatrices, node.X, node.Y + 1, data.PlaneArcanus, wizard.Banner, nil))
     unit := player.AddUnit(units.MakeOverworldUnitFromUnit(units.SkyDrake, node.X + 1, node.Y + 1, data.PlaneArcanus, wizard.Banner, nil))
     stack := player.FindStackByUnit(unit)
     player.SetSelectedStack(stack)


### PR DESCRIPTION
Floating island is actually not summoned to the summoning circle but cast on a map tile with water (including lakes).

Also includes some smaller fixes regarding summoning:
- only show combat spells in the spellbook during combat
- fixes summoning picture of some units: shadow demons, death knights, cockatrices, giant spiders

So far, only "Lycantrophy" is missing of all the summoning spells! Not sure how this is rendered though...

Maybe better add some helper function to look up a stack on map?