### PR TITLE
cast: add lycanthropy

### DIFF
--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1622,7 +1622,8 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
                 images, _ := imageCache.GetImages("cityscap.lbx", enchantment.Enchantment.LbxIndex())
                 index := animationCounter % uint64(len(images))
                 screen.DrawImage(images[index], &options)
-            case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity, data.CityEnchantmentConsecration:
+            case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity, data.CityEnchantmentConsecration,
+                data.CityEnchantmentInspirations:
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(alphaScale)
                 options.GeoM = baseGeoM

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -171,7 +171,7 @@ const (
     UnitEnchantmentBerserk
     UnitEnchantmentBlackChannels
     UnitEnchantmentWraithForm
-    UnitEnchantmentLycanthropie
+    UnitEnchantmentLycanthropy
 
     // curses
     UnitCurseConfusion
@@ -458,7 +458,7 @@ func (enchantment UnitEnchantment) LbxFile() string {
         case UnitEnchantmentBerserk: return "special2.lbx"
         case UnitEnchantmentBlackChannels: return "special.lbx"
         case UnitEnchantmentWraithForm: return "special.lbx"
-        case UnitEnchantmentLycanthropie: return "special.lbx"
+        case UnitEnchantmentLycanthropy: return "special.lbx"
 
         case UnitCurseConfusion: return "special2.lbx"
         case UnitCurseCreatureBinding: return "special.lbx"
@@ -550,7 +550,7 @@ func (enchantment UnitEnchantment) CastAnimationIndex() int {
         case UnitEnchantmentBerserk: return 4
         case UnitEnchantmentBlackChannels: return 4
         case UnitEnchantmentWraithForm: return 4
-        case UnitEnchantmentLycanthropie: return 4
+        case UnitEnchantmentLycanthropy: return 4
 
         // chaos
         case UnitEnchantmentImmolation: return 2

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -171,6 +171,7 @@ const (
     UnitEnchantmentBerserk
     UnitEnchantmentBlackChannels
     UnitEnchantmentWraithForm
+    UnitEnchantmentLycanthropie
 
     // curses
     UnitCurseConfusion
@@ -457,6 +458,7 @@ func (enchantment UnitEnchantment) LbxFile() string {
         case UnitEnchantmentBerserk: return "special2.lbx"
         case UnitEnchantmentBlackChannels: return "special.lbx"
         case UnitEnchantmentWraithForm: return "special.lbx"
+        case UnitEnchantmentLycanthropie: return "special.lbx"
 
         case UnitCurseConfusion: return "special2.lbx"
         case UnitCurseCreatureBinding: return "special.lbx"
@@ -548,6 +550,7 @@ func (enchantment UnitEnchantment) CastAnimationIndex() int {
         case UnitEnchantmentBerserk: return 4
         case UnitEnchantmentBlackChannels: return 4
         case UnitEnchantmentWraithForm: return 4
+        case UnitEnchantmentLycanthropie: return 4
 
         // chaos
         case UnitEnchantmentImmolation: return 2

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -46,6 +46,10 @@ const (
     LocationTypeDisenchant
 )
 
+type UnitEnchantmentCallback func (*units.OverworldUnit)
+
+func noUnitEnchantmentCallback(unit *units.OverworldUnit) {}
+
 type CityEnchantmentCallback func (*citylib.City) bool
 
 func noCityEnchantmentCallback(city *citylib.City) bool {
@@ -93,76 +97,78 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             UNIT ENCHANTMENTS
         */
         case "Bless":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBless)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBless, noUnitEnchantmentCallback)
         case "Heroism":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHeroism)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHeroism, noUnitEnchantmentCallback)
         case "Giant Strength":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGiantStrength)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGiantStrength, noUnitEnchantmentCallback)
         case "Lionheart":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLionHeart)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLionHeart, noUnitEnchantmentCallback)
         case "Immolation":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentImmolation)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentImmolation, noUnitEnchantmentCallback)
         case "Resist Elements":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistElements)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistElements, noUnitEnchantmentCallback)
         case "Resist Magic":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistMagic)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistMagic, noUnitEnchantmentCallback)
         case "Elemental Armor":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentElementalArmor)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentElementalArmor, noUnitEnchantmentCallback)
         case "Righteousness":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRighteousness)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRighteousness, noUnitEnchantmentCallback)
         case "Cloak of Fear":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentCloakOfFear)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentCloakOfFear, noUnitEnchantmentCallback)
         case "True Sight":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentTrueSight)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentTrueSight, noUnitEnchantmentCallback)
         case "Flight":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlight)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlight, noUnitEnchantmentCallback)
         case "Chaos Channels":
             choices := []data.UnitEnchantment{
                 data.UnitEnchantmentChaosChannelsDemonSkin,
                 data.UnitEnchantmentChaosChannelsDemonWings,
                 data.UnitEnchantmentChaosChannelsFireBreath,
             }
