### PR TITLE
cast: add unrest from Armageddon and Great Wasting

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -82,7 +82,7 @@ type CityServicesProvider interface {
     BadMoonActive() bool
     PopulationBoomActive(city *City) bool
     PlagueActive(city *City) bool
-    GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment]
+    GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment]
 }
 
 type ReignProvider interface {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -82,6 +82,7 @@ type CityServicesProvider interface {
     BadMoonActive() bool
     PopulationBoomActive(city *City) bool
     PlagueActive(city *City) bool
+    GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment]
 }
 
 type ReignProvider interface {
@@ -1022,6 +1023,18 @@ func (city *City) ComputeUnrest() int {
 
     if city.HasEnchantment(data.CityEnchantmentDarkRituals) {
         unrestAbsolute += 1
+    }
+
+    for banner, enchantments := range city.CityServices.GetAllGlobalEnchantments() {
+        if banner != city.ReignProvider.GetBanner() {
+            if enchantments.Contains(data.EnchantmentGreatWasting) {
+                unrestAbsolute += 1
+            }
+
+            if enchantments.Contains(data.EnchantmentArmageddon) {
+                unrestAbsolute += 2
+            }
+        }
     }
 
     // capital race vs town race modifier

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -61,6 +61,11 @@ func (provider *NoCities) PlagueActive(city *City) bool {
     return false
 }
 
+func (provider *NoCities) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+    return enchantments
+}
+
 type NoReign struct {
     NumberOfBooks int
     TaxRate fraction.Fraction
@@ -195,6 +200,11 @@ func (provider *AllConnected) PopulationBoomActive(city *City) bool {
 
 func (provider *AllConnected) PlagueActive(city *City) bool {
     return false
+}
+
+func (provider *AllConnected) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+    return enchantments
 }
 
 func closeFloat(a float64, b float64) bool {

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -61,8 +61,8 @@ func (provider *NoCities) PlagueActive(city *City) bool {
     return false
 }
 
-func (provider *NoCities) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
-    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+func (provider *NoCities) GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]*set.Set[data.Enchantment])
     return enchantments
 }
 
@@ -202,8 +202,8 @@ func (provider *AllConnected) PlagueActive(city *City) bool {
     return false
 }
 
-func (provider *AllConnected) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
-    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+func (provider *AllConnected) GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]*set.Set[data.Enchantment])
     return enchantments
 }
 

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -365,6 +365,10 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 player.GlobalEnchantments.Insert(data.EnchantmentArmageddon)
 
+                for _, player := range game.Players {
+                    player.UpdateUnrest()
+                }
+
                 game.RefreshUI()
             }
         case "Great Wasting":
@@ -372,6 +376,10 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 game.Events <- &GameEventCastGlobalEnchantment{Player: player, Enchantment: data.EnchantmentGreatWasting}
 
                 player.GlobalEnchantments.Insert(data.EnchantmentGreatWasting)
+
+                for _, player := range game.Players {
+                    player.UpdateUnrest()
+                }
 
                 game.RefreshUI()
             }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6775,9 +6775,16 @@ func (game *Game) doArmageddon() {
                     for y := range mapObject.Map.Rows() {
                         point := data.PlanePoint{X: x, Y: y, Plane: mapObject.Plane}
                         tile := terrain.GetTile(mapObject.Map.Terrain[x][y])
-                        if !tile.IsWater() && !tile.IsRiver() && !mapObject.HasVolcano(x, y) && !mapObject.HasMagicNode(x, y) && !catchment.Contains(point) {
-                            points = append(points, point)
+                        if tile.IsWater() || tile.IsRiver() || mapObject.HasVolcano(x, y) || mapObject.HasMagicNode(x, y) || catchment.Contains(point) {
+                            continue
                         }
+
+                        city, _ := game.FindCity(x, y, mapObject.Plane)
+                        if city != nil && (city.HasEnchantment(data.CityEnchantmentConsecration) || city.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                            continue
+                        }
+
+                        points = append(points, point)
                     }
                 }
             }
@@ -6804,9 +6811,16 @@ func (game *Game) doGreatWasting() {
                     for y := range mapObject.Map.Rows() {
                         point := data.PlanePoint{X: x, Y: y, Plane: mapObject.Plane}
                         tile := terrain.GetTile(mapObject.Map.Terrain[x][y])
-                        if !tile.IsWater() && !tile.IsRiver() && !mapObject.HasCorruption(x, y) && !catchment.Contains(point) {
-                            points = append(points, point)
+                        if tile.IsWater() || tile.IsRiver() || mapObject.HasCorruption(x, y) || catchment.Contains(point) {
+                            continue
                         }
+
+                        city, _ := game.FindCity(x, y, mapObject.Plane)
+                        if city != nil && (city.HasEnchantment(data.CityEnchantmentConsecration) || city.HasEnchantment(data.CityEnchantmentChaosWard)) {
+                            continue
+                        }
+
+                        points = append(points, point)
                     }
                 }
             }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -7762,3 +7762,11 @@ func (game *Game) DrawGame(screen *ebiten.Image){
 
     game.HudUI.Draw(game.HudUI, screen)
 }
+
+func (game *Game) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+    for _, player := range game.Players {
+        enchantments[player.GetBanner()] = *player.GlobalEnchantments
+    }
+    return enchantments
+}

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5232,7 +5232,7 @@ func (game *Game) IsGlobalEnchantmentActive(enchantment data.Enchantment) bool {
     })
 }
 
-// Returns dispel chance against 250. 
+// Returns dispel chance against 250.
 // TargetSpellCost may be either a base cost or an effective cost (https://masterofmagic.fandom.com/wiki/Casting_Cost#Dispelling_Magic)
 // If checkTargetSpellOwnerRetorts is true, then Archmage and Mastery retorts will be taken into consideration for dispel resistance
 // FIXME: add Runemaster check here (it should increase the dispel strength)
