### PR TITLE
city: handle river/coast gold bonus

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -74,6 +74,7 @@ func (citySize CitySize) String() string {
 type CatchmentProvider interface {
     GetCatchmentArea(x int, y int) map[image.Point]maplib.FullTile
     OnShore(x int, y int) bool
+    ByRiver(x int, y int) bool
     TileDistance(x1 int, y1 int, x2 int, y2 int) int
 }
 
@@ -432,6 +433,10 @@ func (city *City) FameForCaptureOrRaze(captured bool) int {
 // true if the city is adjacent to a water tile
 func (city *City) OnShore() bool {
     return city.CatchmentProvider.OnShore(city.X, city.Y)
+}
+
+func (city *City) ByRiver() bool {
+    return city.CatchmentProvider.ByRiver(city.X, city.Y)
 }
 
 func (city *City) AddEnchantment(enchantment data.CityEnchantment, owner data.BannerType) {

--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -73,6 +73,7 @@ func (citySize CitySize) String() string {
 
 type CatchmentProvider interface {
     GetCatchmentArea(x int, y int) map[image.Point]maplib.FullTile
+    GetGoldBonus(x int, y int) int
     OnShore(x int, y int) bool
     ByRiver(x int, y int) bool
     TileDistance(x1 int, y1 int, x2 int, y2 int) int
@@ -1384,10 +1385,7 @@ func (city *City) ComputeTotalBonusPercent() float64 {
         percent += 50
     }
 
-    // FIXME: add river/shore bonus
-    // +10 if adjacent to a shore
-    // +20 if on a river
-    // +30 if on a river and adjacent to a shore, or on a river mouth
+    percent += float64(city.CatchmentProvider.GetGoldBonus(city.X, city.Y))
 
     return min(percent, float64(city.Citizens() * 3))
 }

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -38,6 +38,10 @@ func (catchment *Catchment) OnShore(x int, y int) bool {
     return false
 }
 
+func (catchment *Catchment) ByRiver(x int, y int) bool {
+    return false
+}
+
 func (catchment *Catchment) TileDistance(x1 int, y1 int, x2 int, y2 int) int {
     return 0
 }

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -34,6 +34,10 @@ func (catchment *Catchment) GetCatchmentArea(x int, y int) map[image.Point]mapli
     return catchment.Map
 }
 
+func (catchment *Catchment) GetGoldBonus(x int, y int) int {
+    return 0
+}
+
 func (catchment *Catchment) OnShore(x int, y int) bool {
     return false
 }

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -28,6 +28,7 @@ func makeSimpleMap() map[image.Point]maplib.FullTile {
 
 type Catchment struct {
     Map map[image.Point]maplib.FullTile
+    GoldBonus int
 }
 
 func (catchment *Catchment) GetCatchmentArea(x int, y int) map[image.Point]maplib.FullTile {
@@ -35,7 +36,7 @@ func (catchment *Catchment) GetCatchmentArea(x int, y int) map[image.Point]mapli
 }
 
 func (catchment *Catchment) GetGoldBonus(x int, y int) int {
-    return 0
+    return catchment.GoldBonus
 }
 
 func (catchment *Catchment) OnShore(x int, y int) bool {
@@ -689,7 +690,7 @@ func TestScenario1(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap(), GoldBonus: 30}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
     city.Population = 4600
     city.Farmers = 3
     city.Workers = 1
@@ -747,7 +748,7 @@ func TestScenario2(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap()}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap(), GoldBonus: 30}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
     city.Population = 10110
     city.Farmers = 7
     city.Workers = 3
@@ -803,8 +804,7 @@ func TestScenario2(test *testing.T) {
         test.Errorf("City GoldMinerals is not correct: %v", city.GoldMinerals())
     }
     if city.GoldBonus(city.ComputeTotalBonusPercent()) != 4 {
-        // see "FIXME: add river/shore bonus"
-        test.Logf("City GoldBonus is not correct: %v", city.GoldBonus(city.ComputeTotalBonusPercent()))
+        test.Errorf("City GoldBonus is not correct: %v", city.GoldBonus(city.ComputeTotalBonusPercent()))
     }
     if city.GoldMarketplace() != 7 {
         test.Errorf("City GoldMarketplace is not correct: %v", city.GoldMarketplace())

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1486,10 +1486,10 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
     onRiver := city.ByRiver()
     onShore := city.OnShore()
     switch {
-        case onRiver && onMyrror: spriteIndex = 115
-        case onRiver: spriteIndex = 3
         case onShore && onMyrror: spriteIndex = 116
         case onShore: spriteIndex = 4
+        case onRiver && onMyrror: spriteIndex = 115
+        case onRiver: spriteIndex = 3
     }
     if spriteIndex != -1 {
         river, err := imageCache.GetImages("cityscap.lbx", spriteIndex)

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1482,21 +1482,25 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
     }
 
     // river / shore
-    // FIXME: make this configurable
-    // FIXME: 4/116 is shore
-    spriteIndex = 3
-    if onMyrror {
-        spriteIndex = 115
+    spriteIndex = -1
+    onRiver := city.ByRiver()
+    onShore := city.OnShore()
+    switch {
+        case onRiver && onMyrror: spriteIndex = 115
+        case onRiver: spriteIndex = 3
+        case onShore && onMyrror: spriteIndex = 116
+        case onShore: spriteIndex = 4
     }
-
-    river, err := imageCache.GetImages("cityscap.lbx", spriteIndex)
-    if err == nil {
-        var options ebiten.DrawImageOptions
-        options.ColorScale.ScaleAlpha(alphaScale)
-        options.GeoM = baseGeoM
-        options.GeoM.Translate(float64(0 * data.ScreenScale), float64(-2 * data.ScreenScale))
-        index := animationCounter % uint64(len(river))
-        screen.DrawImage(river[index], &options)
+    if spriteIndex != -1 {
+        river, err := imageCache.GetImages("cityscap.lbx", spriteIndex)
+        if err == nil {
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(alphaScale)
+            options.GeoM = baseGeoM
+            options.GeoM.Translate(float64(0 * data.ScreenScale), float64(-2 * data.ScreenScale))
+            index := animationCounter % uint64(len(river))
+            screen.DrawImage(river[index], &options)
+        }
     }
 
     // buildings

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -39,6 +39,10 @@ func (no *NoCatchment) GetCatchmentArea(x int, y int) map[image.Point]maplib.Ful
     return make(map[image.Point]maplib.FullTile)
 }
 
+func (catchment *NoCatchment) GetGoldBonus(x int, y int) int {
+    return 0
+}
+
 func (no *NoCatchment) OnShore(x int, y int) bool {
     return false
 }

--- a/game/magic/game/game_test.go
+++ b/game/magic/game/game_test.go
@@ -43,6 +43,10 @@ func (no *NoCatchment) OnShore(x int, y int) bool {
     return false
 }
 
+func (no *NoCatchment) ByRiver(x int, y int) bool {
+    return false
+}
+
 func (no *NoCatchment) TileDistance(x1 int, y1 int, x2 int, y2 int) int {
     return 0
 }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -672,6 +672,19 @@ func (tile *FullTile) IsTouchingShore(mapObject *Map) bool {
     return false
 }
 
+func (tile *FullTile) IsByRiver(mapObject *Map) bool {
+    for dx := -1; dx <= 1; dx++ {
+        for dy := -1; dy <= 1; dy++ {
+            tile := mapObject.GetTile(tile.X + dx, tile.Y + dy)
+            if tile.Tile.IsRiver() {
+                return true
+            }
+        }
+    }
+
+    return false
+}
+
 func (tile *FullTile) GetBonus() data.BonusType {
     if tile.Corrupted() {
         return data.BonusNone
@@ -1328,6 +1341,11 @@ func (mapObject *Map) GetTileImage(tileX int, tileY int, animationCounter uint64
 func (mapObject *Map) OnShore(x int, y int) bool {
     tile := mapObject.GetTile(x, y)
     return tile.IsTouchingShore(mapObject)
+}
+
+func (mapObject *Map) ByRiver(x int, y int) bool {
+    tile := mapObject.GetTile(x, y)
+    return tile.IsByRiver(mapObject)
 }
 
 // Returns city catchment area (5x5 square minus the corners)

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -1348,6 +1348,11 @@ func (mapObject *Map) ByRiver(x int, y int) bool {
     return tile.IsByRiver(mapObject)
 }
 
+func (mapObject *Map) GetGoldBonus(x int, y int) int {
+    tile := mapObject.GetTile(x, y)
+    return tile.GoldBonus(mapObject)
+}
+
 // Returns city catchment area (5x5 square minus the corners)
 func (mapObject *Map) GetCatchmentArea(x int, y int) map[image.Point]FullTile {
 

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -624,8 +624,8 @@ func (tile *FullTile) GoldBonus(mapObject *Map) int {
 
     switch {
         case tile.IsRiverMouth(mapObject): return 30
-        case tile.IsTouchingShore(mapObject): return 10
         case tile.Tile.TerrainType() == terrain.River: return 20
+        case tile.IsTouchingShore(mapObject, false): return 10
     }
 
     return 0
@@ -652,13 +652,17 @@ func (tile *FullTile) ProductionBonus(hasGaiasBlessing bool) int {
 }
 
 func (tile *FullTile) IsRiverMouth(mapObject *Map) bool {
-    return tile.Tile.TerrainType() == terrain.River && tile.IsTouchingShore(mapObject)
+    return tile.Tile.TerrainType() == terrain.River && tile.IsTouchingShore(mapObject, true)
 }
 
-func (tile *FullTile) IsTouchingShore(mapObject *Map) bool {
+func (tile *FullTile) IsTouchingShore(mapObject *Map, cardinal bool) bool {
     for dx := -1; dx <= 1; dx++ {
         for dy := -1; dy <= 1; dy++ {
             if dx == 0 && dy == 0 {
+                continue
+            }
+
+            if cardinal && dx != 0 && dy != 0 {
                 continue
             }
 
@@ -1340,7 +1344,7 @@ func (mapObject *Map) GetTileImage(tileX int, tileY int, animationCounter uint64
 
 func (mapObject *Map) OnShore(x int, y int) bool {
     tile := mapObject.GetTile(x, y)
-    return tile.IsTouchingShore(mapObject)
+    return tile.IsTouchingShore(mapObject, false)
 }
 
 func (mapObject *Map) ByRiver(x int, y int) bool {

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -258,6 +258,10 @@ func (basic *BasicCatchment) GetCatchmentArea(x int, y int) map[image.Point]mapl
     return map[image.Point]maplib.FullTile{}
 }
 
+func (catchment *BasicCatchment) GetGoldBonus(x int, y int) int {
+    return 0
+}
+
 func (basic *BasicCatchment) OnShore(x int, y int) bool {
     return false
 }

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -262,6 +262,10 @@ func (basic *BasicCatchment) OnShore(x int, y int) bool {
     return false
 }
 
+func (basic *BasicCatchment) ByRiver(x int, y int) bool {
+    return false
+}
+
 func (basic *BasicCatchment) TileDistance(x1 int, y1 int, x2 int, y2 int) int {
     dx := x1 - x2
     dy := y1 - y2


### PR DESCRIPTION
Resolves some todos regarding rivers and coasts in cities:
- draws shore in city scape if nearby shore
- draws river in city scape if nearby or on top of river
- include gold bonus in city gold calculation (use the same as the surveyor already does)
- fix river mouths considering edge shore tiles