-            game.doCastUnitEnchantment(player, spell, choices[rand.N(len(choices))])
+            game.doCastUnitEnchantment(player, spell, choices[rand.N(len(choices))], noUnitEnchantmentCallback)
         case "Endurance":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEndurance)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEndurance, noUnitEnchantmentCallback)
         case "Holy Armor":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyArmor)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyArmor, noUnitEnchantmentCallback)
         case "Holy Weapon":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyWeapon)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyWeapon, noUnitEnchantmentCallback)
         case "Invulnerability":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvulnerability)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvulnerability, noUnitEnchantmentCallback)
         case "Planar Travel":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPlanarTravel)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPlanarTravel, noUnitEnchantmentCallback)
         case "Iron Skin":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentIronSkin)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentIronSkin, noUnitEnchantmentCallback)
         case "Path Finding":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPathFinding)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPathFinding, noUnitEnchantmentCallback)
         case "Regeneration":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRegeneration)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRegeneration, noUnitEnchantmentCallback)
         case "Stone Skin":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentStoneSkin)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentStoneSkin, noUnitEnchantmentCallback)
         case "Water Walking":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWaterWalking)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWaterWalking, noUnitEnchantmentCallback)
         case "Guardian Wind":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGuardianWind)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGuardianWind, noUnitEnchantmentCallback)
         // "Invisiblity" is a typo in the game in spelldat.lbx
         case "Invisiblity":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvisibility)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvisibility, noUnitEnchantmentCallback)
         case "Magic Immunity":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentMagicImmunity)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentMagicImmunity, noUnitEnchantmentCallback)
         case "Spell Lock":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentSpellLock)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentSpellLock, noUnitEnchantmentCallback)
         case "Wind Walking":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWindWalking)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWindWalking, noUnitEnchantmentCallback)
         case "Eldritch Weapon":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEldritchWeapon)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEldritchWeapon, noUnitEnchantmentCallback)
         case "Flame Blade":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade, noUnitEnchantmentCallback)
         case "Black Channels":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBlackChannels)
-            // FIXME: unit should become undead
+            after := func (unit *units.OverworldUnit) {
+                unit.Undead = true
+            }
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBlackChannels, after)
         case "Wraith Form":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm, noUnitEnchantmentCallback)
         case "Lycanthropy":
             game.doCastLycanthropy(player, spell)
 
@@ -573,7 +579,7 @@ func (game *Game) doDisenchantArea(yield coroutine.YieldFunc, player *playerlib.
     }
 }
 
-func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment) {
+func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment, after UnitEnchantmentCallback) {
     var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
     selected = func (yield coroutine.YieldFunc, tileX int, tileY int){
         game.doMoveCamera(yield, tileX, tileY)
@@ -594,6 +600,11 @@ func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellboo
 
         game.doCastOnMap(yield, tileX, tileY, enchantment.CastAnimationIndex(), false, spell.Sound, func (x int, y int, animationFrame int) {})
         unit.AddEnchantment(enchantment)
+
+        overworldUnit, ok := unit.(*units.OverworldUnit)
+        if ok {
+            after(overworldUnit)
+        }
 
         game.RefreshUI()
     }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -166,10 +166,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade)
         case "Black Channels":
             after := func (unit units.StackUnit) bool {
-                overworldUnit, ok := unit.(*units.OverworldUnit)
-                if ok {
-                    overworldUnit.Undead = true
-                }
+                unit.SetUndead()
                 return true
             }
             game.doCastUnitEnchantmentFull(player, spell, data.UnitEnchantmentBlackChannels, noUnitEnchantmentCallback, after)

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -552,9 +552,6 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             COMBAT INSTANTS
         */
 
-        // FIXME: lycanthropy selects a friendly unit
-        // Lycanthropy	Icon DeathDeath	Uncommon	180	--	5	400	6 Regenerating Icon Melee Normal Melee creatures replace a target friendly Normal Unit.
-
         default:
             log.Printf("Warning: casting unhandled spell '%v'", spell.Name)
     }
@@ -1575,20 +1572,20 @@ func (game *Game) doCastLycanthropy(player *playerlib.Player, spell spellbook.Sp
             return
         }
 
-        // FIXME: "Summoned units may not have cast Lycanthropy on them"
         if unit.GetRace() == data.RaceFantastic {
+            game.Events <- &GameEventNotice{Message: "Summoned units may not have cast Lycanthropy on them"}
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
             return
         }
 
-        // FIXME: "Heroes units may not have cast Lycanthropy on them"
         if unit.GetRace() == data.RaceHero {
+            game.Events <- &GameEventNotice{Message: "Heroes units may not have cast Lycanthropy on them"}
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
             return
         }
 
-        // FIXME: "Chaos channeled and Undead units may not have cast Lycanthropy on them"
         if unit.IsUndead() || unit.HasEnchantment(data.UnitEnchantmentBlackChannels) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsDemonSkin) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsDemonWings) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsFireBreath) {
+            game.Events <- &GameEventNotice{Message: "Chaos channeled and Undead units may not have cast Lycanthropy on them"}
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
             return
         }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -654,6 +654,12 @@ func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellboo
             return
         }
 