@@ -7812,10 +7812,10 @@ func (game *Game) DrawGame(screen *ebiten.Image){
     game.HudUI.Draw(game.HudUI, screen)
 }
 
-func (game *Game) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
-    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+func (game *Game) GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]*set.Set[data.Enchantment])
     for _, player := range game.Players {
-        enchantments[player.GetBanner()] = *player.GlobalEnchantments
+        enchantments[player.GetBanner()] = player.GlobalEnchantments.Clone()
     }
     return enchantments
 }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6799,6 +6799,7 @@ func (game *Game) doCallTheVoid(city *citylib.City, player *playerlib.Player) (i
 
 // raises 4 to 6 volcanoes on random tiles
 func (game *Game) doArmageddon() {
+    info := game.ComputeCityStackInfo()
     for _, player := range game.Players {
         if player.GlobalEnchantments.Contains(data.EnchantmentArmageddon) {
             // get a list of valid map tiles on both planes
@@ -6814,7 +6815,7 @@ func (game *Game) doArmageddon() {
                             continue
                         }
 
-                        city, _ := game.FindCity(x, y, mapObject.Plane)
+                        city := info.FindCity(x, y, mapObject.Plane)
                         if city != nil && (city.HasEnchantment(data.CityEnchantmentConsecration) || city.HasEnchantment(data.CityEnchantmentChaosWard)) {
                             continue
                         }
@@ -6835,6 +6836,7 @@ func (game *Game) doArmageddon() {
 
 // corrupts 3-6 random tiles
 func (game *Game) doGreatWasting() {
+    info := game.ComputeCityStackInfo()
     for _, player := range game.Players {
         if player.GlobalEnchantments.Contains(data.EnchantmentGreatWasting) {
             // get a list of valid map tiles on both planes
@@ -6850,7 +6852,7 @@ func (game *Game) doGreatWasting() {
                             continue
                         }
 
-                        city, _ := game.FindCity(x, y, mapObject.Plane)
+                        city := info.FindCity(x, y, mapObject.Plane)
                         if city != nil && (city.HasEnchantment(data.CityEnchantmentConsecration) || city.HasEnchantment(data.CityEnchantmentChaosWard)) {
                             continue
                         }

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/lib/fraction"
+    "github.com/kazzmir/master-of-magic/lib/set"
 )
 
 func TestCityName(test *testing.T){
@@ -62,6 +63,11 @@ func (no *NoServices) PopulationBoomActive(city *citylib.City) bool {
 
 func (no *NoServices) PlagueActive(city *citylib.City) bool {
     return false
+}
+
+func (no *NoServices) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+    return enchantments
 }
 
 func TestChangeCityOwner(test *testing.T){

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -65,8 +65,8 @@ func (no *NoServices) PlagueActive(city *citylib.City) bool {
     return false
 }
 
-func (no *NoServices) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
-    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+func (no *NoServices) GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]*set.Set[data.Enchantment])
     return enchantments
 }
 

--- a/test/city-enchantment/main.go
+++ b/test/city-enchantment/main.go
@@ -53,8 +53,8 @@ func (provider *NoCityProvider) PlagueActive(city *citylib.City) bool {
     return false
 }
 
-func (provider *NoCityProvider) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
-    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+func (provider *NoCityProvider) GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]*set.Set[data.Enchantment])
     return enchantments
 }
 

--- a/test/city-enchantment/main.go
+++ b/test/city-enchantment/main.go
@@ -17,6 +17,7 @@ import (
     // "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/cityview"
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/set"
 
     "github.com/hajimehoshi/ebiten/v2"
     "github.com/hajimehoshi/ebiten/v2/inpututil"
@@ -50,6 +51,11 @@ func (provider *NoCityProvider) PopulationBoomActive(city *citylib.City) bool {
 
 func (provider *NoCityProvider) PlagueActive(city *citylib.City) bool {
     return false
+}
+
+func (provider *NoCityProvider) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+    return enchantments
 }
 
 func NewEngine() (*Engine, error) {

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -57,8 +57,8 @@ func (provider *NoCityProvider) PlagueActive(city *citylib.City) bool {
     return false
 }
 
-func (provider *NoCityProvider) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
-    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+func (provider *NoCityProvider) GetAllGlobalEnchantments() map[data.BannerType]*set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]*set.Set[data.Enchantment])
     return enchantments
 }
 

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -57,6 +57,11 @@ func (provider *NoCityProvider) PlagueActive(city *citylib.City) bool {
     return false
 }
 
+func (provider *NoCityProvider) GetAllGlobalEnchantments() map[data.BannerType]set.Set[data.Enchantment] {
+    enchantments := make(map[data.BannerType]set.Set[data.Enchantment])
+    return enchantments
+}
+
 func NewEngine() (*Engine, error) {
     cache := lbx.AutoCache()
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1152,6 +1152,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     enemy2 := game.AddPlayer(enemyWizard2, false)
     enemy2.TaxRate = fraction.Make(1, 1)
+    enemy2.Mana = 3000
 
     x2, y2, _ := game.FindValidCityLocation(game.Plane)
 


### PR DESCRIPTION
Armageddon and Great Wasting also adds unrest. I went with the [Code from 1.31](https://github.com/jbalcomb/ReMoM/blob/main/src/CITYCALC.C#L3282) + the indicated fixes:
- Armageddon adds +2 unrest per enemy enchantment
- Great Wasting adds +1 unrest per enemy enchtantment

I also add protection by Consecration and Chaos Ward for the city centers.

What do you think, does that make sense @kazzmir @sidav?