### PR TITLE
hero: include enchantments from artifacts. fix overworld move speed

### DIFF
--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -230,6 +230,21 @@ func (artifact *Artifact) HasAbility(ability data.AbilityType) bool {
     return false
 }
 
+func (artifact *Artifact) GetEnchantments() []data.UnitEnchantment {
+    var out []data.UnitEnchantment
+    for _, check := range artifact.Powers {
+        isAbility := check.Type == PowerTypeAbility1 || check.Type == PowerTypeAbility2 || check.Type == PowerTypeAbility3
+        if isAbility {
+            enchantment := check.Ability.Enchantment()
+            if enchantment != data.UnitEnchantmentNone {
+                out = append(out, enchantment)
+            }
+        }
+    }
+
+    return out
+}
+
 func (artifact *Artifact) AddPower(power Power) {
     artifact.Powers = append(artifact.Powers, power)
     slices.SortFunc(artifact.Powers, func (a, b Power) int {

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -598,7 +598,15 @@ func (hero *Hero) GetExperience() int {
 }
 
 func (hero *Hero) GetEnchantments() []data.UnitEnchantment {
-    return hero.Unit.GetEnchantments()
+    var artifactsEnchantments []data.UnitEnchantment
+
+    for _, item := range hero.Equipment {
+        if item != nil {
+            artifactsEnchantments = append(artifactsEnchantments, item.GetEnchantments()...)
+        }
+    }
+
+    return append(hero.Unit.GetEnchantments(), artifactsEnchantments...)
 }
 
 // note that HasEnchantment is not the same as contains(GetEnchantments(), enchantment) because HasEnchantment will search
@@ -741,7 +749,7 @@ func (hero *Hero) NaturalHeal(rate float64) {
 }
 
 func (hero *Hero) ResetMoves() {
-    hero.Unit.ResetMoves()
+    hero.Unit.MovesLeft = fraction.FromInt(hero.GetMovementSpeed())
 }
 
 func (hero *Hero) SetId(id uint64) {
@@ -892,7 +900,12 @@ func (hero *Hero) MovementSpeedEnchantmentBonus(base int, enchantments []data.Un
 func (hero *Hero) GetMovementSpeed() int {
     base := hero.Unit.GetBaseMovementSpeed()
 
-    // FIXME: include artifact enchantments
+    for _, item := range hero.Equipment {
+        if item != nil {
+            base += item.MovementBonus()
+        }
+    }
+
     return hero.Unit.MovementSpeedEnchantmentBonus(base, hero.GetEnchantments())
 }
 
@@ -1002,7 +1015,6 @@ func (hero *Hero) GetMeleeAttackPower() int {
         }
     }
 
-    // FIXME: include enchantments from artifacts
     for _, enchantment := range hero.GetEnchantments() {
         base += hero.MeleeEnchantmentBonus(enchantment)
     }
@@ -1084,7 +1096,6 @@ func (hero *Hero) GetRangedAttackPower() int {
         bonus += hero.GetAbilityRangedAttack()
     }
 
-    // FIXME: include enchantments from artifacts
     for _, enchantment := range hero.GetEnchantments() {
         base += hero.RangedEnchantmentBonus(enchantment)
     }
@@ -1125,7 +1136,6 @@ func (hero *Hero) GetDefense() int {
         }
     }
 
-    // FIXME: handle artifact enchantments
     for _, enchantment := range hero.GetEnchantments() {
         base += hero.DefenseEnchantmentBonus(enchantment)
     }
@@ -1341,7 +1351,6 @@ func (hero *Hero) GetResistance() int {
         }
     }
 
-    // FIXME: include artifact enchantments
     for _, enchantment := range hero.GetEnchantments() {
         base += hero.ResistanceEnchantmentBonus(enchantment)
     }
@@ -1360,7 +1369,6 @@ func (hero *Hero) HitPointsEnchantmentBonus(enchantment data.UnitEnchantment) in
 func (hero *Hero) GetHitPoints() int {
     base := hero.GetBaseHitPoints()
 
-    // FIXME: include artifact enchantments
     for _, enchantment := range hero.GetEnchantments() {
         base += hero.HitPointsEnchantmentBonus(enchantment)
     }

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -680,7 +680,7 @@ func (unit *OverworldUnit) NaturalHeal(rate float64) {
 }
 
 func (unit *OverworldUnit) ResetMoves() {
-    unit.MovesLeft = fraction.FromInt(unit.Unit.MovementSpeed)
+    unit.MovesLeft = fraction.FromInt(unit.GetMovementSpeed())
 }
 
 func (unit *OverworldUnit) HasMovesLeft() bool {

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1573,9 +1573,17 @@ func createScenario17(cache *lbx.LbxCache) *gamelib.Game {
             {
                 Type: artifact.PowerTypeAbility1,
                 Amount: 2,
+                Ability: data.ItemAbilityHaste,
+                Name: "Haste",
+            },
+            /*
+            {
+                Type: artifact.PowerTypeAbility1,
+                Amount: 2,
                 Ability: data.ItemAbilityFlaming,
                 Name: "Flaming",
             },
+            */
             /*
             {
                 Type: artifact.PowerTypeSpellCharges,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3d9a73d5-5d37-4b9c-b9d1-6a62f4ded631)

![image](https://github.com/user-attachments/assets/a253ba96-d7d6-4259-9849-26a8a2e5643d)

an item with Haste should provide the hero with the Haste enchantment, and apply the haste bonus to the movement points.