### PR TITLE
city: update unrest on enchantment changes

### DIFF
--- a/game/magic/ai/enemy.go
+++ b/game/magic/ai/enemy.go
@@ -300,12 +300,7 @@ func (ai *EnemyAI) PostUpdate(self *playerlib.Player, enemies []*playerlib.Playe
 func (ai *EnemyAI) NewTurn(player *playerlib.Player) {
     // make sure cities have enough farmers
     for _, city := range player.Cities {
-        stack := player.FindStack(city.X, city.Y, city.Plane)
-        var units []units.StackUnit
-        if stack != nil {
-            units = stack.Units()
-        }
-        city.ResetCitizens(units)
+        city.ResetCitizens()
     }
 
     // keep going as long as there is more food available

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -107,13 +107,18 @@ func (reign *NoReign) GetGlobalEnchantments() *set.Set[data.Enchantment] {
     return reign.GlobalEnchantments
 }
 
+func (reign *NoReign) GetUnits(x int, y int, plane data.Plane) []units.StackUnit {
+    return nil
+}
+
+
 func TestBasicCity(test *testing.T){
     reign := NoReign{TaxRate: fraction.Make(3, 2)}
     city := MakeCity("Test City", 10, 10, data.RaceHighMen, nil, &Catchment{Map: makeSimpleMap()}, &NoCities{}, &reign)
     city.Population = 6000
     city.Farmers = 6
     city.Workers = 0
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
     if city.Name != "Test City" {
         test.Error("City name is not correct")
     }
@@ -132,8 +137,8 @@ func TestBasicCity(test *testing.T){
         test.Errorf("Subsistence farmers should have been 3 but was %v", city.ComputeSubsistenceFarmers())
     }
 
-    if city.ComputeUnrest(nil) != 1 {
-        test.Errorf("Unrest should have been 1 but was %v", city.ComputeUnrest(nil))
+    if city.ComputeUnrest() != 1 {
+        test.Errorf("Unrest should have been 1 but was %v", city.ComputeUnrest())
     }
 
     if city.Rebels != 1 {
@@ -141,10 +146,10 @@ func TestBasicCity(test *testing.T){
     }
 
     reign.TaxRate = fraction.Make(3, 1)
-    city.UpdateUnrest(nil)
+    city.UpdateUnrest()
 
-    if city.ComputeUnrest(nil) != 4 {
-        test.Errorf("Unrest should have been 4 but was %v", city.ComputeUnrest(nil))
+    if city.ComputeUnrest() != 4 {
+        test.Errorf("Unrest should have been 4 but was %v", city.ComputeUnrest())
     }
 
     if city.Rebels != 3 {
@@ -202,13 +207,13 @@ func TestForeignTrade(test *testing.T){
     city1.Population = 6000
     city1.Farmers = 6
     city1.Workers = 0
-    city1.ResetCitizens(nil)
+    city1.ResetCitizens()
 
     city2 := MakeCity("Test City 2", 10, 10, data.RaceHighMen, nil, &Catchment{Map: makeSimpleMap()}, &connected, &NoReign{TaxRate: fraction.Make(3, 2)})
     city2.Population = 7000
     city2.Farmers = 7
     city2.Workers = 0
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     connected.Cities = []*City{city1, city2}
 
@@ -222,7 +227,7 @@ func TestForeignTrade(test *testing.T){
     city3.Population = 5000
     city3.Farmers = 5
     city3.Workers = 0
-    city3.ResetCitizens(nil)
+    city3.ResetCitizens()
 
     connected.Cities = []*City{city1, city2, city3}
 
@@ -256,8 +261,6 @@ func TestEnchantments(test *testing.T){
     city.BuildingInfo = make([]building.BuildingInfo, 35)
     city.AddBuilding(building.BuildingShrine)
 
-    stack := []units.StackUnit{}
-
     if city.FoodProductionRate() != 10 {
         // 5 * 2 farmer
         test.Errorf("City FoodProductionRate is not correct: %v", city.FoodProductionRate())
@@ -273,9 +276,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 1 {
+    if city.ComputeUnrest() != 1 {
         // 0.2 * 10 race - 1 shrine
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 15 {
@@ -306,9 +309,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 1 {
+    if city.ComputeUnrest() != 1 {
         // 0.2 * 10 race - 1 shrine
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 15 {
@@ -339,9 +342,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 1 {
+    if city.ComputeUnrest() != 1 {
         // 0.2 * 10 race - 1 shrine
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 15 {
@@ -372,9 +375,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 2 {
+    if city.ComputeUnrest() != 2 {
         // 0.2 * 10 race - 1 shrine + 1 cursed lands
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 15 {
@@ -405,9 +408,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 0 {
+    if city.ComputeUnrest() != 0 {
         // 0.2 * 10 race - 1 shrine + 1 cursed lands - 2 gaias blessing
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 85 {
@@ -438,9 +441,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 1 {
+    if city.ComputeUnrest() != 1 {
         // 0.2 * 10 race - 1 shrine + 1 cursed lands - 2 gaias blessing + 1 dark rituals
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 63 {
@@ -470,9 +473,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 0 {
+    if city.ComputeUnrest() != 0 {
         // 0 stream of life
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != 127 {
@@ -505,9 +508,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 3 {
+    if city.ComputeUnrest() != 3 {
         // (0.2 race + 0.25 famine) * 10 - 1 shrine + 1 cursed lands - 2 gaias blessing + 1 dark rituals
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != -250 {
@@ -538,9 +541,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 5 {
+    if city.ComputeUnrest() != 5 {
         // (0.2 race + 0.25 famine) * 10 - 1 shrine + 1 cursed lands - 2 gaias blessing + 1 dark rituals + 2 pestilence
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != -250 {
@@ -571,9 +574,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 6 {
+    if city.ComputeUnrest() != 6 {
         // (0.2 race + 0.25 famine) * 10 + 1 cursed lands - 2 gaias blessing + 1 dark rituals + 2 pestilence
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != -250 {
@@ -604,9 +607,9 @@ func TestEnchantments(test *testing.T){
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
     }
 
-    if city.ComputeUnrest(stack) != 5 {
+    if city.ComputeUnrest() != 5 {
         // (0.2 race + 0.25 famine) * 10 + 1 cursed lands - 2 gaias blessing + 1 dark rituals + 2 pestilence - 1 just cause
-        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest(stack))
+        test.Errorf("City ComputeUnrest is not correct: %v", city.ComputeUnrest())
     }
 
     if city.PopulationGrowthRate() != -250 {
@@ -673,7 +676,7 @@ func TestScenario1(test *testing.T) {
     city.AddBuilding(building.BuildingSmithy)
     city.AddBuilding(building.BuildingFortress)
     city.ProducingBuilding = building.BuildingHousing
-    // maybe add 2 units garrison and call city.ResetCitizens(nil)
+    // maybe add 2 units garrison and call city.ResetCitizens()
 
     // Food
     if city.FarmerFoodProduction(city.Farmers) != 6 {
@@ -735,7 +738,7 @@ func TestScenario2(test *testing.T) {
     city.AddBuilding(building.BuildingMarketplace)
     city.AddBuilding(building.BuildingMinersGuild)
     city.ProducingBuilding = building.BuildingTradeGoods
-    // maybe add 6 units garrison and call city.ResetCitizens(nil)
+    // maybe add 6 units garrison and call city.ResetCitizens()
 
     // Food
     if city.FarmerFoodProduction(city.Farmers) != 14 {

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -912,6 +912,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                     yes := func(){
                         defer ui.RemoveGroup(group)
                         cityScreen.City.CancelEnchantment(enchantment.Enchantment, enchantment.Owner)
+                        cityScreen.City.UpdateUnrest()
 
                         enchantmentBuildings := enchantmentBuildings()
                         building, ok := enchantmentBuildings[enchantment.Enchantment]
@@ -2475,6 +2476,7 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
                     if enchantment.Owner == player.GetBanner() {
                         yes := func(){
                             city.CancelEnchantment(enchantment.Enchantment, enchantment.Owner)
+                            city.UpdateUnrest()
                             setupUI()
                         }
 

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -357,6 +357,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 game.Events <- &GameEventCastGlobalEnchantment{Player: player, Enchantment: data.EnchantmentJustCause}
 
                 player.GlobalEnchantments.Insert(data.EnchantmentJustCause)
+                player.UpdateUnrest()
 
                 game.RefreshUI()
             }
@@ -1110,6 +1111,7 @@ func (game *Game) doCastCityEnchantment(yield coroutine.YieldFunc, tileX int, ti
     }
 
     chosenCity.AddEnchantment(enchantment, player.GetBanner())
+    chosenCity.UpdateUnrest()
 
     yield()
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3489,7 +3489,7 @@ func (game *Game) doMoveSelectedUnit(yield coroutine.YieldFunc, player *playerli
     // update unrest for new units in the city
     newCity := player.FindCity(stack.X(), stack.Y(), stack.Plane())
     if newCity != nil {
-        newCity.UpdateUnrest(stack.Units())
+        newCity.UpdateUnrest()
     }
 
     if stepsTaken > 0 {
@@ -4512,8 +4512,7 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
         for _, building := range cityBuildingLoss {
             zone.City.Buildings.Remove(building)
         }
-        // there cant be any units defending because they were all defeated
-        zone.City.ResetCitizens(nil)
+        zone.City.ResetCitizens()
     }
 
     // Show end screen
@@ -6502,7 +6501,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
     var removeCities []*citylib.City
 
     for _, city := range player.Cities {
-        cityEvents := city.DoNextTurn(player.GetUnits(city.X, city.Y, city.Plane), game.GetMap(city.Plane))
+        cityEvents := city.DoNextTurn(game.GetMap(city.Plane))
         for _, event := range cityEvents {
             switch event.(type) {
             case *citylib.CityEventPopulationGrowth:
@@ -6737,7 +6736,6 @@ func (game *Game) doCallTheVoid(city *citylib.City, player *playerlib.Player) (i
     city.Population -= killedCitizens * 1000
 
     stack := player.FindStack(city.X, city.Y, city.Plane)
-    var garrison []units.StackUnit
     killedUnits := 0
     if stack != nil {
         for _, unit := range stack.Units() {
@@ -6754,11 +6752,9 @@ func (game *Game) doCallTheVoid(city *citylib.City, player *playerlib.Player) (i
                 }
             }
         }
-
-        garrison = stack.Units()
     }
 
-    city.ResetCitizens(garrison)
+    city.ResetCitizens()
 
     mapUse := game.GetMap(city.Plane)
 
@@ -6789,12 +6785,7 @@ func ChangeCityOwner(city *citylib.City, owner *playerlib.Player, newOwner *play
     city.Buildings.Remove(buildinglib.BuildingFortress)
     city.Buildings.Remove(buildinglib.BuildingSummoningCircle)
 
-    var newUnits []units.StackUnit
-    stack := newOwner.FindStack(city.X, city.Y, city.Plane)
-    if stack != nil {
-        newUnits = stack.Units()
-    }
-    city.UpdateUnrest(newUnits)
+    city.UpdateUnrest()
 
     switch enchantmentChange {
         case ChangeCityKeepEnchantments:

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -72,12 +72,12 @@ func TestChangeCityOwner(test *testing.T){
 
     city := citylib.MakeCity("xyz", 1, 1, player1.Wizard.Race, nil, &NoCatchment{}, &NoServices{}, player1)
     city.Population = 6000
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
     city.AddBuilding(buildinglib.BuildingFortress)
     city.AddEnchantment(data.CityEnchantmentAltarOfBattle, player1.GetBanner())
     player1.AddCity(city)
 
-    if city.ComputeUnrest(nil) != 0 {
+    if city.ComputeUnrest() != 0 {
         test.Errorf("Unrest is unexpected")
     }
 
@@ -99,7 +99,7 @@ func TestChangeCityOwner(test *testing.T){
         test.Errorf("City still has the fortress")
     }
 
-    if city.ComputeUnrest(nil) != 3 {
+    if city.ComputeUnrest() != 3 {
         test.Errorf("Unrest is not updated")
     }
 

--- a/game/magic/magicview/view.go
+++ b/game/magic/magicview/view.go
@@ -903,6 +903,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                         }
                         yes := func(){
                             player.GlobalEnchantments.Remove(enchantment.Enchantment)
+                            player.UpdateUnrest()
                             setupEnchantments()
                             ui.RemoveGroup(group)
                         }

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -243,7 +243,7 @@ func initializePlayer(game *gamelib.Game, wizard setup.WizardCustom, isHuman boo
     introCity.ProducingUnit = units.UnitNone
     introCity.Farmers = 4
 
-    introCity.ResetCitizens(player.GetUnits(cityX, cityY, startingPlane))
+    introCity.ResetCitizens()
 
     player.AddCity(introCity)
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -607,8 +607,12 @@ func (player *Player) ManaPerTurn(power int, cityEnchantmentsProvider CityEnchan
 
 func (player *Player) UpdateTaxRate(rate fraction.Fraction){
     player.TaxRate = rate
+    player.UpdateUnrest()
+}
+
+func (player *Player) UpdateUnrest(){
     for _, city := range player.Cities {
-        city.UpdateUnrest(player.GetUnits(city.X, city.Y, city.Plane))
+        city.UpdateUnrest()
     }
 }
 

--- a/test/city-enchantment/main.go
+++ b/test/city-enchantment/main.go
@@ -104,7 +104,7 @@ func (engine *Engine) MakeUI() (*uilib.UI, context.Context, error) {
     city.Buildings.Insert(buildinglib.BuildingSawmill)
     city.Buildings.Insert(buildinglib.BuildingMechaniciansGuild)
     city.ProducingBuilding = buildinglib.BuildingHousing
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     city.AddEnchantment(data.CityEnchantmentWallOfFire, data.BannerRed)
 

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -7,6 +7,7 @@ import (
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/fraction"
+    "github.com/kazzmir/master-of-magic/lib/set"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
     "github.com/kazzmir/master-of-magic/game/magic/cityview"
@@ -30,7 +31,6 @@ type Engine struct {
     CityScreen *cityview.CityScreen
     ImageCache util.ImageCache
     Map *maplib.Map
-    Garrison []units.StackUnit
     Player *playerlib.Player
 }
 
@@ -72,6 +72,7 @@ func NewEngine() (*Engine, error) {
             },
         },
         TaxRate: fraction.Make(2, 1),
+        GlobalEnchantments: set.MakeSet[data.Enchantment](),
     }
 
     player.Gold = 500
@@ -126,7 +127,7 @@ func NewEngine() (*Engine, error) {
 
     city.ProducingBuilding = buildinglib.BuildingHousing
     // city.ProducingUnit = units.HighElfSpearmen
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
         // ProducingUnit: units.UnitNone,
 
     city.AddEnchantment(data.CityEnchantmentWallOfFire, data.BannerRed)
@@ -141,19 +142,16 @@ func NewEngine() (*Engine, error) {
     city.AddEnchantment(data.CityEnchantmentDarkRituals, data.BannerRed)
     city.AddEnchantment(data.CityEnchantmentEvilPresence, data.BannerGreen)
 
-    var garrison []units.StackUnit
     for i := 0; i < 2; i++ {
         unit := units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, city.X, city.Y, city.Plane, city.GetBanner(), player.MakeExperienceInfo())
         player.AddUnit(unit)
-        garrison = append(garrison, unit)
     }
     for i := 0; i < 4; i++ {
         unit := units.MakeOverworldUnitFromUnit(units.HighElfSwordsmen, city.X, city.Y, city.Plane, city.GetBanner(), player.MakeExperienceInfo())
         player.AddUnit(unit)
-        garrison = append(garrison, unit)
     }
 
-    city.UpdateUnrest(garrison)
+    city.UpdateUnrest()
 
     cityScreen := cityview.MakeCityScreen(cache, city, &player, buildinglib.BuildingWizardsGuild)
 
@@ -162,7 +160,6 @@ func NewEngine() (*Engine, error) {
         CityScreen: cityScreen,
         ImageCache: util.MakeImageCache(cache),
         Map: &gameMap,
-        Garrison: garrison,
         Player: &player,
     }, nil
 }
@@ -181,7 +178,7 @@ func (engine *Engine) toggleEnchantment(enchantment data.CityEnchantment) {
     } else {
         engine.CityScreen.City.AddEnchantment(enchantment, data.BannerBlue)
     }
-    engine.CityScreen.City.UpdateUnrest(engine.Garrison)
+    engine.CityScreen.City.UpdateUnrest()
     engine.CityScreen.UI = engine.CityScreen.MakeUI(buildinglib.BuildingNone)
 }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -110,7 +110,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -247,7 +247,7 @@ func createScenario3(cache *lbx.LbxCache) *gamelib.Game {
     introCity.AddBuilding(buildinglib.BuildingShrine)
     introCity.AddBuilding(buildinglib.BuildingGranary)
 
-    introCity.ResetCitizens(nil)
+    introCity.ResetCitizens()
 
     player.AddCity(introCity)
 
@@ -317,7 +317,7 @@ func createScenario4(cache *lbx.LbxCache) *gamelib.Game {
 
     introCity.AddBuilding(buildinglib.BuildingShrine)
 
-    introCity.ResetCitizens(nil)
+    introCity.ResetCitizens()
 
     player.AddCity(introCity)
 
@@ -396,7 +396,7 @@ func createScenario5(cache *lbx.LbxCache) *gamelib.Game {
 
     introCity.AddBuilding(buildinglib.BuildingShrine)
 
-    introCity.ResetCitizens(nil)
+    introCity.ResetCitizens()
 
     player.AddCity(introCity)
 
@@ -459,7 +459,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
 
     introCity.AddBuilding(buildinglib.BuildingShrine)
 
-    introCity.ResetCitizens(nil)
+    introCity.ResetCitizens()
 
     player.AddCity(introCity)
 
@@ -492,7 +492,7 @@ func createScenario6(cache *lbx.LbxCache) *gamelib.Game {
     city2.ProducingBuilding = buildinglib.BuildingShrine
     city2.ProducingUnit = units.UnitNone
 
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     player.AddCity(city2)
 
@@ -543,7 +543,7 @@ func createScenario7(cache *lbx.LbxCache) *gamelib.Game {
 
         introCity.AddBuilding(buildinglib.BuildingShrine)
 
-        introCity.ResetCitizens(nil)
+        introCity.ResetCitizens()
 
         player.AddCity(introCity)
     }
@@ -560,7 +560,7 @@ func createScenario7(cache *lbx.LbxCache) *gamelib.Game {
 
         introCity.AddBuilding(buildinglib.BuildingShrine)
 
-        introCity.ResetCitizens(nil)
+        introCity.ResetCitizens()
 
         player.AddCity(introCity)
     }
@@ -616,7 +616,7 @@ func createScenario8(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -694,7 +694,7 @@ func createScenario9(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -768,7 +768,7 @@ func createScenario10(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -842,7 +842,7 @@ func createScenario11(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -910,7 +910,7 @@ func createScenario12(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1098,7 +1098,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city.AddBuilding(buildinglib.BuildingShrine)
     city.AddBuilding(buildinglib.BuildingGranary)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1133,7 +1133,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city2.AddBuilding(buildinglib.BuildingBank)
     city2.Farmers = 10
     city2.Workers = 4
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
     enemy.AddCity(city2)
 
     enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y, data.PlaneArcanus, enemy.Wizard.Banner, enemy.MakeExperienceInfo()))
@@ -1163,7 +1163,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city3.AddBuilding(buildinglib.BuildingBank)
     city3.Farmers = 10
     city3.Workers = 4
-    city3.ResetCitizens(nil)
+    city3.ResetCitizens()
     city3.AddEnchantment(data.CityEnchantmentConsecration, enemy2.GetBanner())
     enemy2.AddCity(city3)
 
@@ -1253,7 +1253,7 @@ func createScenario14(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1318,7 +1318,7 @@ func createScenario15(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 20
     city.Workers = 0
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1399,7 +1399,7 @@ func createScenario16(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = city.Citizens() - 1
     city.Workers = 0
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1484,7 +1484,7 @@ func createScenario17(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1636,7 +1636,7 @@ func createScenario18(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 5
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1721,7 +1721,7 @@ func createScenario19(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1796,7 +1796,7 @@ func createScenario20(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = city.Citizens() - 1
     city.Workers = 0
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1855,7 +1855,7 @@ func createScenario20(cache *lbx.LbxCache) *gamelib.Game {
     city2.Workers = 2
     city2.Rebels = 1
 
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     for range 1 {
         // randomUnit := units.ChooseRandomUnit(enemy.Wizard.Race)
@@ -1914,7 +1914,7 @@ func createScenario21(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = city.Citizens() - 1
     city.Workers = 0
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -1963,7 +1963,7 @@ func createScenario21(cache *lbx.LbxCache) *gamelib.Game {
     city2.Buildings.Insert(buildinglib.BuildingSmithy)
     city2.Buildings.Insert(buildinglib.BuildingOracle)
 
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     city2.Farmers = 5
     city2.Workers = 2
@@ -2027,7 +2027,7 @@ func createScenario22(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2101,7 +2101,7 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = city.Citizens() - 1
     city.Workers = 0
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2184,7 +2184,7 @@ func createScenario23(cache *lbx.LbxCache) *gamelib.Game {
     city2.Buildings.Insert(buildinglib.BuildingSmithy)
     city2.Buildings.Insert(buildinglib.BuildingOracle)
 
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     city2.Farmers = 5
     city2.Workers = 2
@@ -2245,7 +2245,7 @@ func createScenario24(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 5
     city.Workers = 1
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2318,7 +2318,7 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     city.Race = wizard.Race
     city.Farmers = 5
     city.Workers = 1
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
     player.AddCity(city)
 
     player.AddHero(hero.MakeHero(units.MakeOverworldUnit(units.HeroGunther, 0, 0, data.PlaneArcanus), hero.HeroGunther, "Gunther"))
@@ -2383,7 +2383,7 @@ func createScenario26(cache *lbx.LbxCache) *gamelib.Game {
     city.Race = wizard.Race
     city.Farmers = 5
     city.Workers = 1
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
     player.AddCity(city)
 
     gunther := hero.MakeHero(units.MakeOverworldUnit(units.HeroGunther, 0, 0, data.PlaneArcanus), hero.HeroGunther, "Gunther")
@@ -2456,7 +2456,7 @@ func createScenario27(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 7
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2545,7 +2545,7 @@ func createScenario28(cache *lbx.LbxCache) *gamelib.Game {
     city.Race = wizard.Race
     city.Farmers = 10
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2684,7 +2684,7 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 9
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2693,14 +2693,14 @@ func createScenario30(cache *lbx.LbxCache) *gamelib.Game {
     city2 := citylib.MakeCity("City2", x2, y2, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city2.Plane = city.Plane
     city2.Population = 6000
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     player.AddCity(city2)
 
     city3 := citylib.MakeCity("City3", x + 1, y2+2, data.RaceHighElf, game.BuildingInfo, game.CurrentMap(), game, player)
     city3.Plane = city.Plane
     city3.Population = 6000
-    city3.ResetCitizens(nil)
+    city3.ResetCitizens()
 
     player.AddCity(city3)
 
@@ -2772,7 +2772,7 @@ func createScenario31(cache *lbx.LbxCache) *gamelib.Game {
     city.Workers = 3
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2871,7 +2871,7 @@ func createScenario32(cache *lbx.LbxCache) *gamelib.Game {
     city.Workers = 3
     city.Buildings.Insert(buildinglib.BuildingFortress)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -2972,7 +2972,7 @@ func createScenario33(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 13
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -3034,7 +3034,7 @@ func createScenario34(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player1.AddCity(city)
 
@@ -3111,7 +3111,7 @@ func createScenario35(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player1.AddCity(city)
 
@@ -3187,7 +3187,7 @@ func createScenario36(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 8
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     enemy1.AddCity(city)
 
@@ -3273,7 +3273,7 @@ func createScenario38(cache *lbx.LbxCache) *gamelib.Game {
     city1.Race = wizard1.Race
     city1.Farmers = 3
     city1.Workers = 3
-    city1.ResetCitizens(nil)
+    city1.ResetCitizens()
     player1.AddCity(city1)
     player1.LiftFog(x, y, 3, data.PlaneArcanus)
 
@@ -3354,7 +3354,7 @@ func createScenario39(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -3436,7 +3436,7 @@ func createScenario40(cache *lbx.LbxCache) *gamelib.Game {
     city.AddBuilding(buildinglib.BuildingShrine)
     city.AddBuilding(buildinglib.BuildingGranary)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -3491,7 +3491,7 @@ func createScenario41(cache *lbx.LbxCache) *gamelib.Game {
     city.ProducingUnit = units.TrollSettlers
     city.Production = float32(city.ProducingUnit.ProductionCost)
     city.Farmers = 1
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
     player.Gold = 1000
@@ -3554,7 +3554,7 @@ func createScenario42(cache *lbx.LbxCache) *gamelib.Game {
     city.AddBuilding(buildinglib.BuildingGranary)
     city.AddBuilding(buildinglib.BuildingOracle)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -3590,7 +3590,7 @@ func createScenario42(cache *lbx.LbxCache) *gamelib.Game {
     city2.AddBuilding(buildinglib.BuildingGranary)
     city2.AddBuilding(buildinglib.BuildingFarmersMarket)
 
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
 
     enemy1.AddCity(city2)
 
@@ -3657,7 +3657,7 @@ func createScenario43(cache *lbx.LbxCache) *gamelib.Game {
     city.AddBuilding(buildinglib.BuildingShrine)
     city.AddBuilding(buildinglib.BuildingTemple)
     city.Farmers = 1
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
     player.Gold = 1000
@@ -3762,8 +3762,7 @@ func createScenario44(cache *lbx.LbxCache) *gamelib.Game {
 
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.ShadowDemons, x-1, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
 
-    stack := player.FindStack(x, y, city.Plane)
-    city.ResetCitizens(stack.Units())
+    city.ResetCitizens()
 
     enemy1 := game.AddPlayer(setup.WizardCustom{
         Name: "dingus",
@@ -3843,7 +3842,7 @@ func createScenario45(cache *lbx.LbxCache) *gamelib.Game {
 
     player.LiftFog(x, y, 200, data.PlaneArcanus)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     enemy1 := game.AddPlayer(setup.WizardCustom{
         Name: "dingus",
@@ -3938,7 +3937,7 @@ func createScenario46(cache *lbx.LbxCache) *gamelib.Game {
     city.AddBuilding(buildinglib.BuildingFightersGuild)
     city.AddBuilding(buildinglib.BuildingWarCollege)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -4008,7 +4007,7 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
     city.AddBuilding(buildinglib.BuildingShrine)
     city.AddBuilding(buildinglib.BuildingGranary)
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 
@@ -4041,7 +4040,7 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
     city2.AddBuilding(buildinglib.BuildingBank)
     city2.Farmers = 10
     city2.Workers = 4
-    city2.ResetCitizens(nil)
+    city2.ResetCitizens()
     enemy.AddCity(city2)
 
     enemy1Unit := enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.MagicSpirit, x + 1, y + 1, data.PlaneArcanus, enemy.GetBanner(), enemy.MakeExperienceInfo()))
@@ -4076,7 +4075,7 @@ func createScenario47(cache *lbx.LbxCache) *gamelib.Game {
     city3.AddBuilding(buildinglib.BuildingBank)
     city3.Farmers = 10
     city3.Workers = 4
-    city3.ResetCitizens(nil)
+    city3.ResetCitizens()
     city3.AddEnchantment(data.CityEnchantmentConsecration, enemy2.GetBanner())
     enemy2.AddCity(city3)
 

--- a/test/scale/main.go
+++ b/test/scale/main.go
@@ -85,7 +85,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
     city.Farmers = 3
     city.Workers = 3
 
-    city.ResetCitizens(nil)
+    city.ResetCitizens()
 
     player.AddCity(city)
 


### PR DESCRIPTION
Update unrest when adding and/or removing city and/or global enchantments.

I also added (the already existing) `GetUnits` to `ReignProvider` so cities can query their garrison themselves.

@kazzmir What do you think? Anything I missed?