### PR TITLE
cast: add incarnation

### DIFF
--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -255,9 +255,8 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             game.doSummonHero(player, false)
         case "Summon Champion":
             game.doSummonHero(player, true)
-
-        // FIXME: Incarnation
-        // Incarnation	Icon LifeLife	Rare	500	--	12	960	Summons Torin the Chosen – one of the most powerful Champions in the game.
+        case "Incarnation":
+            game.doIncarnation(player)
         case "Enchant Road":
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeAny, SelectedFunc: game.doCastEnchantRoad}
         case "Corruption":
@@ -385,6 +384,23 @@ func (game *Game) doSummonHero(player *playerlib.Player, champion bool) {
         }
 
         game.RefreshUI()
+    }
+}
+
+func (game *Game) doIncarnation(player *playerlib.Player) {
+    for _, hero := range game.Heroes {
+        if hero.HeroType == herolib.HeroTorin && hero.Status != herolib.StatusEmployed {
+            event := GameEventHireHero{
+                Hero: hero,
+                Player: player,
+                Cost: 0,
+            }
+
+            select {
+                case game.Events <- &event:
+                default:
+            }
+        }
     }
 }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4708,7 +4708,7 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
             if item != nil {
                 showHeroNotice = true
                 select {
-                    case game.Events <- &GameEventVault{CreatedArtifact: item}:
+                    case game.Events <- &GameEventVault{CreatedArtifact: item, Player: player}:
                     default:
                 }
             }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5662,7 +5662,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                             }
 
                             x, y := options.GeoM.Apply(float64(4 * data.ScreenScale), float64(19 * data.ScreenScale))
-                            vector.StrokeLine(screen, float32(x), float32(y), float32(x + healthLength), float32(y), 1, useColor, false)
+                            vector.StrokeLine(screen, float32(x), float32(y), float32(x + healthLength), float32(y), float32(data.ScreenScale), useColor, false)
                         }
 
                         silverBadge := 51

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4742,9 +4742,14 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
             if dead {
                 player.RemoveUnit(unit)
 
-                if unit.IsHero() && player.IsHuman() {
+                if unit.IsHero() {
                     hero := unit.(*herolib.Hero)
-                    distributeEquipment(player, hero)
+                    if player.IsHuman() {
+                        distributeEquipment(player, hero)
+                    }
+                    for index := range hero.Equipment {
+                        hero.Equipment[index] = nil
+                    }
                 }
             }
         }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4747,6 +4747,7 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
                     if player.IsHuman() {
                         distributeEquipment(player, hero)
                     }
+                    // FIXME: what happens with the equipment in case of non-human players?
                     for index := range hero.Equipment {
                         hero.Equipment[index] = nil
                     }

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -77,6 +77,13 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 
     getAlpha := ui.MakeFadeIn(fadeSpeed)
 
+    hireText := "Hire"
+    titleText := fmt.Sprintf("Hero for Hire: %v gold", goldToHire)
+    if hero.HeroType == herolib.HeroTorin {
+        hireText = "Accept"
+        titleText = "Hero Summoned"
+    }
+
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
@@ -172,7 +179,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 
             x := float64(hireRect.Min.X + hireRect.Max.X) / 2
             y := float64(hireRect.Min.Y + hireRect.Max.Y) / 2
-            okDismissFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Hire")
+            okDismissFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, hireText)
         },
     })
 
@@ -213,7 +220,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             options.ColorScale.ScaleAlpha(getAlpha())
             screen.DrawImage(banner, &options)
 
-            okDismissFont.PrintCenter(screen, float64(135 * data.ScreenScale), float64(6 * data.ScreenScale), float64(1 * data.ScreenScale), options.ColorScale, fmt.Sprintf("Hero for Hire: %v gold", goldToHire))
+            okDismissFont.PrintCenter(screen, float64(135 * data.ScreenScale), float64(6 * data.ScreenScale), float64(1 * data.ScreenScale), options.ColorScale, titleText)
         },
     })
 

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -512,7 +512,13 @@ func (hero *Hero) GetHireFee() int {
 }
 
 func (hero *Hero) AdjustHealth(amount int) {
-    hero.Unit.AdjustHealth(amount)
+    hero.Unit.Health += amount
+    if hero.Unit.Health < 0 {
+        hero.Unit.Health = 0
+    }
+    if hero.Unit.Health > hero.GetMaxHealth() {
+        hero.Unit.Health = hero.GetMaxHealth()
+    }
 
     if hero.GetHealth() <= 0 {
         hero.SetStatus(StatusDead)

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -285,7 +285,12 @@ func (player *Player) AddHero(hero *herolib.Hero) bool {
         if player.Heroes[i] == nil {
             player.Heroes[i] = hero
 
-            hero.Unit = units.MakeOverworldUnitFromUnit(hero.GetRawUnit(), fortressCity.X, fortressCity.Y, fortressCity.Plane, player.Wizard.Banner, player.MakeExperienceInfo())
+            level := hero.GetExperienceLevel()
+            experienceInfo := player.MakeExperienceInfo()
+
+            hero.Unit = units.MakeOverworldUnitFromUnit(hero.GetRawUnit(), fortressCity.X, fortressCity.Y, fortressCity.Plane, player.Wizard.Banner, experienceInfo)
+            hero.AddExperience(level.ExperienceRequired(experienceInfo.HasWarlord(), experienceInfo.Crusade()))
+
             player.AddUnit(hero)
             return true
         }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -285,6 +285,7 @@ func (player *Player) AddHero(hero *herolib.Hero) bool {
         if player.Heroes[i] == nil {
             player.Heroes[i] = hero
 
+            // keep the current level of the hero when creating a new overworld unit (which stores the experience)
             level := hero.GetExperienceLevel()
             experienceInfo := player.MakeExperienceInfo()
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -289,6 +289,7 @@ func (player *Player) AddHero(hero *herolib.Hero) bool {
             experienceInfo := player.MakeExperienceInfo()
 
             hero.Unit = units.MakeOverworldUnitFromUnit(hero.GetRawUnit(), fortressCity.X, fortressCity.Y, fortressCity.Plane, player.Wizard.Banner, experienceInfo)
+            hero.AdjustHealth(hero.GetMaxHealth())
             hero.AddExperience(level.ExperienceRequired(experienceInfo.HasWarlord(), experienceInfo.Crusade()))
 
             player.AddUnit(hero)

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -991,7 +991,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     // summoning
     player.KnownSpells.AddSpell(allSpells.FindByName("Guardian Spirit"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Unicorns"))
-    // player.KnownSpells.AddSpell(allSpells.FindByName("Incarnation"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Incarnation"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Angel"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Arch Angel"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Floating Island"))
@@ -1102,6 +1102,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city.Workers = 3
     city.Wall = false
 
+    city.AddBuilding(buildinglib.BuildingFortress)
     city.AddBuilding(buildinglib.BuildingShrine)
     city.AddBuilding(buildinglib.BuildingGranary)
 


### PR DESCRIPTION
Implements the "Incarnation" spell:

<img width="500" alt="Bildschirmfoto 2025-02-16 um 07 43 44" src="https://github.com/user-attachments/assets/a6b6ef9d-6bbc-4541-a2ef-1943dfeb4978" />

Also fixes some small issues:
- `GameEventVault` missing player variable
- deceased heros keeping equipment (Torin can be incarnated again, other heros resurrected)
- level of hired heros getting reset when being hired (heros will level up when not being hired, torin keeps his level on re-summoning)