### PR TITLE
Overworld: implement Consecration

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -464,14 +464,21 @@ func (city *City) RemoveEnchantments(enchantmentsToRemove ...data.CityEnchantmen
     }
 }
 
-func (city *City) HasEnchantment(check data.CityEnchantment) bool {
+// Returns true if the city has at least one of the enchantments from arguments
+func (city *City) HasAnyOfEnchantments(enchantmentsToCheck ...data.CityEnchantment) bool {
     for _, enchantment := range city.Enchantments.Values() {
-        if enchantment.Enchantment == check {
-            return true
+        for _, check := range enchantmentsToCheck {
+            if enchantment.Enchantment == check {
+                return true
+            }
         }
     }
 
     return false
+}
+
+func (city *City) HasEnchantment(check data.CityEnchantment) bool {
+    return city.HasAnyOfEnchantments(check)
 }
 
 func (city *City) GetEnchantmentsCastBy(banner data.BannerType) []Enchantment {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -445,13 +445,15 @@ func (city *City) AddEnchantment(enchantment data.CityEnchantment, owner data.Ba
     })
 }
 
-func (city *City) RemoveEnchantment(enchantment data.CityEnchantment, owner data.BannerType) {
+// Used when an enchantment removal is an explicit player action (e.g. disabling a specific enchantment from a city screen)
+func (city *City) CancelEnchantment(enchantment data.CityEnchantment, owner data.BannerType) {
     city.Enchantments.Remove(Enchantment{
         Enchantment: enchantment,
         Owner: owner,
     })
 }
 
+// Used when an enchantment removal is caused by some mechanic (e.g. consecration spell).
 func (city *City) RemoveEnchantments(enchantmentsToRemove ...data.CityEnchantment) {
     for _, enchantmentTypeToRemove := range enchantmentsToRemove {
         for _, enchantmentInstance := range city.Enchantments.Values() {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -439,6 +439,16 @@ func (city *City) RemoveEnchantment(enchantment data.CityEnchantment, owner data
     })
 }
 
+func (city *City) RemoveEnchantments(enchantmentsToRemove ...data.CityEnchantment) {
+    for _, enchantmentTypeToRemove := range enchantmentsToRemove {
+        for _, enchantmentInstance := range city.Enchantments.Values() {
+            if enchantmentInstance.Enchantment == enchantmentTypeToRemove {
+                city.Enchantments.Remove(enchantmentInstance)
+            }
+        }
+    }
+}
+
 func (city *City) HasEnchantment(check data.CityEnchantment) bool {
     for _, enchantment := range city.Enchantments.Values() {
         if enchantment.Enchantment == check {

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -459,7 +459,7 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City ComputePower is not correct: %v", city.ComputePower())
     }
 
-    city.RemoveEnchantment(data.CityEnchantmentStreamOfLife, banner)  // enable unrest
+    city.CancelEnchantment(data.CityEnchantmentStreamOfLife, banner)  // enable unrest
 
     // Famine
     city.AddEnchantment(data.CityEnchantmentFamine, banner)

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -909,7 +909,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                     group := uilib.MakeGroup()
                     yes := func(){
                         defer ui.RemoveGroup(group)
-                        cityScreen.City.RemoveEnchantment(enchantment.Enchantment, enchantment.Owner)
+                        cityScreen.City.CancelEnchantment(enchantment.Enchantment, enchantment.Owner)
 
                         enchantmentBuildings := enchantmentBuildings()
                         building, ok := enchantmentBuildings[enchantment.Enchantment]
@@ -2463,7 +2463,7 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
                 LeftClick: func(element *uilib.UIElement) {
                     if enchantment.Owner == player.GetBanner() {
                         yes := func(){
-                            city.RemoveEnchantment(enchantment.Enchantment, enchantment.Owner)
+                            city.CancelEnchantment(enchantment.Enchantment, enchantment.Owner)
                             setupUI()
                         }
 

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1730,7 +1730,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
                 images, _ := imageCache.GetImages("cityscap.lbx", enchantment.Enchantment.LbxIndex())
                 index := animationCounter % uint64(len(images))
                 screen.DrawImage(images[index], &options)
-            case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity:
+            case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity, data.CityEnchantmentConsecration:
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(alphaScale)
                 options.GeoM = baseGeoM

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -611,7 +611,7 @@ func (enchantment CityEnchantment) SoundIndex() int {
         case CityEnchantmentCloudOfShadow, CityEnchantmentEvilPresence, CityEnchantmentFamine,
             CityEnchantmentPestilence, CityEnchantmentWallOfDarkness:
             return 32
-        case CityEnchantmentConsecration: return 0 // FIXME: it's not an actual value
+        case CityEnchantmentConsecration: return 31
         case CityEnchantmentCursedLands: return 61
         case CityEnchantmentDarkRituals: return 60
         // case CityEnchantmentEarthGate: return 0
@@ -632,7 +632,7 @@ func (enchantment CityEnchantment) IconOffset() int {
     // FIXME: Add other offsets
     switch enchantment {
         // case CityEnchantmentCloudOfShadow: return 0
-        case CityEnchantmentConsecration: return 120 // FIXME: it's not an actual value
+        case CityEnchantmentConsecration: return 177
         case CityEnchantmentInspirations: return 134
         case CityEnchantmentNaturesEye: return 114
         case CityEnchantmentProsperity: return 153

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -611,7 +611,7 @@ func (enchantment CityEnchantment) SoundIndex() int {
         case CityEnchantmentCloudOfShadow, CityEnchantmentEvilPresence, CityEnchantmentFamine,
             CityEnchantmentPestilence, CityEnchantmentWallOfDarkness:
             return 32
-        // case CityEnchantmentConsecration: return 0
+        case CityEnchantmentConsecration: return 0 // FIXME: it's not an actual value
         case CityEnchantmentCursedLands: return 61
         case CityEnchantmentDarkRituals: return 60
         // case CityEnchantmentEarthGate: return 0
@@ -632,7 +632,7 @@ func (enchantment CityEnchantment) IconOffset() int {
     // FIXME: Add other offsets
     switch enchantment {
         // case CityEnchantmentCloudOfShadow: return 0
-        // case CityEnchantmentConsecration: return 0
+        case CityEnchantmentConsecration: return 120 // FIXME: it's not an actual value
         case CityEnchantmentInspirations: return 134
         case CityEnchantmentNaturesEye: return 114
         case CityEnchantmentProsperity: return 153

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -139,8 +139,8 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                // FIXME: show a fizzle notification?
                 if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                    game.ShowFizzleSpell(spell, player)
                     return
                 }
 
@@ -153,8 +153,8 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                // FIXME: show a fizzle notification?
                 if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                    game.ShowFizzleSpell(spell, player)
                     return
                 }
     
@@ -167,8 +167,8 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                // FIXME: show a fizzle notification?
                 if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                    game.ShowFizzleSpell(spell, player)
                     return
                 }
 
@@ -205,8 +205,8 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 chosenCity, owner := game.FindCity(tileX, tileY, game.Plane)
 
-                // FIXME: show a fizzle notification?
                 if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard) {
+                    game.ShowFizzleSpell(spell, player)
                     return
                 }
 
@@ -224,9 +224,9 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                // FIXME: show a fizzle notification?
                 // FIXME: it's not obvious if Chaos Ward prevents Raise Volcano from being cast on city center. Left it here because it sounds logical
                 if chosenCity != nil && (chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                    game.ShowFizzleSpell(spell, player)
                     return
                 }
                 game.doCastRaiseVolcano(yield, tileX, tileY, player)
@@ -326,9 +326,9 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                // FIXME: show a fizzle notification?
                 // FIXME: it's not obvious if Chaos Ward prevents Corruption from being cast on city center. Left it here because it sounds logical
                 if chosenCity != nil && (chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                    game.ShowFizzleSpell(spell, player)
                     return
                 }
                 game.doCastCorruption(yield, tileX, tileY)

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -157,7 +157,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
-    
+
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentFamine)
             }
 

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -139,7 +139,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
@@ -153,7 +153,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
@@ -167,7 +167,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
-                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
@@ -186,7 +186,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
 
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) {
+                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
@@ -205,7 +205,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 chosenCity, owner := game.FindCity(tileX, tileY, game.Plane)
 
-                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard) {
+                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentChaosWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
@@ -225,7 +225,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
                 // FIXME: it's not obvious if Chaos Ward prevents Raise Volcano from being cast on city center. Left it here because it sounds logical
-                if chosenCity != nil && (chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                if chosenCity != nil && chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentChaosWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }
@@ -327,7 +327,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
 
                 // FIXME: it's not obvious if Chaos Ward prevents Corruption from being cast on city center. Left it here because it sounds logical
-                if chosenCity != nil && (chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                if chosenCity != nil && chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentChaosWard) {
                     game.ShowFizzleSpell(spell, player)
                     return
                 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -138,18 +138,42 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
         case "Cursed Lands":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+
+                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+
+                // FIXME: show a fizzle notification?
+                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                    return
+                }
+
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentCursedLands)
             }
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
         case "Famine":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+
+                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+
+                // FIXME: show a fizzle notification?
+                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                    return
+                }
+    
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentFamine)
             }
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
         case "Pestilence":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+
+                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+
+                // FIXME: show a fizzle notification?
+                if chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentDeathWard) {
+                    return
+                }
+
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentPestilence)
             }
 