+        if unit.HasEnchantment(enchantment) {
+            game.Events <- &GameEventNotice{Message: fmt.Sprintf("That unit already has %v cast on it", spell.Name)}
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
+            return
+        }
+
         game.doCastOnMap(yield, tileX, tileY, enchantment.CastAnimationIndex(), false, spell.Sound, func (x int, y int, animationFrame int) {})
         unit.AddEnchantment(enchantment)
 

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -99,71 +99,71 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             UNIT ENCHANTMENTS
         */
         case "Bless":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBless, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBless)
         case "Heroism":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHeroism, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHeroism)
         case "Giant Strength":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGiantStrength, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGiantStrength)
         case "Lionheart":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLionHeart, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLionHeart)
         case "Immolation":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentImmolation, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentImmolation)
         case "Resist Elements":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistElements, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistElements)
         case "Resist Magic":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistMagic, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistMagic)
         case "Elemental Armor":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentElementalArmor, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentElementalArmor)
         case "Righteousness":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRighteousness, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRighteousness)
         case "Cloak of Fear":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentCloakOfFear, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentCloakOfFear)
         case "True Sight":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentTrueSight, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentTrueSight)
         case "Flight":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlight, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlight)
         case "Chaos Channels":
             choices := []data.UnitEnchantment{
                 data.UnitEnchantmentChaosChannelsDemonSkin,
                 data.UnitEnchantmentChaosChannelsDemonWings,
                 data.UnitEnchantmentChaosChannelsFireBreath,
             }
-            game.doCastUnitEnchantment(player, spell, choices[rand.N(len(choices))], noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, choices[rand.N(len(choices))])
         case "Endurance":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEndurance, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEndurance)
         case "Holy Armor":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyArmor, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyArmor)
         case "Holy Weapon":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyWeapon, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyWeapon)
         case "Invulnerability":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvulnerability, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvulnerability)
         case "Planar Travel":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPlanarTravel, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPlanarTravel)
         case "Iron Skin":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentIronSkin, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentIronSkin)
         case "Path Finding":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPathFinding, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPathFinding)
         case "Regeneration":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRegeneration, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRegeneration)
         case "Stone Skin":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentStoneSkin, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentStoneSkin)
         case "Water Walking":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWaterWalking, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWaterWalking)
         case "Guardian Wind":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGuardianWind, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGuardianWind)
         // "Invisiblity" is a typo in the game in spelldat.lbx
         case "Invisiblity":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvisibility, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvisibility)
         case "Magic Immunity":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentMagicImmunity, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentMagicImmunity)
         case "Spell Lock":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentSpellLock, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentSpellLock)
         case "Wind Walking":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWindWalking, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWindWalking)
         case "Eldritch Weapon":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEldritchWeapon, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEldritchWeapon)
         case "Flame Blade":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade)
         case "Black Channels":
             after := func (unit units.StackUnit) bool {
                 overworldUnit, ok := unit.(*units.OverworldUnit)
@@ -172,9 +172,9 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBlackChannels, noUnitEnchantmentCallback, after)
+            game.doCastUnitEnchantmentFull(player, spell, data.UnitEnchantmentBlackChannels, noUnitEnchantmentCallback, after)
         case "Wraith Form":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm)
         case "Lycanthropy":
             before := func (unit units.StackUnit) bool {
                 if unit.GetRace() == data.RaceFantastic {
@@ -205,7 +205,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLycanthropie, before, after)
+            game.doCastUnitEnchantmentFull(player, spell, data.UnitEnchantmentLycanthropie, before, after)
 
         /*
             TOWN ENCHANTMENTS
@@ -215,13 +215,13 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 Spell Ward
         */
         case "Astral Gate":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentAstralGate, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentAstralGate)
         case "Heavenly Light":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentHeavenlyLight, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentHeavenlyLight)
         case "Cloud of Shadow":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentCloudOfShadow, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentCloudOfShadow)
         case "Prosperity":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentProsperity, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentProsperity)
         case "Consecration":
             after := func (city *citylib.City) bool {
                 // Remove all the city curses from the targeted city on cast (https://masterofmagic.fandom.com/wiki/Consecration)
@@ -235,23 +235,23 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 )
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentConsecration, noCityEnchantmentCallback, after)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentConsecration, noCityEnchantmentCallback, after)
         case "Inspirations":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentInspirations, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentInspirations)
         case "Gaia's Blessing":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentGaiasBlessing, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentGaiasBlessing)
         case "Nature's Eye":
             after := func (city *citylib.City) bool {
                 player.UpdateFogVisibility()
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentNaturesEye, noCityEnchantmentCallback, after)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentNaturesEye, noCityEnchantmentCallback, after)
         case "Dark Rituals":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentDarkRituals, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentDarkRituals)
         case "Stream of Life":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentStreamOfLife, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentStreamOfLife)
         case "Altar of Battle":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentAltarOfBattle, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentAltarOfBattle)
         case "Wall of Stone":
             before := func (city *citylib.City) bool {
                 city.AddBuilding(building.BuildingCityWalls)
@@ -264,11 +264,11 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCityNoWalls, data.CityEnchantmentWallOfStone, before, after)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeFriendlyCityNoWalls, data.CityEnchantmentWallOfStone, before, after)
         case "Wall of Fire":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentWallOfFire, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentWallOfFire)
         case "Wall of Darkness":
