### PR TITLE
disenchant area: apply to warp node

### DIFF
--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -378,7 +378,10 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeLand, SelectedFunc: selected}
         case "Warp Node":
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyMeldedNode, SelectedFunc: game.doCastWarpNode}
+            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
+                game.doCastWarpNode(yield, tileX, tileY, player)
+            }
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyMeldedNode, SelectedFunc: selected}
         case "Disenchant Area":
 
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
@@ -1232,7 +1235,7 @@ func (game *Game) doCastCorruption(yield coroutine.YieldFunc, tileX int, tileY i
     game.RefreshUI()
 }
 
-func (game *Game) doCastWarpNode(yield coroutine.YieldFunc, tileX int, tileY int) {
+func (game *Game) doCastWarpNode(yield coroutine.YieldFunc, tileX int, tileY int, caster *playerlib.Player) {
     update := func (x int, y int, frame int) {}
 
     game.doCastOnMap(yield, tileX, tileY, 13, true, 5, update)
@@ -1240,6 +1243,7 @@ func (game *Game) doCastWarpNode(yield coroutine.YieldFunc, tileX int, tileY int
     node := game.CurrentMap().GetMagicNode(tileX, tileY)
     if node != nil {
         node.Warped = true
+        node.WarpedOwner = caster
     }
 }
 

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -541,7 +541,17 @@ func (game *Game) doDisenchantArea(yield coroutine.YieldFunc, player *playerlib.
         }
     }
 
-    // FIXME: dispel warp node
+    mapUse := game.GetMap(game.Plane)
+    magicNode := mapUse.GetMagicNode(tileX, tileY)
+    if magicNode != nil && magicNode.Warped && magicNode.WarpedOwner != player {
+        warpNode := allSpells.FindByName("Warp Node")
+        cost := applyResistance(game.GetPlayerByBanner(magicNode.WarpedOwner.GetBanner()), warpNode.Cost(true), warpNode.Magic)
+
+        dispellChance := disenchantStrength * 100 / (disenchantStrength + cost)
+        if rand.N(100) < dispellChance {
+            magicNode.Warped = false
+        }
+    }
 }
 
 func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment) {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5980,7 +5980,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                         buildIndex = 1
                     } else if powers.Meld {
                         canMeld := false
-                        if node != nil && !node.Warped{
+                        if node != nil && !node.Warped {
                             canMeld = true
                         }
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -399,6 +399,7 @@ type ExtraMagicNode struct {
     GuardianSpiritMeld bool
 
     Warped bool
+    WarpedOwner Wizard
 }
 
 func (node *ExtraMagicNode) DrawLayer1(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64, tileWidth int, tileHeight int){
@@ -529,7 +530,6 @@ func (node *ExtraMagicNode) GetPower(magicBonus float64) float64 {
 
     return float64(len(node.Zone)) * magicBonus
 }
-
 
 type ExtraVolcano struct {
     CastingWizard Wizard

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -399,6 +399,7 @@ type ExtraMagicNode struct {
     GuardianSpiritMeld bool
 
     Warped bool
+    // the wizard that cast warp node (so it can be dispelled)
     WarpedOwner Wizard
 }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -4107,6 +4107,25 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
     city.AddEnchantment(data.CityEnchantmentConsecration, player.GetBanner())
     city.AddEnchantment(data.CityEnchantmentFamine, enemy.GetBanner())
 
+    // force a node to be melded and warped
+    var node *maplib.ExtraMagicNode
+    mapUse := game.GetMap(data.PlaneArcanus)
+    nodeLook:
+    for x := range mapUse.Width() {
+        for y := range mapUse.Height() {
+            if mapUse.GetMagicNode(x, y) != nil {
+                node = mapUse.GetMagicNode(x, y)
+                break nodeLook
+            }
+        }
+    }
+
+    if node != nil {
+        node.Meld(enemy, units.MagicSpirit)
+        node.Warped = true
+        node.WarpedOwner = enemy
+    }
+
     return game
 }
 


### PR DESCRIPTION
Dispel warp node if the warp node was cast by a rival wizard. This also tracks the original caster of warp node in the ExtraMagicNode object