@@ -188,6 +212,13 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeTransmute, SelectedFunc: game.doCastTransmute}
         case "Raise Volcano":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+
+                // FIXME: show a fizzle notification?
+                // FIXME: it's not obvious if Chaos Ward prevents Raise Volcano from being cast on city center. Left it here because it sounds logical
+                if chosenCity != nil && (chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                    return
+                }
                 game.doCastRaiseVolcano(yield, tileX, tileY, player)
             }
 
@@ -282,7 +313,18 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
         case "Enchant Road":
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeAny, SelectedFunc: game.doCastEnchantRoad}
         case "Corruption":
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeLand, SelectedFunc: game.doCastCorruption}
+            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+
+                // FIXME: show a fizzle notification?
+                // FIXME: it's not obvious if Chaos Ward prevents Corruption from being cast on city center. Left it here because it sounds logical
+                if chosenCity != nil && (chosenCity.HasEnchantment(data.CityEnchantmentConsecration) || chosenCity.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                    return
+                }
+                game.doCastCorruption(yield, tileX, tileY)
+            }
+
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeLand, SelectedFunc: selected}
         case "Warp Node":
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyMeldedNode, SelectedFunc: game.doCastWarpNode}
         default:

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -110,15 +110,13 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 // Remove all the city curses from the targeted city on cast (https://masterofmagic.fandom.com/wiki/Consecration)
                 // Wiki specifies only the following ones as city curses