-            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentWallOfDarkness, noCityEnchantmentCallback, noCityEnchantmentCallback)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentWallOfDarkness)
 
         /*
             TOWN CURSES
@@ -283,7 +283,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentCursedLands, before, noCityEnchantmentCallback)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeEnemyCity, data.CityEnchantmentCursedLands, before, noCityEnchantmentCallback)
         case "Famine":
             before := func (city *citylib.City) bool {
                 if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
@@ -292,7 +292,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentFamine, before, noCityEnchantmentCallback)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeEnemyCity, data.CityEnchantmentFamine, before, noCityEnchantmentCallback)
         case "Pestilence":
             before := func (city *citylib.City) bool {
                 if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
@@ -301,7 +301,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentPestilence, before, noCityEnchantmentCallback)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeEnemyCity, data.CityEnchantmentPestilence, before, noCityEnchantmentCallback)
         case "Evil Presence":
             before := func (city *citylib.City) bool {
                 if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
@@ -310,7 +310,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentEvilPresence, before, noCityEnchantmentCallback)
+            game.doCastCityEnchantmentFull(spell, player, LocationTypeEnemyCity, data.CityEnchantmentEvilPresence, before, noCityEnchantmentCallback)
 
 
         /*
@@ -614,7 +614,7 @@ func (game *Game) doDisenchantArea(yield coroutine.YieldFunc, player *playerlib.
     }
 }
 
-func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment, before UnitEnchantmentCallback, after UnitEnchantmentCallback) {
+func (game *Game) doCastUnitEnchantmentFull(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment, before UnitEnchantmentCallback, after UnitEnchantmentCallback) {
     var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
     selected = func (yield coroutine.YieldFunc, tileX int, tileY int){
         game.doMoveCamera(yield, tileX, tileY)
@@ -647,6 +647,10 @@ func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellboo
     }
 
     game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
+}
+
+func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment) {
+   game.doCastUnitEnchantmentFull(player, spell, enchantment, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
 }
 
 func (game *Game) doSelectUnit(yield coroutine.YieldFunc, player *playerlib.Player, stack *playerlib.UnitStack) units.StackUnit {
@@ -1130,7 +1134,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     return 0, 0, true
 }
 
-func (game *Game) doCastCityEnchantment(spell spellbook.Spell, player *playerlib.Player, locationType LocationType, enchantment data.CityEnchantment, before CityEnchantmentCallback, after CityEnchantmentCallback) {
+func (game *Game) doCastCityEnchantmentFull(spell spellbook.Spell, player *playerlib.Player, locationType LocationType, enchantment data.CityEnchantment, before CityEnchantmentCallback, after CityEnchantmentCallback) {
     var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
     selected = func (yield coroutine.YieldFunc, tileX int, tileY int) {
         // FIXME: Show this only for enemies if detect magic is active and the city is known to the human player
@@ -1167,6 +1171,10 @@ func (game *Game) doCastCityEnchantment(spell spellbook.Spell, player *playerlib
     }
 
     game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: locationType, SelectedFunc: selected}
+}
+
+func (game *Game) doCastCityEnchantment(spell spellbook.Spell, player *playerlib.Player, locationType LocationType, enchantment data.CityEnchantment) {
+    game.doCastCityEnchantmentFull(spell, player, locationType, enchantment, noCityEnchantmentCallback, noCityEnchantmentCallback)
 }
 
 type UpdateMapFunction func (tileX int, tileY int, animationFrame int)

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -194,7 +194,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                return true
             }
             after := func (unit units.StackUnit) bool {
-                unit.RemoveEnchantment(data.UnitEnchantmentLycanthropie)
+                unit.RemoveEnchantment(data.UnitEnchantmentLycanthropy)
                 overworldUnit, ok := unit.(*units.OverworldUnit)
                 if ok {
                     damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
@@ -205,7 +205,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastUnitEnchantmentFull(player, spell, data.UnitEnchantmentLycanthropie, before, after)
+            game.doCastUnitEnchantmentFull(player, spell, data.UnitEnchantmentLycanthropy, before, after)
 
         /*
             TOWN ENCHANTMENTS

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -194,6 +194,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                return true
             }
             after := func (unit units.StackUnit) bool {
+                unit.RemoveEnchantment(data.UnitEnchantmentLycanthropie)
                 overworldUnit, ok := unit.(*units.OverworldUnit)
                 if ok {
                     damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
@@ -204,7 +205,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 }
                 return true
             }
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm, before, after)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLycanthropie, before, after)
 
         /*
             TOWN ENCHANTMENTS

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -46,9 +46,11 @@ const (
     LocationTypeDisenchant
 )
 
-type UnitEnchantmentCallback func (*units.OverworldUnit)
+type UnitEnchantmentCallback func (units.StackUnit) bool
 
-func noUnitEnchantmentCallback(unit *units.OverworldUnit) {}
+func noUnitEnchantmentCallback(unit units.StackUnit) bool {
+    return true
+}
 
 type CityEnchantmentCallback func (*citylib.City) bool
 
@@ -97,80 +99,112 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             UNIT ENCHANTMENTS
         */
         case "Bless":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBless, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBless, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Heroism":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHeroism, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHeroism, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Giant Strength":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGiantStrength, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGiantStrength, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Lionheart":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLionHeart, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentLionHeart, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Immolation":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentImmolation, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentImmolation, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Resist Elements":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistElements, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistElements, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Resist Magic":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistMagic, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentResistMagic, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Elemental Armor":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentElementalArmor, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentElementalArmor, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Righteousness":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRighteousness, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRighteousness, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Cloak of Fear":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentCloakOfFear, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentCloakOfFear, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "True Sight":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentTrueSight, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentTrueSight, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Flight":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlight, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlight, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Chaos Channels":
             choices := []data.UnitEnchantment{
                 data.UnitEnchantmentChaosChannelsDemonSkin,
                 data.UnitEnchantmentChaosChannelsDemonWings,
                 data.UnitEnchantmentChaosChannelsFireBreath,
             }
