### PR TITLE
Make LMB enter the text input.

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1099,6 +1099,12 @@ func (game *Game) doInput(yield coroutine.YieldFunc, title string, name string, 
                 }
             }
         },
+        // Emulating the original game behavior.
+        NotLeftClicked: func(element *uilib.UIElement) {
+            if len(name) > 0 {
+                quit = true
+            }
+        },
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := game.ImageCache.GetImage("backgrnd.lbx", 33, 0)
             var options ebiten.DrawImageOptions

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -653,6 +653,14 @@ func (screen *NewWizardScreen) MakeCustomNameUI() *uilib.UI {
                 }
             }
         },
+        // Emulating the original game behavior
+        NotLeftClicked: func(element *uilib.UIElement) {
+            if len(screen.CustomWizard.Name) > 0 {
+                screen.State = NewWizardScreenStateCustomBooks
+                ui.UnfocusElement()
+                screen.UI = screen.MakeCustomWizardBooksUI()
+            }
+        },
     }
 
     ui.AddElement(nameElement)


### PR DESCRIPTION
I'm not sure you'll accept this...
Well. In the original MOM any LMB or RMB click closes text inputs as if "enter" was pressed. Currently, in this project only enter keyboard key closes text inputs.
I've made it similar to OG MOM (it seems reasonable, as it allows mouse-only play), but still with some differences:
1. RMB does nothing (it can be used for something else)
2. LMB on the text input itself does nothing (we would use it for moving the cursor?)
3. Artifact creation menu unchanged. Not sure this behavior is needed here at all