### PR TITLE
city: move attributes from player to reign provider

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -164,10 +164,6 @@ func (city *City) GetY() int {
     return city.Y
 }
 
-func (city *City) GetBanner() data.BannerType {
-    return city.ReignProvider.GetBanner()
-}
-
 func (city *City) GetOutpostHouses() int {
     // every 100 population is 1 house
     return city.Population / 100
@@ -1760,6 +1756,10 @@ func (city *City) GetSightRange() int {
     }
 
     return 2
+}
+
+func (city *City) GetBanner() data.BannerType {
+    return city.ReignProvider.GetBanner()
 }
 
 func ReadCityNames(cache *lbx.LbxCache) ([]string, error) {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -91,7 +91,7 @@ type ReignProvider interface {
     TotalBooks() int
     GetRulingRace() data.Race
     GetTaxRate() fraction.Fraction
-    // FIXME: Also add Banner?
+    GetBanner() data.BannerType
 }
 
 const MAX_CITY_CITIZENS = 25
@@ -114,7 +114,6 @@ type City struct {
     X int
     Y int
     Outpost bool
-    Banner data.BannerType
     Buildings *set.Set[buildinglib.Building]
 
     Enchantments *set.Set[Enchantment]
@@ -135,12 +134,11 @@ type City struct {
 }
 
 // FIXME: Add plane?
-func MakeCity(name string, x int, y int, race data.Race, banner data.BannerType, buildingInfo buildinglib.BuildingInfos, catchmentProvider CatchmentProvider, cityServices CityServicesProvider, reignProvider ReignProvider) *City {
+func MakeCity(name string, x int, y int, race data.Race, buildingInfo buildinglib.BuildingInfos, catchmentProvider CatchmentProvider, cityServices CityServicesProvider, reignProvider ReignProvider) *City {
     city := City{
         Name: name,
         X: x,
         Y: y,
-        Banner: banner,
         Race: race,
         Buildings: set.MakeSet[buildinglib.Building](),
         Enchantments: set.MakeSet[Enchantment](),
@@ -166,7 +164,7 @@ func (city *City) GetY() int {
 }
 
 func (city *City) GetBanner() data.BannerType {
-    return city.Banner
+    return city.ReignProvider.GetBanner()
 }
 
 func (city *City) GetOutpostHouses() int {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -89,7 +89,7 @@ type ReignProvider interface {
     HasLifeBooks() bool
     HasDeathBooks() bool
     TotalBooks() int
-    RulingRace() data.Race
+    GetRulingRace() data.Race
     GetTaxRate() fraction.Fraction
     // FIXME: Also add Banner?
 }
@@ -973,7 +973,7 @@ func (city *City) InteracialUnrest() float64 {
 
     set(data.RaceTroll, data.RaceTroll, 0)
 
-    return unrest[city.Race][city.ReignProvider.RulingRace()]
+    return unrest[city.Race][city.ReignProvider.GetRulingRace()]
 }
 
 func (city *City) ComputeUnrest(garrison []units.StackUnit) int {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -164,6 +164,10 @@ func (city *City) GetY() int {
     return city.Y
 }
 
+func (city *City) GetBanner() data.BannerType {
+    return city.ReignProvider.GetBanner()
+}
+
 func (city *City) GetOutpostHouses() int {
     // every 100 population is 1 house
     return city.Population / 100
@@ -1756,10 +1760,6 @@ func (city *City) GetSightRange() int {
     }
 
     return 2
-}
-
-func (city *City) GetBanner() data.BannerType {
-    return city.ReignProvider.GetBanner()
 }
 
 func ReadCityNames(cache *lbx.LbxCache) ([]string, error) {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -89,7 +89,7 @@ type ReignProvider interface {
     HasLifeBooks() bool
     HasDeathBooks() bool
     TotalBooks() int
-    // FIXME: Also add RulingRace?
+    RulingRace() data.Race
     // FIXME: Also add TaxRate?
     // FIXME: Also add Banner?
 }
@@ -111,8 +111,6 @@ type City struct {
     Plane data.Plane
     // the race of the towns people
     Race data.Race
-    // the race of the controlling wizard
-    RulingRace data.Race
     X int
     Y int
     Outpost bool
@@ -146,7 +144,6 @@ func MakeCity(name string, x int, y int, race data.Race, banner data.BannerType,
         Y: y,
         Banner: banner,
         Race: race,
-        RulingRace: race,
         Buildings: set.MakeSet[buildinglib.Building](),
         Enchantments: set.MakeSet[Enchantment](),
         TaxRate: taxRate,
@@ -984,7 +981,7 @@ func (city *City) InteracialUnrest() float64 {
 
     set(data.RaceTroll, data.RaceTroll, 0)
 
-    return unrest[city.Race][city.RulingRace]
+    return unrest[city.Race][city.ReignProvider.RulingRace()]
 }
 
 func (city *City) ComputeUnrest(garrison []units.StackUnit) int {

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -93,9 +93,13 @@ func (reign *NoReign) GetTaxRate() fraction.Fraction {
     return reign.TaxRate
 }
 
+func (reign *NoReign) GetBanner() data.BannerType {
+    return data.BannerBlue
+}
+
 func TestBasicCity(test *testing.T){
     reign := NoReign{TaxRate: fraction.Make(3, 2)}
-    city := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &NoCities{}, &reign)
+    city := MakeCity("Test City", 10, 10, data.RaceHighMen, nil, &Catchment{Map: makeSimpleMap()}, &NoCities{}, &reign)
     city.Population = 6000
     city.Farmers = 6
     city.Workers = 0
@@ -184,13 +188,13 @@ func closeFloat(a float64, b float64) bool {
 
 func TestForeignTrade(test *testing.T){
     var connected AllConnected
-    city1 := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
+    city1 := MakeCity("Test City", 10, 10, data.RaceHighMen, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city1.Population = 6000
     city1.Farmers = 6
     city1.Workers = 0
     city1.ResetCitizens(nil)
 
-    city2 := MakeCity("Test City 2", 10, 10, data.RaceHighMen, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
+    city2 := MakeCity("Test City 2", 10, 10, data.RaceHighMen, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city2.Population = 7000
     city2.Farmers = 7
     city2.Workers = 0
@@ -204,7 +208,7 @@ func TestForeignTrade(test *testing.T){
     }
 
     // different race
-    city3 := MakeCity("Test City 3 elf", 10, 10, data.RaceHighElf, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
+    city3 := MakeCity("Test City 3 elf", 10, 10, data.RaceHighElf, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city3.Population = 5000
     city3.Farmers = 5
     city3.Workers = 0
@@ -232,7 +236,7 @@ func TestEnchantments(test *testing.T){
     }
     catchment := Catchment{Map: map_}
 
-    city := MakeCity("Test City", 10, 10, data.RaceHighMen, banner, nil, &catchment, &NoCities{}, &NoReign{TaxRate: fraction.FromInt(1)})
+    city := MakeCity("Test City", 10, 10, data.RaceHighMen, nil, &catchment, &NoCities{}, &NoReign{TaxRate: fraction.FromInt(1)})
     city.Population = 10100
     city.Farmers = 5
     city.Workers = 3
@@ -616,7 +620,7 @@ func TestScenario1(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, data.BannerGreen, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
     city.Population = 4600
     city.Farmers = 3
     city.Workers = 1
@@ -674,7 +678,7 @@ func TestScenario2(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, data.BannerGreen, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
     city.Population = 10110
     city.Farmers = 7
     city.Workers = 3

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -85,7 +85,7 @@ func (reign *NoReign) TotalBooks() int {
     return reign.NumberOfBooks
 }
 
-func (reign *NoReign) RulingRace() data.Race {
+func (reign *NoReign) GetRulingRace() data.Race {
     return data.RaceHighMen
 }
 

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -62,6 +62,7 @@ func (provider *NoCities) PlagueActive(city *City) bool {
 
 type NoReign struct {
     NumberOfBooks int
+    TaxRate fraction.Fraction
 }
 
 func (reign *NoReign) HasDivinePower() bool {
@@ -88,8 +89,13 @@ func (reign *NoReign) RulingRace() data.Race {
     return data.RaceHighMen
 }
 
+func (reign *NoReign) GetTaxRate() fraction.Fraction {
+    return reign.TaxRate
+}
+
 func TestBasicCity(test *testing.T){
-    city := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, fraction.Make(3, 2), nil, &Catchment{Map: makeSimpleMap()}, &NoCities{}, &NoReign{})
+    reign := NoReign{TaxRate: fraction.Make(3, 2)}
+    city := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &NoCities{}, &reign)
     city.Population = 6000
     city.Farmers = 6
     city.Workers = 0
@@ -120,7 +126,8 @@ func TestBasicCity(test *testing.T){
         test.Errorf("Rebels should have been 1 but was %v", city.Rebels)
     }
 
-    city.UpdateTaxRate(fraction.Make(3, 1), nil)
+    reign.TaxRate = fraction.Make(3, 1)
+    city.UpdateUnrest(nil)
 
     if city.ComputeUnrest(nil) != 4 {
         test.Errorf("Unrest should have been 4 but was %v", city.ComputeUnrest(nil))
@@ -177,13 +184,13 @@ func closeFloat(a float64, b float64) bool {
 
 func TestForeignTrade(test *testing.T){
     var connected AllConnected
-    city1 := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, fraction.Make(3, 2), nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{})
+    city1 := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city1.Population = 6000
     city1.Farmers = 6
     city1.Workers = 0
     city1.ResetCitizens(nil)
 
-    city2 := MakeCity("Test City 2", 10, 10, data.RaceHighMen, data.BannerBlue, fraction.Make(3, 2), nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{})
+    city2 := MakeCity("Test City 2", 10, 10, data.RaceHighMen, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city2.Population = 7000
     city2.Farmers = 7
     city2.Workers = 0
@@ -197,7 +204,7 @@ func TestForeignTrade(test *testing.T){
     }
 
     // different race
-    city3 := MakeCity("Test City 3 elf", 10, 10, data.RaceHighElf, data.BannerBlue, fraction.Make(3, 2), nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{})
+    city3 := MakeCity("Test City 3 elf", 10, 10, data.RaceHighElf, data.BannerBlue, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city3.Population = 5000
     city3.Farmers = 5
     city3.Workers = 0
@@ -225,7 +232,7 @@ func TestEnchantments(test *testing.T){
     }
     catchment := Catchment{Map: map_}
 
-    city := MakeCity("Test City", 10, 10, data.RaceHighMen, banner, fraction.FromInt(1), nil, &catchment, &NoCities{}, &NoReign{})
+    city := MakeCity("Test City", 10, 10, data.RaceHighMen, banner, nil, &catchment, &NoCities{}, &NoReign{TaxRate: fraction.FromInt(1)})
     city.Population = 10100
     city.Farmers = 5
     city.Workers = 3
@@ -609,7 +616,7 @@ func TestScenario1(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, data.BannerGreen, fraction.FromInt(1), nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11})
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, data.BannerGreen, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
     city.Population = 4600
     city.Farmers = 3
     city.Workers = 1
@@ -667,7 +674,7 @@ func TestScenario2(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, data.BannerGreen, fraction.FromInt(1), nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11})
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, data.BannerGreen, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
     city.Population = 10110
     city.Farmers = 7
     city.Workers = 3

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -84,6 +84,10 @@ func (reign *NoReign) TotalBooks() int {
     return reign.NumberOfBooks
 }
 
+func (reign *NoReign) RulingRace() data.Race {
+    return data.RaceHighMen
+}
+
 func TestBasicCity(test *testing.T){
     city := MakeCity("Test City", 10, 10, data.RaceHighMen, data.BannerBlue, fraction.Make(3, 2), nil, &Catchment{Map: makeSimpleMap()}, &NoCities{}, &NoReign{})
     city.Population = 6000

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -233,7 +233,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
         ui.RemoveGroup(mainGroup)
         mainGroup = uilib.MakeGroup()
         ui.AddGroup(mainGroup)
-        bannerUnit := units.MakeOverworldUnitFromUnit(unit, 0, 0, city.Plane, city.Banner, nil)
+        bannerUnit := units.MakeOverworldUnitFromUnit(unit, 0, 0, city.Plane, city.ReignProvider.GetBanner(), nil)
         mainGroup.AddElement(&uilib.UIElement{
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -233,7 +233,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
         ui.RemoveGroup(mainGroup)
         mainGroup = uilib.MakeGroup()
         ui.AddGroup(mainGroup)
-        bannerUnit := units.MakeOverworldUnitFromUnit(unit, 0, 0, city.Plane, city.ReignProvider.GetBanner(), nil)
+        bannerUnit := units.MakeOverworldUnitFromUnit(unit, 0, 0, city.Plane, city.GetBanner(), nil)
         mainGroup.AddElement(&uilib.UIElement{
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4904,7 +4904,7 @@ func (game *Game) CityProductionBonus(x int, y int, plane data.Plane) int {
 func (game *Game) CreateOutpost(settlers units.StackUnit, player *playerlib.Player) *citylib.City {
     cityName := game.SuggestCityName(settlers.GetRace())
 
-    newCity := citylib.MakeCity(cityName, settlers.GetX(), settlers.GetY(), settlers.GetRace(), settlers.GetBanner(), player.TaxRate, game.BuildingInfo, game.GetMap(settlers.GetPlane()), game, player)
+    newCity := citylib.MakeCity(cityName, settlers.GetX(), settlers.GetY(), settlers.GetRace(), settlers.GetBanner(), game.BuildingInfo, game.GetMap(settlers.GetPlane()), game, player)
     newCity.Plane = settlers.GetPlane()
     newCity.Population = 300
     newCity.Outpost = true
@@ -6768,7 +6768,7 @@ func ChangeCityOwner(city *citylib.City, owner *playerlib.Player, newOwner *play
     if stack != nil {
         newUnits = stack.Units()
     }
-    city.UpdateTaxRate(newOwner.TaxRate, newUnits)
+    city.UpdateUnrest(newUnits)
 
     switch enchantmentChange {
         case ChangeCityKeepEnchantments:

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4906,7 +4906,6 @@ func (game *Game) CreateOutpost(settlers units.StackUnit, player *playerlib.Play
 
     newCity := citylib.MakeCity(cityName, settlers.GetX(), settlers.GetY(), settlers.GetRace(), settlers.GetBanner(), player.TaxRate, game.BuildingInfo, game.GetMap(settlers.GetPlane()), game, player)
     newCity.Plane = settlers.GetPlane()
-    newCity.RulingRace = player.Wizard.Race
     newCity.Population = 300
     newCity.Outpost = true
     newCity.Banner = player.Wizard.Banner
@@ -6759,7 +6758,6 @@ func ChangeCityOwner(city *citylib.City, owner *playerlib.Player, newOwner *play
     owner.RemoveCity(city)
     newOwner.AddCity(city)
     city.Banner = newOwner.Wizard.Banner
-    city.RulingRace = newOwner.Wizard.Race
     city.ReignProvider = newOwner
 
     city.Buildings.Remove(buildinglib.BuildingFortress)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1432,7 +1432,7 @@ func (game *Game) showOutpost(yield coroutine.YieldFunc, city *citylib.City, sta
             stackOptions.GeoM.Translate(float64(7 * data.ScreenScale), float64(55 * data.ScreenScale))
 
             for _, unit := range stack.Units() {
-                pic, _ := GetUnitImage(unit, &game.ImageCache, city.ReignProvider.GetBanner())
+                pic, _ := GetUnitImage(unit, &game.ImageCache, city.GetBanner())
                 screen.DrawImage(pic, &stackOptions)
                 stackOptions.GeoM.Translate(float64(pic.Bounds().Dx() + 1 * data.ScreenScale), 0)
             }
@@ -4639,8 +4639,8 @@ func GetCityImage(city *citylib.City, cache *util.ImageCache) (*ebiten.Image, er
     }
 
     // the city image is a sub-frame of animation 20
-    // return cache.GetImageTransform("mapback.lbx", 20, index, city.ReignProvider.GetBanner().String(), util.ComposeImageTransform(units.MakeUpdateUnitColorsFunc(city.ReignProvider.GetBanner()), util.AutoCropGeneric))
-    return cache.GetImageTransform("mapback.lbx", spriteIndex, animationIndex, city.ReignProvider.GetBanner().String(), units.MakeUpdateUnitColorsFunc(city.ReignProvider.GetBanner()))
+    // return cache.GetImageTransform("mapback.lbx", 20, index, city.GetBanner().String(), util.ComposeImageTransform(units.MakeUpdateUnitColorsFunc(city.GetBanner()), util.AutoCropGeneric))
+    return cache.GetImageTransform("mapback.lbx", spriteIndex, animationIndex, city.GetBanner().String(), units.MakeUpdateUnitColorsFunc(city.GetBanner()))
 }
 
 func (game *Game) ShowGrandVizierUI(){
@@ -5276,7 +5276,7 @@ func (info CityStackInfo) ContainsEnemy(x int, y int, plane data.Plane, player *
     }
 
     city := info.FindCity(x, y, plane)
-    if city != nil && city.ReignProvider.GetBanner() != player.GetBanner() {
+    if city != nil && city.GetBanner() != player.GetBanner() {
         return true
     }
 
@@ -6556,7 +6556,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
                 }
             case *citylib.CityEventNewUnit:
                 newUnit := event.(*citylib.CityEventNewUnit)
-                overworldUnit := units.MakeOverworldUnitFromUnit(newUnit.Unit, city.X, city.Y, city.Plane, city.ReignProvider.GetBanner(), player.MakeExperienceInfo())
+                overworldUnit := units.MakeOverworldUnitFromUnit(newUnit.Unit, city.X, city.Y, city.Plane, city.GetBanner(), player.MakeExperienceInfo())
                 // only normal units get weapon bonuses
                 if overworldUnit.GetRace() != data.RaceFantastic {
                     overworldUnit.SetWeaponBonus(newUnit.WeaponBonus)
@@ -6703,7 +6703,7 @@ func (game *Game) doCleanCorruptionForConsecratedCities() {
 // At the beginning of each turn, Awareness clears the fog from all cities for enchantment's owner (newly built included)
 func (game *Game) doExploreFogForAwareness(awarenessOwner *playerlib.Player) {
     for _, city := range game.AllCities() {
-        if city.ReignProvider.GetBanner() == awarenessOwner.GetBanner() {
+        if city.GetBanner() == awarenessOwner.GetBanner() {
             continue // No need, those cities do already provide vision
         }
         awarenessOwner.ExploreFogSquare(city.X, city.Y, 1, city.Plane)

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -70,7 +70,7 @@ func TestChangeCityOwner(test *testing.T){
     player1.TaxRate = fraction.Zero()
     player2.TaxRate = fraction.FromInt(2)
 
-    city := citylib.MakeCity("xyz", 1, 1, player1.Wizard.Race, player1.GetBanner(), nil, &NoCatchment{}, &NoServices{}, player1)
+    city := citylib.MakeCity("xyz", 1, 1, player1.Wizard.Race, nil, &NoCatchment{}, &NoServices{}, player1)
     city.Population = 6000
     city.ResetCitizens(nil)
     city.AddBuilding(buildinglib.BuildingFortress)

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -84,10 +84,6 @@ func TestChangeCityOwner(test *testing.T){
         test.Errorf("Player 2 does not own the city")
     }
 
-    if city.RulingRace != data.RaceDarkElf {
-        test.Errorf("ruling race was not updated to dark elf")
-    }
-
     if !city.TaxRate.Equals(fraction.FromInt(2)) {
         test.Errorf("City tax rate not changed")
     }

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -227,7 +227,7 @@ func initializePlayer(game *gamelib.Game, wizard setup.WizardCustom, isHuman boo
 
     cityName := game.SuggestCityName(player.Wizard.Race)
 
-    introCity := citylib.MakeCity(cityName, cityX, cityY, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.GetMap(startingPlane), game, player)
+    introCity := citylib.MakeCity(cityName, cityX, cityY, player.Wizard.Race, game.BuildingInfo, game.GetMap(startingPlane), game, player)
     introCity.Population = 4000
     introCity.Plane = startingPlane
 

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -227,7 +227,7 @@ func initializePlayer(game *gamelib.Game, wizard setup.WizardCustom, isHuman boo
 
     cityName := game.SuggestCityName(player.Wizard.Race)
 
-    introCity := citylib.MakeCity(cityName, cityX, cityY, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.GetMap(startingPlane), game, player)
+    introCity := citylib.MakeCity(cityName, cityX, cityY, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.GetMap(startingPlane), game, player)
     introCity.Population = 4000
     introCity.Plane = startingPlane
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -598,7 +598,7 @@ func (player *Player) ManaPerTurn(power int, cityEnchantmentsProvider CityEnchan
 func (player *Player) UpdateTaxRate(rate fraction.Fraction){
     player.TaxRate = rate
     for _, city := range player.Cities {
-        city.UpdateTaxRate(rate, player.GetUnits(city.X, city.Y, city.Plane))
+        city.UpdateUnrest(player.GetUnits(city.X, city.Y, city.Plane))
     }
 }
 
@@ -923,4 +923,8 @@ func (player *Player) TotalBooks() int {
 
 func (player *Player) RulingRace() data.Race {
     return player.Wizard.Race
+}
+
+func (player *Player) GetTaxRate() fraction.Fraction {
+    return player.TaxRate
 }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -705,7 +705,7 @@ func (player *Player) ExploreFogSquare(x int, y int, squares int, plane data.Pla
             if mx < 0 || mx >= len(fog) || my < 0 || my >= len(fog[0]) {
                 continue
             }
-            
+
             if fog[mx][my] == data.FogTypeUnexplored {
                 fog[mx][my] = data.FogTypeExplored
             }
@@ -919,4 +919,8 @@ func (player *Player) HasDeathBooks() bool {
 
 func (player *Player) TotalBooks() int {
     return player.Wizard.TotalBooks()
+}
+
+func (player *Player) RulingRace() data.Race {
+    return player.Wizard.Race
 }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -921,7 +921,7 @@ func (player *Player) TotalBooks() int {
     return player.Wizard.TotalBooks()
 }
 
-func (player *Player) RulingRace() data.Race {
+func (player *Player) GetRulingRace() data.Race {
     return player.Wizard.Race
 }
 

--- a/test/city-enchantment/main.go
+++ b/test/city-enchantment/main.go
@@ -87,9 +87,10 @@ func (engine *Engine) MakeUI() (*uilib.UI, context.Context, error) {
         Wizard: setup.WizardCustom{
             Name: "joe",
         },
+        TaxRate: fraction.Make(2, 1),
     }
 
-    city := citylib.MakeCity("Boston", 3, 8, data.RaceHighElf, player.Wizard.Banner, fraction.Make(2, 1), buildingInfo, &gameMap, &NoCityProvider{}, player)
+    city := citylib.MakeCity("Boston", 3, 8, data.RaceHighElf, player.Wizard.Banner, buildingInfo, &gameMap, &NoCityProvider{}, player)
     city.Population = 12000
     city.Farmers = 4
     city.Workers = 2

--- a/test/city-enchantment/main.go
+++ b/test/city-enchantment/main.go
@@ -86,17 +86,17 @@ func (engine *Engine) MakeUI() (*uilib.UI, context.Context, error) {
     player := &playerlib.Player{
         Wizard: setup.WizardCustom{
             Name: "joe",
+            Banner: data.BannerBlue,
         },
         TaxRate: fraction.Make(2, 1),
     }
 
-    city := citylib.MakeCity("Boston", 3, 8, data.RaceHighElf, player.Wizard.Banner, buildingInfo, &gameMap, &NoCityProvider{}, player)
+    city := citylib.MakeCity("Boston", 3, 8, data.RaceHighElf, buildingInfo, &gameMap, &NoCityProvider{}, player)
     city.Population = 12000
     city.Farmers = 4
     city.Workers = 2
     city.Production = 18
     city.ProducingBuilding = buildinglib.BuildingNone
-    city.Banner = data.BannerBlue
     city.Buildings.Insert(buildinglib.BuildingGranary)
     city.Buildings.Insert(buildinglib.BuildingFarmersMarket)
     city.Buildings.Insert(buildinglib.BuildingMarketplace)

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -95,13 +95,12 @@ func NewEngine() (*Engine, error) {
         TileCache: make(map[int]*ebiten.Image),
     }
 
-    city := citylib.MakeCity("Boston", rand.N(20), rand.N(13) + 4, data.RaceKlackon, player.Wizard.Banner, buildingInfo, &gameMap, &NoCityProvider{}, &player)
+    city := citylib.MakeCity("Boston", rand.N(20), rand.N(13) + 4, data.RaceKlackon, buildingInfo, &gameMap, &NoCityProvider{}, &player)
     city.Population = 12000
     city.Farmers = 4
     city.Workers = 2
     city.Production = 18
     city.ProducingBuilding = buildinglib.BuildingNone
-    city.Banner = data.BannerBlue
 
     city.AddBuilding(buildinglib.BuildingFortress)
     city.AddBuilding(buildinglib.BuildingGranary)
@@ -144,12 +143,12 @@ func NewEngine() (*Engine, error) {
 
     var garrison []units.StackUnit
     for i := 0; i < 2; i++ {
-        unit := units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, city.X, city.Y, city.Plane, city.Banner, player.MakeExperienceInfo())
+        unit := units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, city.X, city.Y, city.Plane, city.ReignProvider.GetBanner(), player.MakeExperienceInfo())
         player.AddUnit(unit)
         garrison = append(garrison, unit)
     }
     for i := 0; i < 4; i++ {
-        unit := units.MakeOverworldUnitFromUnit(units.HighElfSwordsmen, city.X, city.Y, city.Plane, city.Banner, player.MakeExperienceInfo())
+        unit := units.MakeOverworldUnitFromUnit(units.HighElfSwordsmen, city.X, city.Y, city.Plane, city.ReignProvider.GetBanner(), player.MakeExperienceInfo())
         player.AddUnit(unit)
         garrison = append(garrison, unit)
     }

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -71,6 +71,7 @@ func NewEngine() (*Engine, error) {
                 setup.AbilityInfernalPower,
             },
         },
+        TaxRate: fraction.Make(2, 1),
     }
 
     player.Gold = 500
@@ -94,7 +95,7 @@ func NewEngine() (*Engine, error) {
         TileCache: make(map[int]*ebiten.Image),
     }
 
-    city := citylib.MakeCity("Boston", rand.N(20), rand.N(13) + 4, data.RaceKlackon, player.Wizard.Banner, fraction.Make(2, 1), buildingInfo, &gameMap, &NoCityProvider{}, &player)
+    city := citylib.MakeCity("Boston", rand.N(20), rand.N(13) + 4, data.RaceKlackon, player.Wizard.Banner, buildingInfo, &gameMap, &NoCityProvider{}, &player)
     city.Population = 12000
     city.Farmers = 4
     city.Workers = 2

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -143,12 +143,12 @@ func NewEngine() (*Engine, error) {
 
     var garrison []units.StackUnit
     for i := 0; i < 2; i++ {
-        unit := units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, city.X, city.Y, city.Plane, city.ReignProvider.GetBanner(), player.MakeExperienceInfo())
+        unit := units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, city.X, city.Y, city.Plane, city.GetBanner(), player.MakeExperienceInfo())
         player.AddUnit(unit)
         garrison = append(garrison, unit)
     }
     for i := 0; i < 4; i++ {
-        unit := units.MakeOverworldUnitFromUnit(units.HighElfSwordsmen, city.X, city.Y, city.Plane, city.ReignProvider.GetBanner(), player.MakeExperienceInfo())
+        unit := units.MakeOverworldUnitFromUnit(units.HighElfSwordsmen, city.X, city.Y, city.Plane, city.GetBanner(), player.MakeExperienceInfo())
         player.AddUnit(unit)
         garrison = append(garrison, unit)
     }

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -394,7 +394,7 @@ func makeScenario4(cache *lbx.LbxCache) *combat.CombatScreen {
     // attackingArmy := createHeroArmy(attackingPlayer)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingCityWalls)
 
@@ -436,7 +436,7 @@ func makeScenario5(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingArmy := createHeroArmy(attackingPlayer, cache)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeMountain, data.PlaneArcanus, combat.ZoneType{ChaosNode: true})
@@ -473,7 +473,7 @@ func makeScenario6(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingArmy := createArchAngelArmy(attackingPlayer)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeMountain, data.PlaneArcanus, combat.ZoneType{ChaosNode: true})
@@ -511,7 +511,7 @@ func makeScenario7(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingArmy := createArchAngelArmy(attackingPlayer)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeWater, data.PlaneArcanus, combat.ZoneType{})

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -384,6 +384,7 @@ func makeScenario4(cache *lbx.LbxCache) *combat.CombatScreen {
         }, true, 0, 0, nil)
 
     attackingPlayer.CastingSkillPower = 10
+    attackingPlayer.TaxRate = fraction.Zero()
 
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Fireball"))
 
@@ -393,7 +394,7 @@ func makeScenario4(cache *lbx.LbxCache) *combat.CombatScreen {
     // attackingArmy := createHeroArmy(attackingPlayer)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, fraction.Zero(), nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingCityWalls)
 
@@ -429,12 +430,13 @@ func makeScenario5(cache *lbx.LbxCache) *combat.CombatScreen {
         }, true, 0, 0, nil)
 
     attackingPlayer.CastingSkillPower = 10
+    attackingPlayer.TaxRate = fraction.Zero()
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
     attackingArmy := createHeroArmy(attackingPlayer, cache)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, fraction.Zero(), nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeMountain, data.PlaneArcanus, combat.ZoneType{ChaosNode: true})
@@ -465,12 +467,13 @@ func makeScenario6(cache *lbx.LbxCache) *combat.CombatScreen {
         }, true, 0, 0, nil)
 
     attackingPlayer.CastingSkillPower = 10
+    attackingPlayer.TaxRate = fraction.Zero()
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
     attackingArmy := createArchAngelArmy(attackingPlayer)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, fraction.Zero(), nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeMountain, data.PlaneArcanus, combat.ZoneType{ChaosNode: true})
@@ -502,12 +505,13 @@ func makeScenario7(cache *lbx.LbxCache) *combat.CombatScreen {
         }, true, 0, 0, nil)
 
     attackingPlayer.CastingSkillPower = 10
+    attackingPlayer.TaxRate = fraction.Zero()
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
     attackingArmy := createArchAngelArmy(attackingPlayer)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, fraction.Zero(), nil, nil, nil, attackingPlayer)
+    city := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, attackingPlayer.Wizard.Banner, nil, nil, nil, attackingPlayer)
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
     return combat.MakeCombatScreen(cache, defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeWater, data.PlaneArcanus, combat.ZoneType{})

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -90,6 +90,8 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
 
     player := game.AddPlayer(wizard, true)
 
+    player.TaxRate = fraction.Zero()
+
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
     /*
@@ -97,7 +99,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -178,7 +180,7 @@ func createScenario2(cache *lbx.LbxCache) *gamelib.Game {
 
     player := game.AddPlayer(wizard, true)
 
-    introCity := citylib.MakeCity("Test City", 4, 5, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", 4, 5, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 6000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -236,7 +238,7 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 9000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -307,7 +309,7 @@ func createScenario4(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 10000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -387,7 +389,7 @@ func createScenario5(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 6000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -449,7 +451,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 14000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -485,7 +487,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("utah", x, y, data.RaceDarkElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city2 := citylib.MakeCity("utah", x, y, data.RaceDarkElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city2.Population = 7000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingShrine
@@ -534,7 +536,7 @@ func createScenario7(cache *lbx.LbxCache) *gamelib.Game {
         x, y, _ := game.FindValidCityLocation(game.Plane)
         player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-        introCity := citylib.MakeCity(fmt.Sprintf("city%v", i), x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+        introCity := citylib.MakeCity(fmt.Sprintf("city%v", i), x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
         introCity.Population = rand.N(5000) + 5000
         introCity.Plane = data.PlaneArcanus
         introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -551,7 +553,7 @@ func createScenario7(cache *lbx.LbxCache) *gamelib.Game {
         x, y, _ := game.FindValidCityLocation(data.PlaneMyrror)
         player.LiftFog(x, y, 3, data.PlaneMyrror)
 
-        introCity := citylib.MakeCity(fmt.Sprintf("city%v myr", i), x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.GetMap(data.PlaneMyrror), game, player)
+        introCity := citylib.MakeCity(fmt.Sprintf("city%v myr", i), x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.GetMap(data.PlaneMyrror), game, player)
         introCity.Population = rand.N(5000) + 5000
         introCity.Plane = data.PlaneMyrror
         introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -606,7 +608,7 @@ func createScenario8(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -685,7 +687,7 @@ func createScenario9(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -760,7 +762,7 @@ func createScenario10(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -835,7 +837,7 @@ func createScenario11(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -904,7 +906,7 @@ func createScenario12(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1082,7 +1084,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1118,10 +1120,11 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     }
 
     enemy := game.AddPlayer(enemyWizard, false)
+    enemy.TaxRate = fraction.Make(1, 1)
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, enemy.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 14000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -1147,10 +1150,11 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     }
 
     enemy2 := game.AddPlayer(enemyWizard2, false)
+    enemy2.TaxRate = fraction.Make(1, 1)
 
     x2, y2, _ := game.FindValidCityLocation(game.Plane)
 
-    city3 := citylib.MakeCity("Test City", x2, y2, enemy2.Wizard.Race, enemy2.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city3 := citylib.MakeCity("Test City", x2, y2, enemy2.Wizard.Race, enemy2.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy2)
     city3.Population = 14000
     city3.Plane = data.PlaneArcanus
     city3.ProducingBuilding = buildinglib.BuildingHousing
@@ -1241,7 +1245,7 @@ func createScenario14(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1302,7 +1306,7 @@ func createScenario15(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 20190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1383,10 +1387,11 @@ func createScenario16(cache *lbx.LbxCache) *gamelib.Game {
     player := game.AddPlayer(wizard, true)
 
     player.Fame = 40
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1473,7 +1478,7 @@ func createScenario17(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1626,7 +1631,7 @@ func createScenario18(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 8190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1712,7 +1717,7 @@ func createScenario19(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1783,10 +1788,11 @@ func createScenario20(cache *lbx.LbxCache) *gamelib.Game {
     player := game.AddPlayer(wizard, true)
 
     player.Fame = 5
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1835,10 +1841,11 @@ func createScenario20(cache *lbx.LbxCache) *gamelib.Game {
     }
 
     enemy := game.AddPlayer(enemyWizard, false)
+    enemy.TaxRate = fraction.Make(1, 1)
 
     enemy.Gold = 5000
 
-    city2 := citylib.MakeCity("Test City", x, y-1, enemy.Wizard.Race, enemy.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x, y-1, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 14000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -1900,10 +1907,11 @@ func createScenario21(cache *lbx.LbxCache) *gamelib.Game {
     player := game.AddPlayer(wizard, true)
 
     player.Fame = 5
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -1948,12 +1956,13 @@ func createScenario21(cache *lbx.LbxCache) *gamelib.Game {
     }
 
     enemy := game.AddPlayer(enemyWizard, false)
+    enemy.TaxRate = fraction.Make(1, 1)
 
     enemy.AIBehavior = ai.MakeRaiderAI()
 
     x2, y2 := game.FindValidCityLocationOnContinent(game.Plane, city.X, city.Y)
     log.Printf("enemy city at %v, %v", x2, y2)
-    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, enemy.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 8000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -2018,7 +2027,7 @@ func createScenario22(cache *lbx.LbxCache) *gamelib.Game {
     // game.Map.CreateEncounter(x, y+1, maplib.EncounterTypeLair, game.Settings.Difficulty, false, game.Plane)
     game.CurrentMap().CreateEncounterRandom(x, y+1, game.Settings.Difficulty, game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2087,10 +2096,11 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
     player := game.AddPlayer(wizard, true)
 
     player.Fame = 5
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2171,10 +2181,11 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
     enemy.PactWithPlayer(enemy4)
 
     enemy.AIBehavior = ai.MakeRaiderAI()
+    enemy.TaxRate = fraction.Make(1, 1)
 
     x2, y2 := game.FindValidCityLocationOnContinent(game.Plane, city.X, city.Y)
     log.Printf("enemy city at %v, %v", x2, y2)
-    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, enemy.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 8000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -2235,7 +2246,7 @@ func createScenario24(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2310,7 +2321,7 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 26
     player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2376,7 +2387,7 @@ func createScenario26(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 26
     player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2438,6 +2449,7 @@ func createScenario27(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     player := game.AddPlayer(wizard, true)
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
@@ -2446,7 +2458,7 @@ func createScenario27(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10000
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2540,7 +2552,7 @@ func createScenario28(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2610,7 +2622,7 @@ func createScenario29(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 12190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2680,7 +2692,7 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 12190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2696,14 +2708,14 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
 
     x2, y2 := x + 3, y
 
-    city2 := citylib.MakeCity("City2", x2, y2, data.RaceHighElf, player.GetBanner(), player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city2 := citylib.MakeCity("City2", x2, y2, data.RaceHighElf, player.GetBanner(), game.BuildingInfo, game.CurrentMap(), game, player)
     city2.Plane = city.Plane
     city2.Population = 6000
     city2.ResetCitizens(nil)
 
     player.AddCity(city2)
 
-    city3 := citylib.MakeCity("City3", x + 1, y2+2, data.RaceHighElf, player.GetBanner(), player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city3 := citylib.MakeCity("City3", x + 1, y2+2, data.RaceHighElf, player.GetBanner(), game.BuildingInfo, game.CurrentMap(), game, player)
     city3.Plane = city.Plane
     city3.Population = 6000
     city3.ResetCitizens(nil)
@@ -2759,6 +2771,7 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
 
     player := game.AddPlayer(wizard, true)
     player.StrategicCombat = true
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
@@ -2767,7 +2780,7 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2858,6 +2871,7 @@ func createScenario32(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     player := game.AddPlayer(wizard, true)
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
@@ -2866,7 +2880,7 @@ func createScenario32(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -2962,10 +2976,11 @@ func createScenario33(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     player := game.AddPlayer(wizard, true)
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3031,7 +3046,7 @@ func createScenario34(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, player1.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player1)
+    city := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player1)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard1.Banner
@@ -3109,7 +3124,7 @@ func createScenario35(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, player1.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player1)
+    city := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player1)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard1.Banner
@@ -3185,7 +3200,7 @@ func createScenario36(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("ai1", x, y, data.RaceBarbarian, enemy1.Wizard.Banner, enemy1.TaxRate, game.BuildingInfo, game.CurrentMap(), game, enemy1)
+    city := citylib.MakeCity("ai1", x, y, data.RaceBarbarian, enemy1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy1)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard1.Banner
@@ -3274,7 +3289,7 @@ func createScenario38(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city1 := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, player1.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player1)
+    city1 := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player1)
     city1.Population = 6190
     city1.Plane = data.PlaneArcanus
     city1.Banner = wizard1.Banner
@@ -3343,6 +3358,7 @@ func createScenario39(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     player := game.AddPlayer(wizard, true)
+    player.TaxRate = fraction.Make(3, 1)
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
@@ -3351,7 +3367,7 @@ func createScenario39(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Make(3, 1), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6300
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3433,7 +3449,7 @@ func createScenario40(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3496,7 +3512,7 @@ func createScenario41(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 1000
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3552,7 +3568,7 @@ func createScenario42(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3589,7 +3605,7 @@ func createScenario42(cache *lbx.LbxCache) *gamelib.Game {
 
     ex, ey, _ := game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("Test City", ex, ey, data.RaceHighElf, enemy1.Wizard.Banner, enemy1.TaxRate, game.BuildingInfo, game.CurrentMap(), game, enemy1)
+    city2 := citylib.MakeCity("Test City", ex, ey, data.RaceHighElf, enemy1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy1)
     city2.Population = 20000
     city2.Plane = data.PlaneArcanus
     city2.Banner = enemy1.Wizard.Banner
@@ -3662,7 +3678,7 @@ func createScenario43(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10000
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3746,7 +3762,7 @@ func createScenario44(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3833,7 +3849,7 @@ func createScenario45(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner
@@ -3874,7 +3890,7 @@ func createScenario45(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("enemy city", x, y, enemy1.Wizard.Race, enemy1.Wizard.Banner, enemy1.TaxRate, game.BuildingInfo, game.CurrentMap(), game, enemy1)
+    city2 := citylib.MakeCity("enemy city", x, y, enemy1.Wizard.Race, enemy1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy1)
     city2.Population = 16190
     city2.Plane = data.PlaneArcanus
     city2.Banner = enemy1.Wizard.Banner

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -3922,10 +3922,9 @@ func createScenario46(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingNone
     city.ProducingUnit = units.TrollSpearmen
@@ -3993,10 +3992,9 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, player.TaxRate, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -4027,10 +4025,11 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
     }
 
     enemy := game.AddPlayer(enemyWizard, false)
+    enemy.TaxRate = fraction.Make(1, 1)
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, enemy.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 14000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -4061,10 +4060,11 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
     }
 
     enemy2 := game.AddPlayer(enemyWizard2, false)
+    enemy2.TaxRate = fraction.Make(1, 1)
 
     x2, y2, _ := game.FindValidCityLocation(game.Plane)
 
-    city3 := citylib.MakeCity("Test City", x2, y2, enemy2.Wizard.Race, enemy2.Wizard.Banner, fraction.Make(1, 1), game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city3 := citylib.MakeCity("Test City", x2, y2, enemy2.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy2)
     city3.Population = 14000
     city3.Plane = data.PlaneArcanus
     city3.ProducingBuilding = buildinglib.BuildingHousing

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -99,10 +99,9 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
@@ -180,7 +179,7 @@ func createScenario2(cache *lbx.LbxCache) *gamelib.Game {
 
     player := game.AddPlayer(wizard, true)
 
-    introCity := citylib.MakeCity("Test City", 4, 5, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", 4, 5, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 6000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -238,7 +237,7 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, player.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 9000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -309,7 +308,7 @@ func createScenario4(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 10000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -389,7 +388,7 @@ func createScenario5(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 6000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -451,7 +450,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    introCity := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     introCity.Population = 14000
     introCity.Plane = data.PlaneArcanus
     introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -487,7 +486,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("utah", x, y, data.RaceDarkElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city2 := citylib.MakeCity("utah", x, y, data.RaceDarkElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city2.Population = 7000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingShrine
@@ -536,7 +535,7 @@ func createScenario7(cache *lbx.LbxCache) *gamelib.Game {
         x, y, _ := game.FindValidCityLocation(game.Plane)
         player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-        introCity := citylib.MakeCity(fmt.Sprintf("city%v", i), x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+        introCity := citylib.MakeCity(fmt.Sprintf("city%v", i), x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
         introCity.Population = rand.N(5000) + 5000
         introCity.Plane = data.PlaneArcanus
         introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -553,7 +552,7 @@ func createScenario7(cache *lbx.LbxCache) *gamelib.Game {
         x, y, _ := game.FindValidCityLocation(data.PlaneMyrror)
         player.LiftFog(x, y, 3, data.PlaneMyrror)
 
-        introCity := citylib.MakeCity(fmt.Sprintf("city%v myr", i), x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.GetMap(data.PlaneMyrror), game, player)
+        introCity := citylib.MakeCity(fmt.Sprintf("city%v myr", i), x, y, data.RaceHighElf, game.BuildingInfo, game.GetMap(data.PlaneMyrror), game, player)
         introCity.Population = rand.N(5000) + 5000
         introCity.Plane = data.PlaneMyrror
         introCity.ProducingBuilding = buildinglib.BuildingHousing
@@ -608,10 +607,9 @@ func createScenario8(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -687,10 +685,9 @@ func createScenario9(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -762,10 +759,9 @@ func createScenario10(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -837,10 +833,9 @@ func createScenario11(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -906,10 +901,9 @@ func createScenario12(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -1084,10 +1078,9 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -1124,7 +1117,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 14000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -1154,7 +1147,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     x2, y2, _ := game.FindValidCityLocation(game.Plane)
 
-    city3 := citylib.MakeCity("Test City", x2, y2, enemy2.Wizard.Race, enemy2.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy2)
+    city3 := citylib.MakeCity("Test City", x2, y2, enemy2.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy2)
     city3.Population = 14000
     city3.Plane = data.PlaneArcanus
     city3.ProducingBuilding = buildinglib.BuildingHousing
@@ -1245,10 +1238,9 @@ func createScenario14(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -1306,10 +1298,9 @@ func createScenario15(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 20190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingGranary)
     city.Buildings.Insert(buildinglib.BuildingFarmersMarket)
     city.Buildings.Insert(buildinglib.BuildingForestersGuild)
@@ -1391,10 +1382,9 @@ func createScenario16(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingWizardsGuild)
     city.ProducingBuilding = buildinglib.BuildingGranary
@@ -1478,10 +1468,9 @@ func createScenario17(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.AddBuilding(buildinglib.BuildingFortress)
@@ -1631,10 +1620,9 @@ func createScenario18(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 8190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -1717,10 +1705,9 @@ func createScenario19(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -1792,10 +1779,9 @@ func createScenario20(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingWizardsGuild)
     city.ProducingBuilding = buildinglib.BuildingGranary
@@ -1845,7 +1831,7 @@ func createScenario20(cache *lbx.LbxCache) *gamelib.Game {
 
     enemy.Gold = 5000
 
-    city2 := citylib.MakeCity("Test City", x, y-1, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x, y-1, enemy.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 14000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -1911,10 +1897,9 @@ func createScenario21(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingWizardsGuild)
     city.ProducingBuilding = buildinglib.BuildingGranary
@@ -1962,7 +1947,7 @@ func createScenario21(cache *lbx.LbxCache) *gamelib.Game {
 
     x2, y2 := game.FindValidCityLocationOnContinent(game.Plane, city.X, city.Y)
     log.Printf("enemy city at %v, %v", x2, y2)
-    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 8000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -2027,10 +2012,9 @@ func createScenario22(cache *lbx.LbxCache) *gamelib.Game {
     // game.Map.CreateEncounter(x, y+1, maplib.EncounterTypeLair, game.Settings.Difficulty, false, game.Plane)
     game.CurrentMap().CreateEncounterRandom(x, y+1, game.Settings.Difficulty, game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -2100,10 +2084,9 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingWizardsGuild)
     city.ProducingBuilding = buildinglib.BuildingGranary
@@ -2185,7 +2168,7 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
 
     x2, y2 := game.FindValidCityLocationOnContinent(game.Plane, city.X, city.Y)
     log.Printf("enemy city at %v, %v", x2, y2)
-    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, enemy.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city2 := citylib.MakeCity("Test City", x2, y2, enemy.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy)
     city2.Population = 8000
     city2.Plane = data.PlaneArcanus
     city2.ProducingBuilding = buildinglib.BuildingHousing
@@ -2246,10 +2229,9 @@ func createScenario24(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -2321,10 +2303,9 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 26
     player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -2387,10 +2368,9 @@ func createScenario26(cache *lbx.LbxCache) *gamelib.Game {
     player.Mana = 26
     player.LiftFog(x, y, 3, data.PlaneArcanus)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -2458,10 +2438,9 @@ func createScenario27(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10000
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingGranary)
     city.Buildings.Insert(buildinglib.BuildingFarmersMarket)
     city.Buildings.Insert(buildinglib.BuildingForestersGuild)
@@ -2552,10 +2531,9 @@ func createScenario28(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -2622,10 +2600,9 @@ func createScenario29(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 12190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Buildings.Insert(buildinglib.BuildingFarmersMarket)
@@ -2692,10 +2669,9 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 12190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -2708,14 +2684,14 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
 
     x2, y2 := x + 3, y
 
-    city2 := citylib.MakeCity("City2", x2, y2, data.RaceHighElf, player.GetBanner(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city2 := citylib.MakeCity("City2", x2, y2, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city2.Plane = city.Plane
     city2.Population = 6000
     city2.ResetCitizens(nil)
 
     player.AddCity(city2)
 
-    city3 := citylib.MakeCity("City3", x + 1, y2+2, data.RaceHighElf, player.GetBanner(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city3 := citylib.MakeCity("City3", x + 1, y2+2, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city3.Plane = city.Plane
     city3.Population = 6000
     city3.ResetCitizens(nil)
@@ -2780,10 +2756,9 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -2880,10 +2855,9 @@ func createScenario32(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race
@@ -2980,10 +2954,9 @@ func createScenario33(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingTradeGoods
     city.ProducingUnit = units.UnitNone
     city.Buildings.Insert(buildinglib.BuildingGranary)
@@ -3046,10 +3019,9 @@ func createScenario34(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player1)
+    city := citylib.MakeCity("", x, y, data.RaceBarbarian, game.BuildingInfo, game.CurrentMap(), game, player1)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard1.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard1.Race
@@ -3124,10 +3096,9 @@ func createScenario35(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player1)
+    city := citylib.MakeCity("", x, y, data.RaceBarbarian, game.BuildingInfo, game.CurrentMap(), game, player1)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard1.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard1.Race
@@ -3200,10 +3171,9 @@ func createScenario36(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("ai1", x, y, data.RaceBarbarian, enemy1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy1)
+    city := citylib.MakeCity("ai1", x, y, data.RaceBarbarian, game.BuildingInfo, game.CurrentMap(), game, enemy1)
     city.Population = 10190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard1.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingTradeGoods
@@ -3289,10 +3259,9 @@ func createScenario38(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city1 := citylib.MakeCity("", x, y, data.RaceBarbarian, player1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player1)
+    city1 := citylib.MakeCity("", x, y, data.RaceBarbarian, game.BuildingInfo, game.CurrentMap(), game, player1)
     city1.Population = 6190
     city1.Plane = data.PlaneArcanus
-    city1.Banner = wizard1.Banner
     city1.ProducingBuilding = buildinglib.BuildingGranary
     city1.ProducingUnit = units.UnitNone
     city1.Race = wizard1.Race
@@ -3367,10 +3336,9 @@ func createScenario39(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6300
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingFortress)
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
@@ -3449,10 +3417,9 @@ func createScenario40(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -3512,10 +3479,9 @@ func createScenario41(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 1000
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingUnit = units.TrollSettlers
     city.Production = float32(city.ProducingUnit.ProductionCost)
     city.Farmers = 1
@@ -3568,10 +3534,9 @@ func createScenario42(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 6190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -3605,10 +3570,9 @@ func createScenario42(cache *lbx.LbxCache) *gamelib.Game {
 
     ex, ey, _ := game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("Test City", ex, ey, data.RaceHighElf, enemy1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy1)
+    city2 := citylib.MakeCity("Test City", ex, ey, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, enemy1)
     city2.Population = 20000
     city2.Plane = data.PlaneArcanus
-    city2.Banner = enemy1.Wizard.Banner
     city2.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city2.ProducingBuilding = buildinglib.BuildingGranary
     city2.ProducingUnit = units.UnitNone
@@ -3678,10 +3642,9 @@ func createScenario43(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
-    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Erfurt", x, y, player.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 10000
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingUnit = units.UnitNone
     city.Production = float32(city.ProducingUnit.ProductionCost)
     city.AddBuilding(buildinglib.BuildingFortress)
@@ -3762,10 +3725,9 @@ func createScenario44(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -3849,10 +3811,9 @@ func createScenario45(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
@@ -3890,10 +3851,9 @@ func createScenario45(cache *lbx.LbxCache) *gamelib.Game {
 
     x, y, _ = game.FindValidCityLocation(game.Plane)
 
-    city2 := citylib.MakeCity("enemy city", x, y, enemy1.Wizard.Race, enemy1.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, enemy1)
+    city2 := citylib.MakeCity("enemy city", x, y, enemy1.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy1)
     city2.Population = 16190
     city2.Plane = data.PlaneArcanus
-    city2.Banner = enemy1.Wizard.Banner
     city2.Buildings.Insert(buildinglib.BuildingSummoningCircle)
     city2.ProducingBuilding = buildinglib.BuildingGranary
     city2.ProducingUnit = units.UnitNone

--- a/test/scale/main.go
+++ b/test/scale/main.go
@@ -76,10 +76,9 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
-    city.Banner = wizard.Banner
     city.ProducingBuilding = buildinglib.BuildingGranary
     city.ProducingUnit = units.UnitNone
     city.Race = wizard.Race

--- a/test/scale/main.go
+++ b/test/scale/main.go
@@ -67,6 +67,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     game.Plane = data.PlaneArcanus
 
     player := game.AddPlayer(wizard, true)
+    player.TaxRate = fraction.Zero()
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 
@@ -75,7 +76,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     y = 20
     */
 
-    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, fraction.Zero(), game.BuildingInfo, game.CurrentMap(), game, player)
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, player.Wizard.Banner, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
     city.Plane = data.PlaneArcanus
     city.Banner = wizard.Banner


### PR DESCRIPTION
Now that a city has a reference to a reign provider, some attributes can be moved to there... what do you think?