-            game.doCastUnitEnchantment(player, spell, choices[rand.N(len(choices))], noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, choices[rand.N(len(choices))], noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Endurance":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEndurance, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEndurance, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Holy Armor":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyArmor, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyArmor, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Holy Weapon":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyWeapon, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentHolyWeapon, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Invulnerability":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvulnerability, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvulnerability, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Planar Travel":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPlanarTravel, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPlanarTravel, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Iron Skin":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentIronSkin, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentIronSkin, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Path Finding":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPathFinding, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentPathFinding, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Regeneration":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRegeneration, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentRegeneration, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Stone Skin":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentStoneSkin, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentStoneSkin, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Water Walking":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWaterWalking, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWaterWalking, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Guardian Wind":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGuardianWind, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentGuardianWind, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         // "Invisiblity" is a typo in the game in spelldat.lbx
         case "Invisiblity":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvisibility, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentInvisibility, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Magic Immunity":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentMagicImmunity, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentMagicImmunity, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Spell Lock":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentSpellLock, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentSpellLock, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Wind Walking":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWindWalking, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWindWalking, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Eldritch Weapon":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEldritchWeapon, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentEldritchWeapon, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Flame Blade":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentFlameBlade, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Black Channels":
-            after := func (unit *units.OverworldUnit) {
-                unit.Undead = true
+            after := func (unit units.StackUnit) bool {
+                overworldUnit, ok := unit.(*units.OverworldUnit)
+                if ok {
+                    overworldUnit.Undead = true
+                }
+                return true
             }
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBlackChannels, after)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentBlackChannels, noUnitEnchantmentCallback, after)
         case "Wraith Form":
-            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm, noUnitEnchantmentCallback)
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm, noUnitEnchantmentCallback, noUnitEnchantmentCallback)
         case "Lycanthropy":