-                for _, enchantmentInstance := range chosenCity.Enchantments.Values() {
-                    if enchantmentInstance.Enchantment == data.CityEnchantmentChaosRift ||
-                        enchantmentInstance.Enchantment == data.CityEnchantmentCursedLands ||
-                        enchantmentInstance.Enchantment == data.CityEnchantmentEvilPresence ||
-                        enchantmentInstance.Enchantment == data.CityEnchantmentFamine ||
-                        enchantmentInstance.Enchantment == data.CityEnchantmentPestilence {
-                            chosenCity.RemoveEnchantment(enchantmentInstance.Enchantment, enchantmentInstance.Owner)
-                        }
-                }
+                chosenCity.RemoveEnchantments(
+                    data.CityEnchantmentChaosRift,
+                    data.CityEnchantmentCursedLands,
+                    data.CityEnchantmentEvilPresence,
+                    data.CityEnchantmentFamine,
+                    data.CityEnchantmentPestilence,
+                )
 
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentConsecration)
             }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -102,6 +102,12 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             }
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+        case "Consecration":
+            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentConsecration)
+            }
+
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
         case "Inspirations":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentInspirations)

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -104,6 +104,22 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
         case "Consecration":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+                if chosenCity == nil {
+                    return
+                }
+                // Remove all the city curses from the targeted city on cast (https://masterofmagic.fandom.com/wiki/Consecration)
+                // Wiki specifies only the following ones as city curses
+                for _, enchantmentInstance := range chosenCity.Enchantments.Values() {
+                    if enchantmentInstance.Enchantment == data.CityEnchantmentChaosRift ||
+                        enchantmentInstance.Enchantment == data.CityEnchantmentCursedLands ||
+                        enchantmentInstance.Enchantment == data.CityEnchantmentEvilPresence ||
+                        enchantmentInstance.Enchantment == data.CityEnchantmentFamine ||
+                        enchantmentInstance.Enchantment == data.CityEnchantmentPestilence {
+                            chosenCity.RemoveEnchantment(enchantmentInstance.Enchantment, enchantmentInstance.Owner)
+                        }
+                }
+
                 game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentConsecration)
             }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6865,19 +6865,8 @@ func (game *Game) doCleanCorruptionForConsecratedCities() {
             continue
         }
         useMap := game.GetMap(city.Plane)
