### PR TITLE
cast: add eternal night

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1659,7 +1659,7 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
 
     // info
     elements = append(elements, makeButton(20, 0, 1, func(){
-        // FIXME
+        // FIXME: show enchantments such as "Eternal Night", "Cloud of Shadow", "Heavenly Light" etc.
     }))
 
     // auto

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1351,39 +1351,39 @@ func (combat *CombatScreen) InvokeSpell(player *playerlib.Player, spell spellboo
         combat instants:
 
         Dispel Magic
-        Raise Dead 
-        Petrify 
-        Call Chaos 	
+        Raise Dead
+        Petrify
+        Call Chaos
         Animate Dead
          */
 
         /*
         unit enchantments:
-        Heroism 
-        Holy Armor 
-        Holy Weapon 
+        Heroism
+        Holy Armor
+        Holy Weapon
         Invulnerability
-        Lionheart 	
+        Lionheart
         Righteousness
-        True Sight 	
+        True Sight
         Elemental Armor
-        Giant Strength 
-        Iron Skin 	
-        Regeneration 
-        Resist Elements 
-        Stone Skin 	
-        Flight 	
+        Giant Strength
+        Iron Skin
+        Regeneration
+        Resist Elements
+        Stone Skin
+        Flight
         Guardian Wind
-        Haste 	
+        Haste
         Invisibility
         Magic Immunity
-        Resist Magic 
-        Spell Lock 	
+        Resist Magic
+        Spell Lock
         Eldritch Weapon
-        Flame Blade 
-        Immolation 
-        Berserk 
-        Cloak of Fear 
+        Flame Blade
+        Immolation
+        Berserk
+        Cloak of Fear
         Wraith Form
          */
     }

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -2184,6 +2184,10 @@ func (model *CombatModel) AddGlobalEnchantment(enchantment data.CombatEnchantmen
 }
 
 func (model *CombatModel) AddEnchantment(player *playerlib.Player, enchantment data.CombatEnchantment) bool {
+    if slices.Contains(model.GlobalEnchantments, enchantment) {
+        return false
+    }
+
     if player == model.DefendingArmy.Player {
         return model.DefendingArmy.AddEnchantment(enchantment)
     } else {

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -325,7 +325,6 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 Chaos Surge
                 Doom Mastery
                 Meteor Storm
-                Eternal Night
                 Evil Omens
                 Zombie Mastery
         */
@@ -410,7 +409,14 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
                 game.RefreshUI()
             }
+        case "Eternal Night":
+            if !player.GlobalEnchantments.Contains(data.EnchantmentEternalNight) {
+                game.Events <- &GameEventCastGlobalEnchantment{Player: player, Enchantment: data.EnchantmentEternalNight}
 
+                player.GlobalEnchantments.Insert(data.EnchantmentEternalNight)
+
+                game.RefreshUI()
+            }
         /*
             INSTANT SPELLS
                 TODO:

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4413,6 +4413,13 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
         }
         if zone.City != nil && zone.City.HasEnchantment(data.CityEnchantmentCloudOfShadow) {
             combatScreen.Model.AddGlobalEnchantment(data.CombatEnchantmentDarkness)
+        } else {
+            for _, enchantments := range game.GetAllGlobalEnchantments() {
+                if enchantments.Contains(data.EnchantmentEternalNight) {
+                    combatScreen.Model.AddGlobalEnchantment(data.CombatEnchantmentDarkness)
+                    break
+                }
+            }
         }
 
         // ebiten.SetCursorMode(ebiten.CursorModeHidden)

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -373,13 +373,17 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Fire Elemental"))
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Bless"))
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Weakness"))
+    attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Darkness"))
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
     // attackingArmy := createWarlockArmyN(attackingPlayer, 3)
     attackingArmy := createArmyN(attackingPlayer, units.HighElfMagician, 3)
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
-    return combat.MakeCombatScreen(cache, &defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeGrass, data.PlaneArcanus, combat.ZoneType{}, 10, 25)
+    // return combat.MakeCombatScreen(cache, &defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeGrass, data.PlaneArcanus, combat.ZoneType{}, 10, 25)
+    combatScreen := combat.MakeCombatScreen(cache, &defendingArmy, attackingArmy, attackingPlayer, combat.CombatLandscapeGrass, data.PlaneArcanus, combat.ZoneType{}, 10, 25)
+    combatScreen.Model.AddGlobalEnchantment(data.CombatEnchantmentDarkness)
+    return combatScreen
 }
 
 func makeScenario2(cache *lbx.LbxCache) *combat.CombatScreen {

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1060,6 +1060,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Armageddon"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Great Wasting"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Detect Magic"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Eternal Night"))
 
     // unit enchantments
     player.KnownSpells.AddSpell(allSpells.FindByName("Bless"))

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1138,6 +1138,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     city2.AddBuilding(buildinglib.BuildingShrine)
     city2.AddBuilding(buildinglib.BuildingGranary)
     city2.AddBuilding(buildinglib.BuildingBank)
+    city2.AddEnchantment(data.CityEnchantmentCloudOfShadow, enemy.GetBanner())
     city2.Farmers = 10
     city2.Workers = 4
     city2.ResetCitizens()

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1113,7 +1113,7 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     player.LiftFog(x, y, 4, data.PlaneArcanus)
 
-    player.AddUnit(units.MakeOverworldUnitFromUnit(units.MagicSpirit, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.MagicSpirit, x, y + 1, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
 
     game.CurrentMap().SetRoad(x, y+1, false)
     game.CurrentMap().SetRoad(x, y+2, false)
@@ -1143,9 +1143,9 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     enemy.AddCity(city2)
 
     enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y, data.PlaneArcanus, enemy.Wizard.Banner, enemy.MakeExperienceInfo()))
-    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x + 2, y + 1, data.PlaneArcanus, enemy.Wizard.Banner, enemy.MakeExperienceInfo()))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y - 1, data.PlaneArcanus, enemy.Wizard.Banner, enemy.MakeExperienceInfo()))
 
-    player.AddUnit(units.MakeOverworldUnitFromUnit(units.DragonTurtle, x + 2, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.DragonTurtle, x, y - 2, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
     player.LiftFog(x, y, 2, data.PlaneArcanus)
 
     enemyWizard2 := setup.WizardCustom{


### PR DESCRIPTION
Adds the [Eternal Night](https://masterofmagic.fandom.com/wiki/Eternal_Night) global enchantment, which adds Darkness to battles if not already under the influence of Cloud of Shadow.

Not 100% sure what the wiki means with "protected" here:  "every battle that does not take place in a Town protected by Heavenly Light comes under an effect virtually identical to that of the Darkness spell". Since True Light negates Darkness and Eternal Night just adds Darkness I guess we should just add it and let Heavenly Light "protect" by negating the effects.

I also added a check to `AddEnchantment` since DOS MoM does not allow casting Darkness/True Light if is already preset as global enchantment.