-            game.doCastLycanthropy(player, spell)
+            before := func (unit units.StackUnit) bool {
+                if unit.GetRace() == data.RaceFantastic {
+                    game.Events <- &GameEventNotice{Message: "Summoned units may not have cast Lycanthropy on them"}
+                    return false
+                }
+
+                if unit.GetRace() == data.RaceHero {
+                    game.Events <- &GameEventNotice{Message: "Heroes units may not have cast Lycanthropy on them"}
+                    return false
+                }
+
+                if unit.IsUndead() || unit.HasEnchantment(data.UnitEnchantmentBlackChannels) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsDemonSkin) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsDemonWings) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsFireBreath) {
+                    game.Events <- &GameEventNotice{Message: "Chaos channeled and Undead units may not have cast Lycanthropy on them"}
+                    return false
+                }
+               return true
+            }
+            after := func (unit units.StackUnit) bool {
+                overworldUnit, ok := unit.(*units.OverworldUnit)
+                if ok {
+                    damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
+                    overworldUnit.Unit = units.WereWolf
+                    overworldUnit.Health = overworldUnit.GetMaxHealth() - damage
+                    overworldUnit.Experience = 0
+                    // unit keeps weapon bonus and enchantments
+                }
+                return true
+            }
+            game.doCastUnitEnchantment(player, spell, data.UnitEnchantmentWraithForm, before, after)
 
         /*
             TOWN ENCHANTMENTS
@@ -579,7 +613,7 @@ func (game *Game) doDisenchantArea(yield coroutine.YieldFunc, player *playerlib.
     }
 }
 
-func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment, after UnitEnchantmentCallback) {
+func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellbook.Spell, enchantment data.UnitEnchantment, before UnitEnchantmentCallback, after UnitEnchantmentCallback) {
     var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
     selected = func (yield coroutine.YieldFunc, tileX int, tileY int){
         game.doMoveCamera(yield, tileX, tileY)
@@ -598,13 +632,15 @@ func (game *Game) doCastUnitEnchantment(player *playerlib.Player, spell spellboo
             return
         }
 
+        if !before(unit) {
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
+            return
+        }
+
         game.doCastOnMap(yield, tileX, tileY, enchantment.CastAnimationIndex(), false, spell.Sound, func (x int, y int, animationFrame int) {})
         unit.AddEnchantment(enchantment)
 
-        overworldUnit, ok := unit.(*units.OverworldUnit)
-        if ok {
-            after(overworldUnit)
-        }
+        after(unit)
 
         game.RefreshUI()
     }
@@ -1521,54 +1557,4 @@ func (game *Game) doCastFloatingIsland(yield coroutine.YieldFunc, player *player
     }
 
     game.doCastOnMap(yield, tileX, tileY, 1, false, 29, update)
-}
-
-func (game *Game) doCastLycanthropy(player *playerlib.Player, spell spellbook.Spell,) {
-    var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
-    selected = func (yield coroutine.YieldFunc, tileX int, tileY int){
-        game.doMoveCamera(yield, tileX, tileY)
-        stack := player.FindStack(tileX, tileY, game.Plane)
-        unit := game.doSelectUnit(yield, player, stack)
-
-        ok := true
-
-        // player didn't select a unit, let them pick a different stack
-        if unit == nil {
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
-            return
-        }
-
-        if unit.GetRace() == data.RaceFantastic {
-            game.Events <- &GameEventNotice{Message: "Summoned units may not have cast Lycanthropy on them"}
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
-            return
-        }
-
-        if unit.GetRace() == data.RaceHero {
-            game.Events <- &GameEventNotice{Message: "Heroes units may not have cast Lycanthropy on them"}
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
-            return
-        }
-
-        if unit.IsUndead() || unit.HasEnchantment(data.UnitEnchantmentBlackChannels) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsDemonSkin) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsDemonWings) || unit.HasEnchantment(data.UnitEnchantmentChaosChannelsFireBreath) {
-            game.Events <- &GameEventNotice{Message: "Chaos channeled and Undead units may not have cast Lycanthropy on them"}
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
-            return
-        }
-
-        // FIXME: sound
-        game.doCastOnMap(yield, tileX, tileY, 4, false, 10, func (x int, y int, animationFrame int) {})
-        overworldUnit, ok := unit.(*units.OverworldUnit)
-        if ok {
-            damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
-            overworldUnit.Unit = units.WereWolf
-            overworldUnit.Health = overworldUnit.GetMaxHealth() - damage
-            overworldUnit.Experience = 0
-            // unit keeps weapon bonus and enchantments
-        }
-
-        game.RefreshUI()
-    }
-
-    game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyUnit, SelectedFunc: selected}
 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -46,6 +46,12 @@ const (
     LocationTypeDisenchant
 )
 
+type CityEnchantmentCallback func (*citylib.City) bool
+
+func noCityEnchantmentCallback(city *citylib.City) bool {
+    return true
+}
+
 func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
     // FIXME: if the player is AI then invoke some callback that the AI will use to select targets instead of using the GameEventSelectLocationForSpell
 
@@ -168,149 +174,103 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 Spell Ward
         */
         case "Astral Gate":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentAstralGate)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
-
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentAstralGate, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Heavenly Light":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentHeavenlyLight)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
-
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentHeavenlyLight, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Cloud of Shadow":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentCloudOfShadow)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
-
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentCloudOfShadow, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Prosperity":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentProsperity)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentProsperity, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Consecration":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-                if chosenCity == nil {
-                    return
-                }
+            after := func (city *citylib.City) bool {
                 // Remove all the city curses from the targeted city on cast (https://masterofmagic.fandom.com/wiki/Consecration)
                 // Wiki specifies only the following ones as city curses
-                chosenCity.RemoveEnchantments(
+                city.RemoveEnchantments(
                     data.CityEnchantmentChaosRift,
                     data.CityEnchantmentCursedLands,
                     data.CityEnchantmentEvilPresence,
                     data.CityEnchantmentFamine,
                     data.CityEnchantmentPestilence,
                 )
-
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentConsecration)
+                return true
             }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentConsecration, noCityEnchantmentCallback, after)
         case "Inspirations":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentInspirations)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentInspirations, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Gaia's Blessing":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentGaiasBlessing)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentGaiasBlessing, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Nature's Eye":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentNaturesEye)
