### PR TITLE
city view: handle enchantment overflow

### DIFF
--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1027,7 +1027,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     enchantmentMin := 0
     var enchantmentElements []*uilib.UIElement
 
-    // FIXME: what happens where there are too many enchantments such that the text goes beyond the enchantment ui box?
+    // if there are too many enchantments then up/down arrows will appear that let the user scroll the enchantment view
     for i, enchantment := range slices.SortedFunc(slices.Values(cityScreen.City.Enchantments.Values()), func (a citylib.Enchantment, b citylib.Enchantment) int {
         return cmp.Compare(a.Enchantment.Name(), b.Enchantment.Name())
     }) {

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1024,7 +1024,6 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     enchantmentAreaRect := image.Rect(140 * data.ScreenScale, 51 * data.ScreenScale, 140 * data.ScreenScale + 60 * data.ScreenScale, 93 * data.ScreenScale)
     maxEnchantments := enchantmentAreaRect.Dy() / (cityScreen.Fonts.BannerFonts[data.BannerGreen].Height() * data.ScreenScale)
 
-    enchantmentMin := 0
     var enchantmentElements []*uilib.UIElement
 
     // if there are too many enchantments then up/down arrows will appear that let the user scroll the enchantment view
@@ -1100,6 +1099,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     }
 
     if cityScreen.City.Enchantments.Size() > maxEnchantments {
+        enchantmentMin := 0
         updateElements := func(){
             fontHeight := cityScreen.Fonts.BannerFonts[data.BannerGreen].Height()
             yOffset := enchantmentMin * fontHeight * data.ScreenScale

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1152,6 +1152,20 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             },
         })
 
+        // scroll wheel element
+        elements = append(elements, &uilib.UIElement{
+            Rect: enchantmentAreaRect,
+            Scroll: func (element *uilib.UIElement, x float64, y float64) {
+                if y < 0 {
+                    enchantmentMin = min(cityScreen.City.Enchantments.Size() - maxEnchantments, enchantmentMin + 1)
+                    updateElements()
+                } else if y > 0 {
+                    enchantmentMin = max(0, enchantmentMin - 1)
+                    updateElements()
+                }
+            },
+        })
+
     }
 
     // FIXME: show Nightshade as a city enchantment if a nightshade tile is in the city catchment area and an appropriate building exists

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1100,6 +1100,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
 
     if cityScreen.City.Enchantments.Size() > maxEnchantments {
         enchantmentMin := 0
+        // shift all enchantment rect's around depending on the scroll position
         updateElements := func(){
             fontHeight := cityScreen.Fonts.BannerFonts[data.BannerGreen].Height()
             yOffset := enchantmentMin * fontHeight * data.ScreenScale

--- a/game/magic/ui/ui.go
+++ b/game/magic/ui/ui.go
@@ -405,7 +405,10 @@ func (ui *UI) StandardUpdate() {
             }
 
             if !ui.Disabled && leftClick && !elementLeftClicked {
-                elementLeftClicked = true
+                // if the element is interested in left click at all
+                if element.LeftClick != nil || element.LeftClickRelease != nil || element.DoubleLeftClick != nil {
+                    elementLeftClicked = true
+                }
                 if element.LeftClick != nil {
                     if element.PlaySoundLeftClick {
                         ui.PlayStandardSound()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8bed1a56-26d8-416b-917b-edfb64ac7f90)

In the city view if there are too many enchantments then the enchantment names could overflow the window. This pr prevents the enchantments list from getting too long and providing up/down arrows to scroll the list. Scrolling via mouse wheel/trackpad is also supported