### PR TITLE
city: surplus gold can be negative

### DIFF
--- a/game/magic/city/city.go
+++ b/game/magic/city/city.go
@@ -1441,10 +1441,6 @@ func (city *City) GoldSurplus() int {
 
     out := income - upkeepCosts
 
-    if out < 0 {
-        out = 0
-    }
-
     return out
 }
 

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -754,7 +754,13 @@ func TestScenario2(test *testing.T) {
     city.Population = 10110
     city.Farmers = 7
     city.Workers = 3
-    city.BuildingInfo = make([]building.BuildingInfo, 35)
+    city.BuildingInfo = make([]building.BuildingInfo, 40)
+
+    // set the buildings to have some upkeep cost
+    city.BuildingInfo[city.BuildingInfo.GetBuildingIndex(building.BuildingBarracks)].UpkeepGold = 3
+    city.BuildingInfo[city.BuildingInfo.GetBuildingIndex(building.BuildingBuildersHall)].UpkeepGold = 3
+    city.BuildingInfo[city.BuildingInfo.GetBuildingIndex(building.BuildingSmithy)].UpkeepGold = 3
+
     city.AddBuilding(building.BuildingBarracks)
     city.AddBuilding(building.BuildingBuildersHall)
     city.AddBuilding(building.BuildingSmithy)
@@ -823,7 +829,9 @@ func TestScenario2(test *testing.T) {
         test.Logf("City PopulationGrowthRate is not correct: %v", city.PopulationGrowthRate())
     }
 
+    // with 0 tax and some building costs, surplus will be negative
     reign.TaxRate = fraction.Zero()
+    city.ProducingBuilding = building.BuildingHousing
 
     if city.GoldSurplus() != -2 {
         test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())

--- a/game/magic/city/city_test.go
+++ b/game/magic/city/city_test.go
@@ -748,10 +748,13 @@ func TestScenario2(test *testing.T) {
     // Test against values from a city screen of original MoM v1.60
 
     // City
-    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap(), GoldBonus: 30}, &NoCities{}, &NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)})
+    reign := NoReign{NumberOfBooks: 11, TaxRate: fraction.FromInt(1)}
+
+    city := MakeCity("Schleswig", 10, 10, data.RaceBarbarian, nil, &Catchment{Map: makeScenarioMap(), GoldBonus: 30}, &NoCities{}, &reign)
     city.Population = 10110
     city.Farmers = 7
     city.Workers = 3
+    city.BuildingInfo = make([]building.BuildingInfo, 35)
     city.AddBuilding(building.BuildingBarracks)
     city.AddBuilding(building.BuildingBuildersHall)
     city.AddBuilding(building.BuildingSmithy)
@@ -819,4 +822,11 @@ func TestScenario2(test *testing.T) {
         // Dos MoM seems to be doing this other than explained in the wiki
         test.Logf("City PopulationGrowthRate is not correct: %v", city.PopulationGrowthRate())
     }
+
+    reign.TaxRate = fraction.Zero()
+
+    if city.GoldSurplus() != -2 {
+        test.Errorf("City GoldSurplus is not correct: %v", city.GoldSurplus())
+    }
+
 }

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1694,12 +1694,14 @@ func (cityScreen *CityScreen) drawIcons(total int, small *ebiten.Image, large *e
         total = -total
     }
 
-    if total / 10 > 3 {
+    totalIcons := total / 10 + total % 10
+
+    if totalIcons > 3 {
         largeGap -= 1 * data.ScreenScale
     }
 
-    if total / 10 > 6 {
-        largeGap -= 5 * data.ScreenScale
+    if totalIcons > 5 {
+        largeGap -= 4 * data.ScreenScale
     }
 
     for range total / 10 {
@@ -1711,10 +1713,10 @@ func (cityScreen *CityScreen) drawIcons(total int, small *ebiten.Image, large *e
     }
 
     smallGap := small.Bounds().Dx() + 1
-    if total % 10 > 3 {
+    if totalIcons > 4 {
         smallGap -= 1 * data.ScreenScale
     }
-    if total % 10 >= 6 {
+    if totalIcons >= 8 {
         smallGap -= 1 * data.ScreenScale
     }
 

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -76,7 +76,8 @@ func NewEngine() (*Engine, error) {
                 data.RetortInfernalPower,
             },
         },
-        TaxRate: fraction.Make(2, 1),
+        // TaxRate: fraction.Make(2, 1),
+        TaxRate: fraction.Zero(),
         GlobalEnchantments: set.MakeSet[data.Enchantment](),
     }
 
@@ -111,10 +112,10 @@ func NewEngine() (*Engine, error) {
     city.AddBuilding(buildinglib.BuildingFortress)
     city.AddBuilding(buildinglib.BuildingGranary)
     city.AddBuilding(buildinglib.BuildingFarmersMarket)
-    city.AddBuilding(buildinglib.BuildingMarketplace)
+    // city.AddBuilding(buildinglib.BuildingMarketplace)
     city.AddBuilding(buildinglib.BuildingMinersGuild)
     city.AddBuilding(buildinglib.BuildingSawmill)
-    city.AddBuilding(buildinglib.BuildingMechaniciansGuild)
+    // city.AddBuilding(buildinglib.BuildingMechaniciansGuild)
     city.AddBuilding(buildinglib.BuildingBuildersHall)
     city.AddBuilding(buildinglib.BuildingCityWalls)
     city.AddBuilding(buildinglib.BuildingWizardsGuild)


### PR DESCRIPTION
negative net gold from a city makes the surplus icons show up in grey scale

![image](https://github.com/user-attachments/assets/3430799d-73b0-4549-9582-d5c06bf50ddf)