+            after := func (city *citylib.City) bool {
                 player.UpdateFogVisibility()
+                return true
             }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentNaturesEye, noCityEnchantmentCallback, after)
         case "Dark Rituals":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentDarkRituals)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentDarkRituals, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Stream of Life":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentStreamOfLife)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentStreamOfLife, noCityEnchantmentCallback, noCityEnchantmentCallback)
         case "Altar of Battle":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentAltarOfBattle)
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentAltarOfBattle, noCityEnchantmentCallback, noCityEnchantmentCallback)
+        case "Wall of Stone":
+            before := func (city *citylib.City) bool {
+                city.AddBuilding(building.BuildingCityWalls)
+                return true
             }
+            after := func (city *citylib.City) bool {
+                city.RemoveEnchantments(data.CityEnchantmentWallOfStone)
+                if city.ProducingBuilding == building.BuildingCityWalls {
+                    city.ProducingBuilding = building.BuildingTradeGoods
+                }
+                return true
+            }
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCityNoWalls, data.CityEnchantmentWallOfStone, before, after)
+        case "Wall of Fire":
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentWallOfFire, noCityEnchantmentCallback, noCityEnchantmentCallback)
+        case "Wall of Darkness":
+            game.doCastCityEnchantment(spell, player, LocationTypeFriendlyCity, data.CityEnchantmentWallOfDarkness, noCityEnchantmentCallback, noCityEnchantmentCallback)
 
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
         /*
             TOWN CURSES
                 TODO:
                 Chaos Rift
         */
         case "Cursed Lands":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-
-                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-
-                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
+            before := func (city *citylib.City) bool {
+                if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
-                    return
+                    return false
                 }
-
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentCursedLands)
+                return true
             }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentCursedLands, before, noCityEnchantmentCallback)
         case "Famine":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-
-                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-
-                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
+            before := func (city *citylib.City) bool {
+                if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
-                    return
+                    return false
                 }
-
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentFamine)
+                return true
             }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentFamine, before, noCityEnchantmentCallback)
         case "Pestilence":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-
-                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-
-                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
+            before := func (city *citylib.City) bool {
+                if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
-                    return
+                    return false
                 }
-
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentPestilence)
+                return true
             }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
+            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentPestilence, before, noCityEnchantmentCallback)
         case "Evil Presence":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-
-                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-                if chosenCity.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
+            before := func (city *citylib.City) bool {
+                if city.HasAnyOfEnchantments(data.CityEnchantmentConsecration, data.CityEnchantmentDeathWard) {
                     game.ShowFizzleSpell(spell, player)
-                    return
+                    return false
                 }
-
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentEvilPresence)
+                return true
             }