-        for dx := -2; dx <= 2; dx++ {
-            for dy := -2; dy <= 2; dy++ {
-                if int(math.Abs(float64(dx)) + math.Abs(float64(dy))) == 4 {
-                    continue
-                }
-                cx := useMap.WrapX(city.X + dx)
-                cy := city.Y + dy
-                if cy < 0 || cy >= useMap.Height() {
-                    continue
-                }
-
-                useMap.RemoveCorruption(cx, cy)
-            }
+        for point, _ := range useMap.GetCatchmentArea(city.X, city.Y) {
+            useMap.RemoveCorruption(point.X, point.Y)
         }
     }
 }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6577,7 +6577,7 @@ func (game *Game) DissipateEnchantments(player *playerlib.Player, power int) {
         }
 
         enchantment := enchantments[rand.N(len(enchantments))]
-        enchantment.City.RemoveEnchantment(enchantment.Enchantment.Enchantment, enchantment.Enchantment.Owner)
+        enchantment.City.CancelEnchantment(enchantment.Enchantment.Enchantment, enchantment.Enchantment.Owner)
     }
 
     var enchantedUnits []units.StackUnit

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -178,7 +178,7 @@ func (engine *Engine) togglePlane() {
 
 func (engine *Engine) toggleEnchantment(enchantment data.CityEnchantment) {
     if engine.CityScreen.City.HasEnchantment(enchantment) {
-        engine.CityScreen.City.RemoveEnchantment(enchantment, data.BannerBlue)
+        engine.CityScreen.City.CancelEnchantment(enchantment, data.BannerBlue)
     } else {
         engine.CityScreen.City.AddEnchantment(enchantment, data.BannerBlue)
     }

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1033,6 +1033,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Magic Spirit"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Summon Champion"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Consecration"))
 
     // special spells
     player.KnownSpells.AddSpell(allSpells.FindByName("Earth Lore"))


### PR DESCRIPTION
I don't really like game/magic/game/cast.go lines 113 - 120. Maybe there's a new func (something like RemoveAllCityEnchantmentsOfTypes()) needed? The current RemoveCityEnchantment requires providing the spell's owner, which is not the case with Consecration.
I also don't really like 6868-6880 in game.go. I think we need a func like useMap.performFuncForEachCityCatchmentTile() with city and func (tileX, tilyY int) as arguments?
Also, I've added chaos/death wards checks for the spells affected by Consecration-related changes, except for some cases where there already was one.