+            game.doCastCityEnchantment(spell, player, LocationTypeEnemyCity, data.CityEnchantmentEvilPresence, before, noCityEnchantmentCallback)
 
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeEnemyCity, SelectedFunc: selected}
 
         /*
             GLOBAL ENCHANTMENTS
@@ -448,34 +408,6 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             }
 
             game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeAny, SelectedFunc: selected}
-        case "Wall of Stone":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-                if chosenCity == nil {
-                    return
-                }
-
-                chosenCity.AddBuilding(building.BuildingCityWalls)
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentWallOfStone)
-                chosenCity.RemoveEnchantments(data.CityEnchantmentWallOfStone)
-                if chosenCity.ProducingBuilding == building.BuildingCityWalls {
-                    chosenCity.ProducingBuilding = building.BuildingTradeGoods
-                }
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCityNoWalls, SelectedFunc: selected}
-        case "Wall of Fire":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentWallOfFire)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
-        case "Wall of Darkness":
-            selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
-                game.doCastCityEnchantment(yield, tileX, tileY, player, data.CityEnchantmentWallOfDarkness)
-            }
-
-            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: LocationTypeFriendlyCity, SelectedFunc: selected}
         case "Call the Void":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 chosenCity, owner := game.FindCity(tileX, tileY, game.Plane)
@@ -1150,26 +1082,43 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     return 0, 0, true
 }
 
-func (game *Game) doCastCityEnchantment(yield coroutine.YieldFunc, tileX int, tileY int, player *playerlib.Player, enchantment data.CityEnchantment) {
-    // FIXME: Show this only for enemies if detect magic is active and the city is known to the human player
-    game.doMoveCamera(yield, tileX, tileY)
-    chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
-    if chosenCity == nil {
-        return
+func (game *Game) doCastCityEnchantment(spell spellbook.Spell, player *playerlib.Player, locationType LocationType, enchantment data.CityEnchantment, before CityEnchantmentCallback, after CityEnchantmentCallback) {
+    var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
+    selected = func (yield coroutine.YieldFunc, tileX int, tileY int) {
+        // FIXME: Show this only for enemies if detect magic is active and the city is known to the human player
+        game.doMoveCamera(yield, tileX, tileY)
+        chosenCity, _ := game.FindCity(tileX, tileY, game.Plane)
+        if chosenCity == nil {
+            return
+        }
+
+        if chosenCity.HasEnchantment(enchantment) {
+            game.Events <- &GameEventNotice{Message: fmt.Sprintf("This city already has a %v cast on it", spell.Name)}
+            game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: locationType, SelectedFunc: selected}
+            return
+        }
+
+        if !before(chosenCity) {
+            return
+        }
+
+        chosenCity.AddEnchantment(enchantment, player.GetBanner())
+        chosenCity.UpdateUnrest()
+
+        yield()
+
+        sound, err := audio.LoadSound(game.Cache, enchantment.SoundIndex())
+        if err == nil {
+            sound.Play()
+        }
+
+        game.showCityEnchantment(yield, chosenCity, player, enchantment)
+        game.RefreshUI()
+
+        after(chosenCity)
     }
 
-    chosenCity.AddEnchantment(enchantment, player.GetBanner())
-    chosenCity.UpdateUnrest()
-
-    yield()
-
-    sound, err := audio.LoadSound(game.Cache, enchantment.SoundIndex())
-    if err == nil {
-        sound.Play()
-    }
-
-    game.showCityEnchantment(yield, chosenCity, player, enchantment)
-    game.RefreshUI()
+    game.Events <- &GameEventSelectLocationForSpell{Spell: spell, Player: player, LocationType: locationType, SelectedFunc: selected}
 }
 
 type UpdateMapFunction func (tileX int, tileY int, animationFrame int)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2565,11 +2565,6 @@ func (game *Game) maybeBuyFromMerchant(player *playerlib.Player) {
 // FIXME: add a "reason" of fizzling, like "Spell X was fizzled because of Y"
 func (game *Game) ShowFizzleSpell(spell spellbook.Spell, caster *playerlib.Player) {
     if caster.IsHuman() {
-        beep, err := audio.LoadSound(game.Cache, 0)
-        if err == nil {
-            beep.Play()
-        }
-
         game.Events <- &GameEventNotice{
             // FIXME: align this message with how dos mom does it
             Message: fmt.Sprintf("The spell %v has fizzled.", spell.Name),
@@ -2580,6 +2575,11 @@ func (game *Game) ShowFizzleSpell(spell spellbook.Spell, caster *playerlib.Playe
 /* show the given message in an error popup on the screen
  */
 func (game *Game) doNotice(yield coroutine.YieldFunc, message string) {
+    beep, err := audio.LoadSound(game.Cache, 0)
+    if err == nil {
+        beep.Play()
+    }
+
     quit := false
     game.HudUI.AddElement(uilib.MakeErrorElement(game.HudUI, game.Cache, &game.ImageCache, message, func(){
         quit = true

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -559,7 +559,11 @@ func (hero *Hero) CanTouchAttack(damage units.Damage) bool {
 }
 
 func (hero *Hero) IsUndead() bool {
-    return false
+    return hero.Unit.IsUndead()
+}
+
+func (hero *Hero) SetUndead() {
+    hero.Unit.SetUndead()
 }
 
 // heroes are never part of a magic realm (life, death, etc)

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -69,6 +69,10 @@ func (unit *OverworldUnit) IsUndead() bool {
     return unit.Undead
 }
 
+func (unit *OverworldUnit) SetUndead() {
+    unit.Undead = true
+}
+
 func (unit *OverworldUnit) GetAbilityValue(ability data.AbilityType) float32 {
     return unit.Unit.GetAbilityValue(ability)
 }

--- a/game/magic/units/stack-unit.go
+++ b/game/magic/units/stack-unit.go
@@ -39,6 +39,7 @@ type StackUnit interface {
     MovementSpeedEnchantmentBonus(int, []data.UnitEnchantment) int
 
     IsUndead() bool
+    SetUndead()
     GetBanner() data.BannerType
     SetBanner(data.BannerType)
     SetWeaponBonus(data.WeaponBonus)

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1086,6 +1086,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Flame Blade"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Black Channels"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Wraith Form"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Lycanthropy"))
 
     x, y, _ := game.FindValidCityLocation(game.Plane)
 


### PR DESCRIPTION
Lycanthropy
- keeps weapon bonus
- keeps damage
- resets experience
- cannot be cast on fantastic units, heroes or undead / black or chaos channeled units and will generate an error message while allowing to select another unit

I also
- added notices when trying to cast a unit or city enchantments on a unit / city which already contains the enchantment (it allows to select another unit / city)
- made black channeled units (irreversibly) undead
- changed showing a notice always playing the beep

For this PR, I have done some refactoring, mostly to allow the notices and to remove some code duplication:
- move `selected` to `doCastCityEnchantments` similar to `doCastUnitEnchantment`
- added `before` and `after` callbacks to `doCastCityEnchantments`
- added `before` and `after` callbacks to `doCastUnitEnchantment`


