### PR TITLE
graphics: use native ebiten scaling instead of upscaling images

### DIFF
--- a/game/magic/armyview/view.go
+++ b/game/magic/armyview/view.go
@@ -11,6 +11,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     fontslib "github.com/kazzmir/master-of-magic/game/magic/fonts"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -70,24 +71,24 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
         Draw: func(this *uilib.UI, screen *ebiten.Image) {
             background, _ := view.ImageCache.GetImage("armylist.lbx", 0, 0)
             var options ebiten.DrawImageOptions
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
-            fonts.BigFont.PrintCenter(screen, float64(160 * data.ScreenScale), float64(10 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("The Armies Of %v", view.Player.Wizard.Name))
+            fonts.BigFont.PrintCenter(screen, float64(160), float64(10), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("The Armies Of %v", view.Player.Wizard.Name))
 
             if highlightedUnit != nil {
                 raceName := highlightedUnit.GetRace().String()
-                fonts.NormalFont.PrintCenter(screen, float64(190 * data.ScreenScale), float64(162 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v %v", raceName, highlightedUnit.GetName()))
+                fonts.NormalFont.PrintCenter(screen, float64(190), float64(162), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v %v", raceName, highlightedUnit.GetName()))
 
             }
 
-            shadow := font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}
-            fonts.NormalFont.PrintOptions(screen, float64(30 * data.ScreenScale), float64(162 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, shadow, "UPKEEP")
-            fonts.NormalFont.PrintOptions(screen, float64(45 * data.ScreenScale), float64(172 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, shadow, fmt.Sprintf("%v", upkeepGold))
-            fonts.NormalFont.PrintOptions(screen, float64(45 * data.ScreenScale), float64(182 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, shadow, fmt.Sprintf("%v", upkeepMana))
-            fonts.NormalFont.PrintOptions(screen, float64(45 * data.ScreenScale), float64(192 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, shadow, fmt.Sprintf("%v", upkeepFood))
+            shadow := font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}
+            fonts.NormalFont.PrintOptions2(screen, float64(30), float64(162), shadow, "UPKEEP")
+            fonts.NormalFont.PrintOptions2(screen, float64(45), float64(172), shadow, fmt.Sprintf("%v", upkeepGold))
+            fonts.NormalFont.PrintOptions2(screen, float64(45), float64(182), shadow, fmt.Sprintf("%v", upkeepMana))
+            fonts.NormalFont.PrintOptions2(screen, float64(45), float64(192), shadow, fmt.Sprintf("%v", upkeepFood))
 
-            minimapRect := image.Rect(85 * data.ScreenScale, 163 * data.ScreenScale, 135 * data.ScreenScale, 197 * data.ScreenScale)
-            minimapArea := screen.SubImage(minimapRect).(*ebiten.Image)
+            minimapRect := image.Rect(85, 163, 135, 197)
+            minimapArea := screen.SubImage(scale.ScaleRect(minimapRect)).(*ebiten.Image)
 
             if highlightedUnit != nil {
                 view.DrawMinimap(minimapArea, highlightedUnit.GetX(), highlightedUnit.GetY(), view.Player.GetFog(highlightedUnit.GetPlane()), this.Counter)
@@ -128,7 +129,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
                 if clicked {
                     use = clickImage
                 }
-                screen.DrawImage(use, &options)
+                scale.DrawScaled(screen, use, &options)
             },
         }
     }
@@ -136,13 +137,13 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
     var resetUnits func()
 
     itemButtons, _ := view.ImageCache.GetImages("armylist.lbx", 3)
-    ui.AddElement(makeButton(273 * data.ScreenScale, 163 * data.ScreenScale, itemButtons[0], itemButtons[1], func(){
+    ui.AddElement(makeButton(273, 163, itemButtons[0], itemButtons[1], func(){
         view.ShowVault()
         resetUnits()
     }))
 
     okButtons, _ := view.ImageCache.GetImages("armylist.lbx", 4)
-    ui.AddElement(makeButton(273 * data.ScreenScale, 183 * data.ScreenScale, okButtons[0], okButtons[1], func(){
+    ui.AddElement(makeButton(273, 183, okButtons[0], okButtons[1], func(){
         view.State = ArmyScreenStateDone
     }))
 
@@ -161,11 +162,11 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
         }
     }
 
-    ui.AddElement(makeButton(60 * data.ScreenScale, 26 * data.ScreenScale, upArrows[0], upArrows[1], scrollUnitsUp))
-    ui.AddElement(makeButton(250 * data.ScreenScale, 26 * data.ScreenScale, upArrows[0], upArrows[1], scrollUnitsUp))
+    ui.AddElement(makeButton(60, 26, upArrows[0], upArrows[1], scrollUnitsUp))
+    ui.AddElement(makeButton(250, 26, upArrows[0], upArrows[1], scrollUnitsUp))
 
-    ui.AddElement(makeButton(60 * data.ScreenScale, 139 * data.ScreenScale, downArrows[0], downArrows[1], scrollUnitsDown))
-    ui.AddElement(makeButton(250 * data.ScreenScale, 139 * data.ScreenScale, downArrows[0], downArrows[1], scrollUnitsDown))
+    ui.AddElement(makeButton(60, 139, downArrows[0], downArrows[1], scrollUnitsDown))
+    ui.AddElement(makeButton(250, 139, downArrows[0], downArrows[1], scrollUnitsDown))
 
     highlightColor := util.PremultiplyAlpha(color.RGBA{R: 255, G: 255, B: 255, A: 90})
 
@@ -176,7 +177,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
         ui.RemoveElements(unitElements)
 
         // row := view.FirstRow
-        rowY := 25 * data.ScreenScale
+        rowY := 25
         rowCount := 0
 
         // recompute upkeep values
@@ -185,8 +186,8 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
         upkeepMana = view.Player.TotalUnitUpkeepMana()
 
         for i, hero := range view.Player.AliveHeroes() {
-            x := (12 + (i % 2) * 265) * data.ScreenScale
-            y := (5 + (i / 2) * 51) * data.ScreenScale
+            x := (12 + (i % 2) * 265)
+            y := (5 + (i / 2) * 51)
 
             portraitLbx, portraitIndex := hero.GetPortraitLbxInfo()
             pic, _ := view.ImageCache.GetImage(portraitLbx, portraitIndex, 0)
@@ -213,13 +214,13 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
                 Draw: func(this *uilib.UIElement, screen *ebiten.Image){
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(x), float64(y))
-                    screen.DrawImage(pic, &options)
+                    scale.DrawScaled(screen, pic, &options)
 
                     options.GeoM.Translate(0, float64(pic.Bounds().Dy()))
 
                     nameX, nameY := options.GeoM.Apply(0, 0)
 
-                    fonts.SmallerFont.PrintCenter(screen, nameX + float64(15 * data.ScreenScale), nameY + float64(6 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, hero.GetName())
+                    fonts.SmallerFont.PrintCenter(screen, nameX + float64(15), nameY + float64(6), float64(data.ScreenScale), options.ColorScale, hero.GetName())
                 },
             }
 
@@ -238,7 +239,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
                 continue
             }
 
-            x := 78 * data.ScreenScale
+            x := 78
 
             for _, unit := range stack.Units() {
                 elementX := float64(x)
@@ -269,10 +270,12 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
                             var options colorm.DrawImageOptions
                             var matrix colorm.ColorM
                             options.GeoM.Translate(elementX, elementY)
+                            options.GeoM.Scale(scale.ScaleAmount, scale.ScaleAmount)
 
                             if highlightedUnit == unit {
                                 x, y := options.GeoM.Apply(0, 0)
-                                vector.DrawFilledRect(screen, float32(x), float32(y+1), float32(pic.Bounds().Dx()), float32(pic.Bounds().Dy())-1, highlightColor, false)
+                                x2, y2 := options.GeoM.Apply(float64(pic.Bounds().Dx()), float64(pic.Bounds().Dy()))
+                                vector.DrawFilledRect(screen, float32(x), float32(y+1), float32(x2-x), float32(y2-y)-1, highlightColor, false)
                             }
 
                             if unit.GetBusy() == units.BusyStatusPatrol {
@@ -300,7 +303,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
                 break
             }
 
-            rowY += 22 * data.ScreenScale
+            rowY += 22
         }
     }
 

--- a/game/magic/armyview/view.go
+++ b/game/magic/armyview/view.go
@@ -73,19 +73,19 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
             var options ebiten.DrawImageOptions
             scale.DrawScaled(screen, background, &options)
 
-            fonts.BigFont.PrintOptions2(screen, float64(160), float64(10), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("The Armies Of %v", view.Player.Wizard.Name))
+            fonts.BigFont.PrintOptions(screen, float64(160), float64(10), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("The Armies Of %v", view.Player.Wizard.Name))
 
             if highlightedUnit != nil {
                 raceName := highlightedUnit.GetRace().String()
-                fonts.NormalFont.PrintOptions2(screen, float64(190), float64(162), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v %v", raceName, highlightedUnit.GetName()))
+                fonts.NormalFont.PrintOptions(screen, float64(190), float64(162), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v %v", raceName, highlightedUnit.GetName()))
 
             }
 
             shadow := font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}
-            fonts.NormalFont.PrintOptions2(screen, float64(30), float64(162), shadow, "UPKEEP")
-            fonts.NormalFont.PrintOptions2(screen, float64(45), float64(172), shadow, fmt.Sprintf("%v", upkeepGold))
-            fonts.NormalFont.PrintOptions2(screen, float64(45), float64(182), shadow, fmt.Sprintf("%v", upkeepMana))
-            fonts.NormalFont.PrintOptions2(screen, float64(45), float64(192), shadow, fmt.Sprintf("%v", upkeepFood))
+            fonts.NormalFont.PrintOptions(screen, float64(30), float64(162), shadow, "UPKEEP")
+            fonts.NormalFont.PrintOptions(screen, float64(45), float64(172), shadow, fmt.Sprintf("%v", upkeepGold))
+            fonts.NormalFont.PrintOptions(screen, float64(45), float64(182), shadow, fmt.Sprintf("%v", upkeepMana))
+            fonts.NormalFont.PrintOptions(screen, float64(45), float64(192), shadow, fmt.Sprintf("%v", upkeepFood))
 
             minimapRect := image.Rect(85, 163, 135, 197)
             minimapArea := screen.SubImage(scale.ScaleRect(minimapRect)).(*ebiten.Image)
@@ -220,7 +220,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
 
                     nameX, nameY := options.GeoM.Apply(0, 0)
 
-                    fonts.SmallerFont.PrintOptions2(screen, nameX + float64(15), nameY + float64(6), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, hero.GetName())
+                    fonts.SmallerFont.PrintOptions(screen, nameX + float64(15), nameY + float64(6), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, hero.GetName())
                 },
             }
 

--- a/game/magic/armyview/view.go
+++ b/game/magic/armyview/view.go
@@ -73,11 +73,11 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
             var options ebiten.DrawImageOptions
             scale.DrawScaled(screen, background, &options)
 
-            fonts.BigFont.PrintCenter(screen, float64(160), float64(10), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("The Armies Of %v", view.Player.Wizard.Name))
+            fonts.BigFont.PrintOptions2(screen, float64(160), float64(10), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("The Armies Of %v", view.Player.Wizard.Name))
 
             if highlightedUnit != nil {
                 raceName := highlightedUnit.GetRace().String()
-                fonts.NormalFont.PrintCenter(screen, float64(190), float64(162), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v %v", raceName, highlightedUnit.GetName()))
+                fonts.NormalFont.PrintOptions2(screen, float64(190), float64(162), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v %v", raceName, highlightedUnit.GetName()))
 
             }
 
@@ -220,7 +220,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
 
                     nameX, nameY := options.GeoM.Apply(0, 0)
 
-                    fonts.SmallerFont.PrintCenter(screen, nameX + float64(15), nameY + float64(6), float64(data.ScreenScale), options.ColorScale, hero.GetName())
+                    fonts.SmallerFont.PrintOptions2(screen, nameX + float64(15), nameY + float64(6), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, hero.GetName())
                 },
             }
 

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -15,6 +15,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/lib/coroutine"
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/font"
@@ -368,7 +369,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
     elements = append(elements, &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(7 * data.ScreenScale), float64(6 * data.ScreenScale))
+            options.GeoM.Translate(float64(7), float64(6))
 
             /*
             image, _ := imageCache.GetImage("items.lbx", artifact.Image, 0)
@@ -381,7 +382,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
 
     leftIndex := 0
     leftImages, _ := imageCache.GetImages("spellscr.lbx", 35)
-    leftRect := util.ImageRect(5 * data.ScreenScale, 24 * data.ScreenScale, leftImages[leftIndex])
+    leftRect := util.ImageRect(5, 24, leftImages[leftIndex])
     elements = append(elements, &uilib.UIElement{
         Rect: leftRect,
         PlaySoundLeftClick: true,
@@ -400,13 +401,13 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(leftRect.Min.X), float64(leftRect.Min.Y))
             image := leftImages[leftIndex]
-            screen.DrawImage(image, &options)
+            scale.DrawScaled(screen, image, &options)
         },
     })
 
     rightIndex := 0
     rightImages, _ := imageCache.GetImages("spellscr.lbx", 36)
-    rightRect := util.ImageRect(17 * data.ScreenScale, 24 * data.ScreenScale, leftImages[rightIndex])
+    rightRect := util.ImageRect(17, 24, leftImages[rightIndex])
     elements = append(elements, &uilib.UIElement{
         Rect: rightRect,
         PlaySoundLeftClick: true,
@@ -425,12 +426,12 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(rightRect.Min.X), float64(rightRect.Min.Y))
             image := rightImages[rightIndex]
-            screen.DrawImage(image, &options)
+            scale.DrawScaled(screen, image, &options)
         },
     })
 
     // name field
-    nameRect := image.Rect(30 * data.ScreenScale, 12 * data.ScreenScale, (30 + 130) * data.ScreenScale, (12 + fonts.NameFont.Height() + 2) * data.ScreenScale)
+    nameRect := image.Rect(30, 12, (30 + 130), (12 + fonts.NameFont.Height() + 2))
     nameFocused := false
     artifact.Name = getName(artifact, *customName)
     nameColorSource := ebiten.NewImage(1, 1)
@@ -493,16 +494,16 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
             }
         },
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            scale := ebiten.ColorScale{}
+            var options ebiten.DrawImageOptions
             if nameFocused {
-                scale.SetR(3)
-                scale.SetG(3)
+                options.ColorScale.SetR(3)
+                options.ColorScale.SetG(3)
             }
 
-            fonts.NameFont.Print(screen, float64(nameRect.Min.X + 1), float64(nameRect.Min.Y + 1), float64(data.ScreenScale), scale, artifact.Name)
+            fonts.NameFont.PrintOptions2(screen, float64(nameRect.Min.X + 1), float64(nameRect.Min.Y + 1), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, artifact.Name)
 
             if nameFocused {
-                util.DrawTextCursor(screen, nameColorSource, float64(nameRect.Min.X) + 1 + fonts.NameFont.MeasureTextWidth(artifact.Name, float64(data.ScreenScale)), float64(nameRect.Min.Y) + 1, ui.Counter)
+                util.DrawTextCursor(screen, nameColorSource, float64(nameRect.Min.X) + 1 + fonts.NameFont.MeasureTextWidth(artifact.Name, 1), float64(nameRect.Min.Y) + 1, ui.Counter)
             }
         },
     }
@@ -510,16 +511,16 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
     elements = append(elements, nameEntry)
 
     // powers
-    x := 7 * data.ScreenScale
-    y := 40 * data.ScreenScale
+    x := 7
+    y := 40
     printRight := false
     for _, group := range powerGroups {
         groupSelect := -1
 
         // goto the next column
-        if y + (fonts.PowerFont.Height() + 1) * len(group) * data.ScreenScale > data.ScreenHeight - 10 * data.ScreenScale {
-            y = 40 * data.ScreenScale
-            x = 170 * data.ScreenScale
+        if y + (fonts.PowerFont.Height() + 1) * len(group) > data.ScreenHeight - 10 {
+            y = 40
+            x = 170
             printRight = true
         }
 
@@ -527,9 +528,9 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
 
         var lastPower *Power = nil
         for i, power := range group {
-            rect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth(power.Name, float64(data.ScreenScale))), y + fonts.PowerFont.Height() * data.ScreenScale)
+            rect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth(power.Name, 1)), y + fonts.PowerFont.Height())
             if groupRight {
-                rect = image.Rect(x - int(fonts.PowerFont.MeasureTextWidth(power.Name, float64(data.ScreenScale))), y, x, y + fonts.PowerFont.Height() * data.ScreenScale)
+                rect = image.Rect(x - int(fonts.PowerFont.MeasureTextWidth(power.Name, 1)), y, x, y + fonts.PowerFont.Height())
             }
 
             elements = append(elements, &uilib.UIElement{
@@ -569,25 +570,25 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                 },
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                     // draw in bright yellow if selected
-                    scale := ebiten.ColorScale{}
+                    var options ebiten.DrawImageOptions
 
                     if groupSelect == i {
-                        scale.SetR(3)
-                        scale.SetG(3)
+                        options.ColorScale.SetR(3)
+                        options.ColorScale.SetG(3)
                     }
 
                     if groupRight {
-                        fonts.PowerFont.PrintRight(screen, float64(rect.Max.X), float64(rect.Min.Y), float64(data.ScreenScale), scale, power.Name)
+                        fonts.PowerFont.PrintOptions2(screen, float64(rect.Max.X), float64(rect.Min.Y), font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, power.Name)
                     } else {
-                        fonts.PowerFont.Print(screen, float64(rect.Min.X), float64(rect.Min.Y), float64(data.ScreenScale), scale, power.Name)
+                        fonts.PowerFont.PrintOptions2(screen, float64(rect.Min.X), float64(rect.Min.Y), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, power.Name)
                     }
                 },
             })
 
-            y += (fonts.PowerFont.Height() + 1) * data.ScreenScale
+            y += (fonts.PowerFont.Height() + 1)
         }
 
-        y += 5 * data.ScreenScale
+        y += 5
     }
 
     return elements
@@ -603,18 +604,18 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
             vector.DrawFilledRect(screen, 0, 0, float32(data.ScreenWidth), float32(data.ScreenHeight), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
 
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(28 * data.ScreenScale), float64(12 * data.ScreenScale))
+            options.GeoM.Translate(float64(28), float64(12))
             background, _ := imageCache.GetImage("spells.lbx", 0, 0)
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             // print text "Choose a spell to embed in this item"
-            fonts.TitleSpellFont.PrintCenter(screen, float64(data.ScreenWidth / 2), float64(2 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Choose a spell to embed in this item")
+            fonts.TitleSpellFont.PrintOptions2(screen, float64(data.ScreenWidth / 2), float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Choose a spell to embed in this item")
         },
     })
 
-    xLeft := 47 * data.ScreenScale
-    xRight := 187 * data.ScreenScale
-    y := 29 * data.ScreenScale
+    xLeft := 47
+    xRight := 187
+    y := 29
 
     var pages []spellbook.Spells
 
@@ -643,15 +644,15 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
         background, _ := imageCache.GetImage("spellscr.lbx", 37, 0)
 
         var options ebiten.DrawImageOptions
-        options.GeoM.Translate(float64(x), float64(80 * data.ScreenScale))
+        options.GeoM.Translate(float64(x), float64(80))
 
         moreElements = append(moreElements, &uilib.UIElement{
             Layer: 2,
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                screen.DrawImage(background, &options)
+                scale.DrawScaled(screen, background, &options)
 
-                ax, ay := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(5 * data.ScreenScale))
-                spellFont.PrintCenter(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, "Charges")
+                ax, ay := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(5))
+                spellFont.PrintOptions2(screen, ax, ay, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Charges")
             },
         })
 
@@ -661,7 +662,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
         for i := range 4 {
             buttons, _ := imageCache.GetImages("spellscr.lbx", 38 + i)
             buttonOptions := options
-            buttonOptions.GeoM.Translate(float64(button0.Bounds().Dx() * i + 3 * data.ScreenScale), float64(14 * data.ScreenScale))
+            buttonOptions.GeoM.Translate(float64(button0.Bounds().Dx() * i + 3), float64(14))
             x, y := buttonOptions.GeoM.Apply(0, 0)
             rect := util.ImageRect(int(x), int(y), buttons[0])
             pressed := false
@@ -678,9 +679,9 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
                 },
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                     if pressed {
-                        screen.DrawImage(buttons[1], &buttonOptions)
+                        scale.DrawScaled(screen, buttons[1], &buttonOptions)
                     } else {
-                        screen.DrawImage(buttons[0], &buttonOptions)
+                        scale.DrawScaled(screen, buttons[0], &buttonOptions)
                     }
                 },
             })
@@ -695,8 +696,8 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
         pageElements = nil
         // left page
         for i, spell := range pages[showPage].Spells {
-            yPos := y + (spellFont.Height() + 1) * i * data.ScreenScale
-            rect := image.Rect(xLeft, yPos, xLeft + int(spellFont.MeasureTextWidth(spell.Name, float64(data.ScreenScale))), yPos + spellFont.Height() * data.ScreenScale)
+            yPos := y + (spellFont.Height() + 1) * i
+            rect := image.Rect(xLeft, yPos, xLeft + int(spellFont.MeasureTextWidth(spell.Name, 1)), yPos + spellFont.Height())
 
             pickCharges := func (count int) {
                 shutdown()
@@ -710,7 +711,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
                     ui.AddElements(makeSelectChargesElements(spell, xRight, pickCharges))
                 },
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                    spellFont.Print(screen, float64(xLeft), float64(yPos), float64(data.ScreenScale), ebiten.ColorScale{}, spell.Name)
+                    spellFont.PrintOptions2(screen, float64(xLeft), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
                 },
             })
         }
@@ -718,8 +719,8 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
         // right page
         if showPage + 1 < len(pages) {
             for i, spell := range pages[showPage+1].Spells {
-                yPos := y + (spellFont.Height() + 1) * i * data.ScreenScale
-                rect := image.Rect(xRight, yPos, xRight + int(spellFont.MeasureTextWidth(spell.Name, float64(data.ScreenScale))), yPos + spellFont.Height() * data.ScreenScale)
+                yPos := y + (spellFont.Height() + 1) * i
+                rect := image.Rect(xRight, yPos, xRight + int(spellFont.MeasureTextWidth(spell.Name, 1)), yPos + spellFont.Height())
 
                 pickCharges := func (count int) {
                     shutdown()
@@ -733,7 +734,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
                         ui.AddElements(makeSelectChargesElements(spell, xLeft, pickCharges))
                     },
                     Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                        spellFont.Print(screen, float64(xRight), float64(yPos), float64(data.ScreenScale), ebiten.ColorScale{}, spell.Name)
+                        spellFont.PrintOptions2(screen, float64(xRight), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
                     },
                 })
             }
@@ -749,7 +750,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
 
         // left dogear
         leftEar, _ := imageCache.GetImage("spells.lbx", 1, 0)
-        leftRect := util.ImageRect(41 * data.ScreenScale, 16 * data.ScreenScale, leftEar)
+        leftRect := util.ImageRect(41, 16, leftEar)
         elements = append(elements, &uilib.UIElement{
             Layer: 1,
             Rect: leftRect,
@@ -762,13 +763,13 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(41, 16)
-                screen.DrawImage(leftEar, &options)
+                scale.DrawScaled(screen, leftEar, &options)
             },
         })
 
         // right dogear
         rightEar, _ := imageCache.GetImage("spells.lbx", 2, 0)
-        rightRect := util.ImageRect(286 * data.ScreenScale, 16 * data.ScreenScale, rightEar)
+        rightRect := util.ImageRect(286, 16, rightEar)
         elements = append(elements, &uilib.UIElement{
             Layer: 1,
             Rect: rightRect,
@@ -781,13 +782,13 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(rightRect.Min.X), float64(rightRect.Min.Y))
-                screen.DrawImage(rightEar, &options)
+                scale.DrawScaled(screen, rightEar, &options)
             },
         })
     }
 
     // X button at bottom to cancel
-    cancelRect := image.Rect(0, 0, 18 * data.ScreenScale, 24 * data.ScreenScale).Add(image.Pt(188 * data.ScreenScale, 172 * data.ScreenScale))
+    cancelRect := image.Rect(0, 0, 18, 24).Add(image.Pt(188, 172))
     elements = append(elements, &uilib.UIElement{
         Rect: cancelRect,
         Layer: 1,
@@ -824,12 +825,12 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
     maxItem := 11
 
     // currentItem := 0
-    y := 39 * data.ScreenScale
-    x := 200 * data.ScreenScale
+    y := 39
+    x := 200
 
     // true if the rect is within the bounds of where the abilities should be
     inBounds := func (rect image.Rectangle) bool {
-        if rect.Min.Y >= 39 * data.ScreenScale && rect.Min.Y <= 160 * data.ScreenScale {
+        if rect.Min.Y >= 39 && rect.Min.Y <= 160 {
             return true
         }
 
@@ -919,27 +920,27 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                             return
                         }
 
-                        scale := ebiten.ColorScale{}
+                        var options ebiten.DrawImageOptions
 
                         if (mutuallyExclusive && groupSelect == i) || (!mutuallyExclusive && selected[i]) {
-                            scale.SetR(3)
-                            scale.SetG(3)
+                            options.ColorScale.SetR(3)
+                            options.ColorScale.SetG(3)
                         }
 
-                        fonts.PowerFont.Print(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), float64(data.ScreenScale), scale, power.Name)
+                        fonts.PowerFont.PrintOptions2(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, power.Name)
                     },
                 })
 
-                y += (fonts.PowerFont.Height() + 1) * data.ScreenScale
+                y += (fonts.PowerFont.Height() + 1)
             }
         }
 
-        y += 5 * data.ScreenScale
+        y += 5
     }
 
     // spell charges
     if len(availableSpells.Spells) > 0 && (artifact.Type == ArtifactTypeWand || artifact.Type == ArtifactTypeStaff) {
-        xRect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth("Spell Charges", float64(data.ScreenScale))), y + fonts.PowerFont.Height() * data.ScreenScale)
+        xRect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth("Spell Charges", 1)), y + fonts.PowerFont.Height())
         selected := false
         totalItems += 1
 
@@ -979,17 +980,17 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                     return
                 }
 
-                scale := ebiten.ColorScale{}
+                var options ebiten.DrawImageOptions
 
                 if selected {
-                    scale.SetR(3)
-                    scale.SetG(3)
+                    options.ColorScale.SetR(3)
+                    options.ColorScale.SetG(3)
                 }
 
                 if addedPower.Type == PowerTypeSpellCharges {
-                    fonts.PowerFont.Print(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), float64(data.ScreenScale), scale, addedPower.Name)
+                    fonts.PowerFont.PrintOptions2(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, addedPower.Name)
                 } else {
-                    fonts.PowerFont.Print(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), float64(data.ScreenScale), scale, "Spell Charges")
+                    fonts.PowerFont.PrintOptions2(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, "Spell Charges")
                 }
             },
         })
@@ -1013,8 +1014,8 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
         doScroll := func (direction int) {
             move := direction * fonts.PowerFont.Height()
             for _, element := range abilityElements {
-                element.Rect.Min.Y += move * data.ScreenScale
-                element.Rect.Max.Y += move * data.ScreenScale
+                element.Rect.Min.Y += move
+                element.Rect.Max.Y += move
 
                 element.PlaySoundLeftClick = inBounds(element.Rect)
             }
@@ -1034,8 +1035,8 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
             }
         }
 
-        upX := 308 * data.ScreenScale
-        upY := 43 * data.ScreenScale
+        upX := 308
+        upY := 43
         upPressed := false
         elements = append(elements, &uilib.UIElement{
             Rect: util.ImageRect(upX, upY, upArrows[0]),
@@ -1050,7 +1051,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                     image = upArrows[0]
                 }
 
-                screen.DrawImage(image, &options)
+                scale.DrawScaled(screen, image, &options)
             },
             PlaySoundLeftClick: true,
             LeftClick: func(element *uilib.UIElement){
@@ -1064,7 +1065,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
         })
 
         downX := upX
-        downY := 165 * data.ScreenScale
+        downY := 165
         downPressed := false
         elements = append(elements, &uilib.UIElement{
             Rect: util.ImageRect(downX, downY, downArrows[0]),
@@ -1078,7 +1079,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                 } else {
                     image = downArrows[0]
                 }
-                screen.DrawImage(image, &options)
+                scale.DrawScaled(screen, image, &options)
             },
             PlaySoundLeftClick: true,
             LeftClick: func(element *uilib.UIElement){
@@ -1091,7 +1092,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
         })
 
         elements = append(elements, &uilib.UIElement{
-            Rect: image.Rect(200 * data.ScreenScale, 39 * data.ScreenScale, (200 + 110) * data.ScreenScale, 170 * data.ScreenScale),
+            Rect: image.Rect(200, 39, (200 + 110), 170),
             Scroll: func (element *uilib.UIElement, x float64, y float64) {
                 if y < 0 {
                     scrollDown()
@@ -1197,7 +1198,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             background, _ := imageCache.GetImage("spellscr.lbx", 13, 0)
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -1291,7 +1292,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
                     use = selected
                 }
                 image, _ := imageCache.GetImage("spellscr.lbx", use, index)
-                screen.DrawImage(image, &options)
+                scale.DrawScaled(screen, image, &options)
             },
         }
     }
@@ -1303,8 +1304,8 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
 
     // 10 item types
     for i := 0; i < 10; i++ {
-        x := 156 * data.ScreenScale + (i % 5) * (tmpImage.Bounds().Dx() + 2 * data.ScreenScale)
-        y := 3 * data.ScreenScale + (i / 5) * (tmpImage.Bounds().Dy() + 2 * data.ScreenScale)
+        x := 156 + (i % 5) * (tmpImage.Bounds().Dx() + 2)
+        y := 3 + (i / 5) * (tmpImage.Bounds().Dy() + 2)
 
         button := makeButton(x, y, unselectedImageStart + i, selectedImageStart + i, ArtifactType(i+1))
         if selectedButton == nil {
@@ -1317,7 +1318,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
 
     ui.AddElement(&uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            fonts.PowerFontWhite.Print(screen, float64(198 * data.ScreenScale), float64(185 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Cost: %v", currentArtifact.Cost))
+            fonts.PowerFontWhite.PrintOptions2(screen, 198, 185, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost: %v", currentArtifact.Cost))
         },
     })
 
@@ -1326,7 +1327,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
 
     okButtons, _ := imageCache.GetImages("spellscr.lbx", 24)
     okIndex := 0
-    okRect := util.ImageRect(281 * data.ScreenScale, 180 * data.ScreenScale, okButtons[0])
+    okRect := util.ImageRect(281, 180, okButtons[0])
     ui.AddElement(&uilib.UIElement{
         Rect: okRect,
         PlaySoundLeftClick: true,
@@ -1364,7 +1365,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(okRect.Min.X), float64(okRect.Min.Y))
             image := okButtons[okIndex]
-            screen.DrawImage(image, &options)
+            scale.DrawScaled(screen, image, &options)
         },
     })
 

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -500,7 +500,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                 options.ColorScale.SetG(3)
             }
 
-            fonts.NameFont.PrintOptions2(screen, float64(nameRect.Min.X + 1), float64(nameRect.Min.Y + 1), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, artifact.Name)
+            fonts.NameFont.PrintOptions(screen, float64(nameRect.Min.X + 1), float64(nameRect.Min.Y + 1), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, artifact.Name)
 
             if nameFocused {
                 util.DrawTextCursor(screen, nameColorSource, float64(nameRect.Min.X) + 1 + fonts.NameFont.MeasureTextWidth(artifact.Name, 1), float64(nameRect.Min.Y) + 1, ui.Counter)
@@ -578,9 +578,9 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                     }
 
                     if groupRight {
-                        fonts.PowerFont.PrintOptions2(screen, float64(rect.Max.X), float64(rect.Min.Y), font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, power.Name)
+                        fonts.PowerFont.PrintOptions(screen, float64(rect.Max.X), float64(rect.Min.Y), font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, power.Name)
                     } else {
-                        fonts.PowerFont.PrintOptions2(screen, float64(rect.Min.X), float64(rect.Min.Y), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, power.Name)
+                        fonts.PowerFont.PrintOptions(screen, float64(rect.Min.X), float64(rect.Min.Y), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, power.Name)
                     }
                 },
             })
@@ -609,7 +609,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
             scale.DrawScaled(screen, background, &options)
 
             // print text "Choose a spell to embed in this item"
-            fonts.TitleSpellFont.PrintOptions2(screen, float64(data.ScreenWidth / 2), float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Choose a spell to embed in this item")
+            fonts.TitleSpellFont.PrintOptions(screen, float64(data.ScreenWidth / 2), float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Choose a spell to embed in this item")
         },
     })
 
@@ -652,7 +652,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
                 scale.DrawScaled(screen, background, &options)
 
                 ax, ay := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(5))
-                spellFont.PrintOptions2(screen, ax, ay, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Charges")
+                spellFont.PrintOptions(screen, ax, ay, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Charges")
             },
         })
 
@@ -711,7 +711,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
                     ui.AddElements(makeSelectChargesElements(spell, xRight, pickCharges))
                 },
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                    spellFont.PrintOptions2(screen, float64(xLeft), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
+                    spellFont.PrintOptions(screen, float64(xLeft), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
                 },
             })
         }
@@ -734,7 +734,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
                         ui.AddElements(makeSelectChargesElements(spell, xLeft, pickCharges))
                     },
                     Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                        spellFont.PrintOptions2(screen, float64(xRight), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
+                        spellFont.PrintOptions(screen, float64(xRight), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
                     },
                 })
             }
@@ -927,7 +927,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                             options.ColorScale.SetG(3)
                         }
 
-                        fonts.PowerFont.PrintOptions2(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, power.Name)
+                        fonts.PowerFont.PrintOptions(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, power.Name)
                     },
                 })
 
@@ -988,9 +988,9 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                 }
 
                 if addedPower.Type == PowerTypeSpellCharges {
-                    fonts.PowerFont.PrintOptions2(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, addedPower.Name)
+                    fonts.PowerFont.PrintOptions(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, addedPower.Name)
                 } else {
-                    fonts.PowerFont.PrintOptions2(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, "Spell Charges")
+                    fonts.PowerFont.PrintOptions(screen, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, "Spell Charges")
                 }
             },
         })
@@ -1318,7 +1318,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
 
     ui.AddElement(&uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            fonts.PowerFontWhite.PrintOptions2(screen, 198, 185, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost: %v", currentArtifact.Cost))
+            fonts.PowerFontWhite.PrintOptions(screen, 198, 185, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost: %v", currentArtifact.Cost))
         },
     })
 

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -854,7 +854,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
             artifactTypes := compatibilities[power]
             if artifactTypes.Contains(artifact.Type) && magicLevel.MagicLevel(power.Magic) >= power.Amount {
                 totalItems += 1
-                xRect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth(power.Name, float64(data.ScreenScale))), y + fonts.PowerFont.Height() * data.ScreenScale)
+                xRect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth(power.Name, 1)), y + fonts.PowerFont.Height())
                 elements = append(elements, &uilib.UIElement{
                     Rect: xRect,
                     PlaySoundLeftClick: inBounds(xRect),

--- a/game/magic/artifact/view.go
+++ b/game/magic/artifact/view.go
@@ -46,7 +46,7 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
     itemImage := RenderArtifactImage(screen, imageCache, artifact, counter, options)
 
     x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X + 3), float64(4))
-    titleFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, artifact.Name)
+    titleFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, artifact.Name)
 
     dot, _ := imageCache.GetImage("itemisc.lbx", 26, 0)
     savedGeom := options.GeoM
@@ -59,6 +59,6 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
         scale.DrawScaled(screen, dot, &options)
 
         x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1), 0)
-        attributeFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, power.Name)
+        attributeFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, power.Name)
     }
 }

--- a/game/magic/artifact/view.go
+++ b/game/magic/artifact/view.go
@@ -6,6 +6,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
@@ -26,11 +27,11 @@ func add1PxBorder(src *image.Paletted) image.Image {
 func RenderArtifactImage(screen *ebiten.Image, imageCache *util.ImageCache, artifact Artifact, counter uint64, options ebiten.DrawImageOptions) *ebiten.Image {
     itemImage, _ := imageCache.GetImageTransform("items.lbx", artifact.Image, 0, "1px-border", add1PxBorder)
     options.GeoM.Translate(-1, -1)
-    screen.DrawImage(itemImage, &options)
+    scale.DrawScaled(screen, itemImage, &options)
 
     enchanted := artifact.HasAbilities()
     if enchanted {
-        util.DrawOutline(screen, imageCache, itemImage, options.GeoM, options.ColorScale, counter, data.GetMagicColor(artifact.FirstAbility().MagicType()))
+        util.DrawOutline(screen, imageCache, itemImage, scale.ScaleGeom(options.GeoM), options.ColorScale, counter, data.GetMagicColor(artifact.FirstAbility().MagicType()))
     }
 
     return itemImage
@@ -38,26 +39,26 @@ func RenderArtifactImage(screen *ebiten.Image, imageCache *util.ImageCache, arti
 
 func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact Artifact, counter uint64, titleFont *font.Font, attributeFont *font.Font, options ebiten.DrawImageOptions) {
     itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
-    screen.DrawImage(itemBackground, &options)
+    scale.DrawScaled(screen, itemBackground, &options)
 
-    options.GeoM.Translate(float64(10 * data.ScreenScale), float64(8 * data.ScreenScale))
+    options.GeoM.Translate(float64(10), float64(8))
 
     itemImage := RenderArtifactImage(screen, imageCache, artifact, counter, options)
 
-    x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X + 3 * data.ScreenScale), float64(4 * data.ScreenScale))
-    titleFont.PrintOptions(screen, x, y, float64(data.ScreenScale), options.ColorScale, font.FontOptions{DropShadow: true}, artifact.Name)
+    x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X + 3), float64(4))
+    titleFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, artifact.Name)
 
     dot, _ := imageCache.GetImage("itemisc.lbx", 26, 0)
     savedGeom := options.GeoM
     for i, power := range artifact.Powers {
         options.GeoM = savedGeom
-        options.GeoM.Translate(float64(3 * data.ScreenScale), float64(26 * data.ScreenScale))
+        options.GeoM.Translate(float64(3), float64(26))
         // integer division is important here
-        options.GeoM.Translate(float64((i/2) * data.ScreenScale * 80), float64((i % 2) * 13 * data.ScreenScale))
+        options.GeoM.Translate(float64((i/2) * 80), float64((i % 2) * 13))
 
-        screen.DrawImage(dot, &options)
+        scale.DrawScaled(screen, dot, &options)
 
-        x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1 * data.ScreenScale), 0)
-        attributeFont.PrintOptions(screen, x, y, float64(data.ScreenScale), options.ColorScale, font.FontOptions{DropShadow: true}, power.Name)
+        x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1), 0)
+        attributeFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, power.Name)
     }
 }

--- a/game/magic/banish/banish.go
+++ b/game/magic/banish/banish.go
@@ -8,6 +8,7 @@ import (
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/audio"
     "github.com/kazzmir/master-of-magic/lib/coroutine"
     "github.com/kazzmir/master-of-magic/lib/lbx"
@@ -148,28 +149,28 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
     animationSteps := 30
 
     badGuy1Sprite := Sprite{
-        StartX: float64(320 * data.ScreenScale),
-        StartY: float64(80 * data.ScreenScale),
-        DestX: float64(250 * data.ScreenScale),
-        DestY: float64(80 * data.ScreenScale),
+        StartX: float64(320),
+        StartY: float64(80),
+        DestX: float64(250),
+        DestY: float64(80),
         Steps: animationSteps,
         Image: badGuy1,
     }
 
     badGuy2Sprite := Sprite{
-        StartX: float64(180 * data.ScreenScale),
-        StartY: float64(200 * data.ScreenScale),
-        DestX: float64(100 * data.ScreenScale),
-        DestY: float64(130 * data.ScreenScale),
+        StartX: float64(180),
+        StartY: float64(200),
+        DestX: float64(100),
+        DestY: float64(130),
         Steps: animationSteps,
         Image: badGuy2,
     }
 
     wizardSprite := Sprite{
-        StartX: float64(320 * data.ScreenScale),
-        StartY: float64(200 * data.ScreenScale),
-        DestX: float64(200 * data.ScreenScale),
-        DestY: float64(60 * data.ScreenScale),
+        StartX: float64(320),
+        StartY: float64(200),
+        DestX: float64(200),
+        DestY: float64(60),
         Steps: animationSteps,
         Image: attackImage,
     }
@@ -190,22 +191,22 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
 
     draw := func (screen *ebiten.Image){
         var options ebiten.DrawImageOptions
-        screen.DrawImage(background, &options)
+        scale.DrawScaled(screen, background, &options)
 
         if !wizardGone {
             if dissappear {
-                options.GeoM.Translate(float64(66 * data.ScreenScale), float64(16 * data.ScreenScale))
-                screen.DrawImage(dissappearAnimation.Frame(), &options)
+                options.GeoM.Translate(float64(66), float64(16))
+                scale.DrawScaled(screen, dissappearAnimation.Frame(), &options)
             } else {
-                options.GeoM.Translate(float64(69 * data.ScreenScale), float64(75 * data.ScreenScale))
-                screen.DrawImage(defeatedWizardImage, &options)
+                options.GeoM.Translate(float64(69), float64(75))
+                scale.DrawScaled(screen, defeatedWizardImage, &options)
             }
         }
 
         if spellAnimation != nil {
             options.GeoM.Reset()
             options.GeoM.Translate(spellX, spellY)
-            screen.DrawImage(spellAnimation.Frame(), &options)
+            scale.DrawScaled(screen, spellAnimation.Frame(), &options)
         }
 
         for _, sprite := range sprites {
@@ -222,10 +223,10 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
             }
 
             options.GeoM.Translate(x, y)
-            screen.DrawImage(sprite.Image, &options)
+            scale.DrawScaled(screen, sprite.Image, &options)
         }
 
-        mainFont.PrintCenter(screen, float64(160 * data.ScreenScale), float64(10 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v banishes %v", attackingWizard.Wizard.Name, defeatedWizard.Wizard.Name))
+        mainFont.PrintOptions2(screen, 160, 10, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v banishes %v", attackingWizard.Wizard.Name, defeatedWizard.Wizard.Name))
     }
 
     yellSound, err := audio.LoadSound(cache, 35)
@@ -245,8 +246,8 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
         }
 
         spellAnimation = util.MakeAnimation(spell1Images, false)
-        spellX = float64(175 * data.ScreenScale)
-        spellY = float64(64 * data.ScreenScale)
+        spellX = float64(175)
+        spellY = float64(64)
 
         for i := 0; i < 2000; i++ {
             if i % animationSpeed == 0 {
@@ -275,8 +276,8 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
         }
 
         spellAnimation = util.MakeAnimation(spell1Images[len(spell1Images)-2:len(spell1Images)], true)
-        spellX = float64(175 * data.ScreenScale)
-        spellY = float64(64 * data.ScreenScale)
+        spellX = float64(175)
+        spellY = float64(64)
 
         dissappear = true
         for i := 0; i < 2000; i++ {
@@ -294,8 +295,8 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
         wizardGone = true
 
         spellAnimation = util.MakeReverseAnimation(spell1Images, false)
-        spellX = float64(175 * data.ScreenScale)
-        spellY = float64(64 * data.ScreenScale)
+        spellX = float64(175)
+        spellY = float64(64)
 
         for i := 0; i < 200; i++ {
             if i % animationSpeed == 0 {

--- a/game/magic/banish/banish.go
+++ b/game/magic/banish/banish.go
@@ -226,7 +226,7 @@ func ShowBanishAnimation(cache *lbx.LbxCache, attackingWizard *playerlib.Player,
             scale.DrawScaled(screen, sprite.Image, &options)
         }
 
-        mainFont.PrintOptions2(screen, 160, 10, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v banishes %v", attackingWizard.Wizard.Name, defeatedWizard.Wizard.Name))
+        mainFont.PrintOptions(screen, 160, 10, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v banishes %v", attackingWizard.Wizard.Name, defeatedWizard.Wizard.Name))
     }
 
     yellSound, err := audio.LoadSound(cache, 35)

--- a/game/magic/citylistview/view.go
+++ b/game/magic/citylistview/view.go
@@ -12,6 +12,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -95,7 +96,7 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
         Draw: func(ui *uilib.UI, screen *ebiten.Image) {
             background, _ := view.ImageCache.GetImage("reload.lbx", 21, 0)
             var options ebiten.DrawImageOptions
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -103,25 +104,25 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
                 }
             })
 
-            bigFont.PrintCenter(screen, float64(160 * data.ScreenScale), float64(5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("The Cities Of %v", view.Player.Wizard.Name))
+            bigFont.PrintCenter(screen, float64(160), float64(5), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("The Cities Of %v", view.Player.Wizard.Name))
 
-            y := float64(17 * data.ScreenScale)
-            x := float64(31 * data.ScreenScale)
-            normalFont.Print(screen, x, y, float64(data.ScreenScale), ebiten.ColorScale{}, "Name")
-            normalFont.Print(screen, x + float64(57 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Race")
-            normalFont.PrintRight(screen, x + float64(119 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Pop")
-            normalFont.PrintRight(screen, x + float64(139 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Gold")
-            normalFont.PrintRight(screen, x + float64(159 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Prd")
-            normalFont.Print(screen, x + float64(165 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Producing")
-            normalFont.PrintRight(screen, x + float64(258 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Time")
+            y := float64(17)
+            x := float64(31)
+            normalFont.Print(screen, x, y, scale.ScaleAmount, ebiten.ColorScale{}, "Name")
+            normalFont.Print(screen, x + 57, y, scale.ScaleAmount, ebiten.ColorScale{}, "Race")
+            normalFont.PrintRight(screen, x + float64(119), y, scale.ScaleAmount, ebiten.ColorScale{}, "Pop")
+            normalFont.PrintRight(screen, x + float64(139), y, scale.ScaleAmount, ebiten.ColorScale{}, "Gold")
+            normalFont.PrintRight(screen, x + float64(159), y, scale.ScaleAmount, ebiten.ColorScale{}, "Prd")
+            normalFont.Print(screen, x + float64(165), y, scale.ScaleAmount, ebiten.ColorScale{}, "Producing")
+            normalFont.PrintRight(screen, x + float64(258), y, scale.ScaleAmount, ebiten.ColorScale{}, "Time")
 
-            normalFont.Print(screen, float64(232 * data.ScreenScale), float64(173 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%vGP", view.Player.Gold))
-            normalFont.Print(screen, float64(267 * data.ScreenScale), float64(173 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%vMP", view.Player.Mana))
+            normalFont.Print(screen, 232, 173, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%vGP", view.Player.Gold))
+            normalFont.Print(screen, 267, 173, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%vMP", view.Player.Mana))
 
             if highlightedCity != nil {
-                normalFont.Print(screen, float64(99 * data.ScreenScale), float64(158 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, highlightedCity.Name)
-                minimapRect := image.Rect(42 * data.ScreenScale, 162 * data.ScreenScale, 91 * data.ScreenScale, 195 * data.ScreenScale)
-                minimapArea := screen.SubImage(minimapRect).(*ebiten.Image)
+                normalFont.Print(screen, float64(99), float64(158), scale.ScaleAmount, ebiten.ColorScale{}, highlightedCity.Name)
+                minimapRect := image.Rect(42, 162, 91, 195)
+                minimapArea := screen.SubImage(scale.ScaleRect(minimapRect)).(*ebiten.Image)
                 view.DrawMinimap(minimapArea, highlightedCity.X, highlightedCity.Y, highlightedCity.Plane, ui.Counter)
             // vector.DrawFilledRect(minimapArea, float32(minimapRect.Min.X), float32(minimapRect.Min.Y), float32(minimapRect.Bounds().Dx()), float32(minimapRect.Bounds().Dy()), util.PremultiplyAlpha(color.RGBA{R: 0xff, G: 0, B: 0, A: 128}), false)
             }
@@ -138,7 +139,7 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
     highlightColor := util.PremultiplyAlpha(color.RGBA{R: 255, G: 255, B: 255, A: 90})
 
     maxRows := 9
-    y := 28 * data.ScreenScale
+    y := 28
     rowCount := 0
     for i, city := range cities {
 
@@ -154,7 +155,7 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
 
         elementY := float64(y)
         elements = append(elements, &uilib.UIElement{
-            Rect: image.Rect(28 * data.ScreenScale, int(elementY), 296 * data.ScreenScale, int(elementY) + 14 * data.ScreenScale),
+            Rect: image.Rect(28, int(elementY), 296, int(elementY) + 14),
             LeftClickRelease: func(element *uilib.UIElement){
                 view.DoSelectCity(city)
                 view.State = CityListScreenStateDone
@@ -174,26 +175,26 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
                 x := float64(31)
 
                 if highlightedCity == city {
-                    vector.DrawFilledRect(screen, float32((x-1) * float64(data.ScreenScale)), float32(elementY- float64(3 * data.ScreenScale)), float32(52 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
-                    vector.DrawFilledRect(screen, float32((x-1+57) * float64(data.ScreenScale)), float32(elementY-float64(3 * data.ScreenScale)), float32(44 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
-                    vector.DrawFilledRect(screen, float32((x-1+119-14) * float64(data.ScreenScale)), float32(elementY-float64(3 * data.ScreenScale)), float32(16 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
-                    vector.DrawFilledRect(screen, float32((x-1+139-14) * float64(data.ScreenScale)), float32(elementY-float64(3 * data.ScreenScale)), float32(16 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
-                    vector.DrawFilledRect(screen, float32((x-1+159-14) * float64(data.ScreenScale)), float32(elementY-float64(3 * data.ScreenScale)), float32(16 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
-                    vector.DrawFilledRect(screen, float32((x-1+165) * float64(data.ScreenScale)), float32(elementY-float64(3 * data.ScreenScale)), float32(76 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
-                    vector.DrawFilledRect(screen, float32((x-1+258-13) * float64(data.ScreenScale)), float32(elementY-float64(3 * data.ScreenScale)), float32(15 * data.ScreenScale), float32(10 * data.ScreenScale), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1))), scale.Scale(float32(elementY - 3)), scale.Scale(float32(52)), scale.Scale(float32(10)), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1+57))), scale.Scale(float32(elementY-3)), scale.Scale(float32(44)), scale.Scale(float32(10)), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1+119-14))), scale.Scale(float32(elementY-3)), scale.Scale(float32(16)), scale.Scale(float32(10)), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1+139-14))), scale.Scale(float32(elementY-3)), scale.Scale(float32(16)), scale.Scale(float32(10)), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1+159-14))), scale.Scale(float32(elementY-3)), scale.Scale(float32(16)), scale.Scale(float32(10)), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1+165))), scale.Scale(float32(elementY-3)), scale.Scale(float32(76)), scale.Scale(float32(10)), highlightColor, false)
+                    vector.DrawFilledRect(screen, scale.Scale(float32((x-1+258-13))), scale.Scale(float32(elementY-3)), scale.Scale(float32(15)), scale.Scale(float32(10)), highlightColor, false)
                 }
 
-                normalFont.Print(screen, x * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, city.Name)
-                normalFont.Print(screen, (x + 57) * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, city.Race.String())
-                normalFont.PrintRight(screen, (x + 119) * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", city.Citizens()))
-                normalFont.PrintRight(screen, (x + 139) * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", goldSurplus))
-                normalFont.PrintRight(screen, (x + 159) * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", int(city.WorkProductionRate())))
-                normalFont.Print(screen, (x + 165) * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, city.ProducingString())
-                normalFont.PrintRight(screen, (x + 258) * float64(data.ScreenScale), elementY, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", city.ProducingTurnsLeft()))
+                normalFont.Print(screen, x, elementY, scale.ScaleAmount, ebiten.ColorScale{}, city.Name)
+                normalFont.Print(screen, (x + 57), elementY, scale.ScaleAmount, ebiten.ColorScale{}, city.Race.String())
+                normalFont.PrintRight(screen, (x + 119), elementY, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v", city.Citizens()))
+                normalFont.PrintRight(screen, (x + 139), elementY, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v", goldSurplus))
+                normalFont.PrintRight(screen, (x + 159), elementY, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v", int(city.WorkProductionRate())))
+                normalFont.Print(screen, (x + 165), elementY, scale.ScaleAmount, ebiten.ColorScale{}, city.ProducingString())
+                normalFont.PrintRight(screen, (x + 258), elementY, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v", city.ProducingTurnsLeft()))
             },
         })
 
-        y += 14 * data.ScreenScale
+        y += 14
 
         rowCount += 1
         if rowCount >= maxRows {
@@ -205,7 +206,7 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
         clicked := false
 
         return &uilib.UIElement{
-            Rect: util.ImageRect(x * data.ScreenScale, y * data.ScreenScale, normal),
+            Rect: util.ImageRect(x, y, normal),
             LeftClick: func (this *uilib.UIElement){
                 clicked = true
             },
@@ -220,7 +221,7 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
                 if clicked {
                     use = clickImage
                 }
-                screen.DrawImage(use, &options)
+                scale.DrawScaled(screen, use, &options)
             },
         }
     }

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -10,7 +10,6 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/scale"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
@@ -189,15 +188,15 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                     // vector.DrawFilledCircle(screen, float32(middleX), float32(middleY), 1, color.RGBA{255, 255, 255, 255}, true)
                 }
 
-                fonts.DescriptionFont.Print(screen, float64(130), float64(12), float64(data.ScreenScale), ebiten.ColorScale{}, city.BuildingInfo.Name(building))
-                fonts.SmallFont.Print(screen, float64(130), float64(33), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Cost %v", city.BuildingInfo.ProductionCost(building)))
+                fonts.DescriptionFont.PrintOptions2(screen, float64(130), float64(12), font.FontOptions{Scale: scale.ScaleAmount}, city.BuildingInfo.Name(building))
+                fonts.SmallFont.PrintOptions2(screen, float64(130), float64(33), font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost %v", city.BuildingInfo.ProductionCost(building)))
 
-                fonts.DescriptionFont.Print(screen, float64(85), float64(48), float64(data.ScreenScale), ebiten.ColorScale{}, "Maintenance")
+                fonts.DescriptionFont.PrintOptions2(screen, float64(85), float64(48), font.FontOptions{Scale: scale.ScaleAmount}, "Maintenance")
 
                 buildingMaintenance := city.BuildingInfo.UpkeepCost(building)
 
                 if buildingMaintenance == 0 {
-                    fonts.MediumFont.Print(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", 1) + float64(4), float64(49), float64(data.ScreenScale), ebiten.ColorScale{}, "0")
+                    fonts.MediumFont.PrintOptions2(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", 1) + float64(4), float64(49), font.FontOptions{Scale: scale.ScaleAmount}, "0")
                 } else {
                     smallCoin, err := imageCache.GetImage("backgrnd.lbx", 42, 0)
                     if err == nil {
@@ -210,11 +209,11 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                     }
                 }
 
-                fonts.DescriptionFont.Print(screen, float64(85), float64(58), float64(data.ScreenScale), ebiten.ColorScale{}, "Allows")
+                fonts.DescriptionFont.PrintOptions2(screen, 85, 58, font.FontOptions{Scale: scale.ScaleAmount}, "Allows")
 
-                fonts.MediumFont.RenderWrapped(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Allows", 1) + float64(10), float64(59), allowsWrapped, ebiten.ColorScale{}, font.FontOptions{})
+                fonts.MediumFont.RenderWrapped(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Allows", 1) + float64(10), float64(59), allowsWrapped, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
 
-                fonts.DescriptionFont.RenderWrapped(screen, float64(85), float64(108), descriptionWrapped, ebiten.ColorScale{}, font.FontOptions{})
+                fonts.DescriptionFont.RenderWrapped(screen, 85, 108, descriptionWrapped, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
 
                 /*
                 helpEntries := help.GetEntriesByName(building.String())
@@ -305,7 +304,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                         use = fonts.TitleFontWhite
                     }
 
-                    use.Print(screen, float64(x1 + 2), float64(y1 + 1), float64(data.ScreenScale), ebiten.ColorScale{}, city.BuildingInfo.Name(building))
+                    use.PrintOptions2(screen, float64(x1 + 2), float64(y1 + 1), font.FontOptions{Scale: scale.ScaleAmount}, city.BuildingInfo.Name(building))
                 },
             }
 
@@ -362,7 +361,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                         use = fonts.TitleFontWhite
                     }
 
-                    use.Print(screen, float64(x1 + 2), float64(y1 + 1), float64(data.ScreenScale), ebiten.ColorScale{}, unit.String())
+                    use.PrintOptions2(screen, float64(x1 + 2), float64(y1 + 1), font.FontOptions{Scale: scale.ScaleAmount}, unit.String())
                 },
             }
 
@@ -401,7 +400,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 options.GeoM.Translate(float64(cancelX), float64(cancelY))
                 scale.DrawScaled(screen, buttonBackground, &options)
 
-                fonts.OkCancelFont.PrintCenter(screen, float64(cancelX + buttonBackground.Bounds().Dx() / 2), float64(cancelY + 1), float64(data.ScreenScale), ebiten.ColorScale{}, "Cancel")
+                fonts.OkCancelFont.PrintOptions2(screen, float64(cancelX + buttonBackground.Bounds().Dx() / 2), float64(cancelY + 1), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Cancel")
             },
         })
 
@@ -424,7 +423,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 options.GeoM.Translate(float64(okX), float64(okY))
                 scale.DrawScaled(screen, buttonBackground, &options)
 
-                fonts.OkCancelFont.PrintCenter(screen, float64(okX + buttonBackground.Bounds().Dx() / 2), float64(okY + 1), float64(data.ScreenScale), ebiten.ColorScale{}, "Ok")
+                fonts.OkCancelFont.PrintOptions2(screen, float64(okX + buttonBackground.Bounds().Dx() / 2), float64(okY + 1), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Ok")
             },
         })
     }

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -211,9 +211,9 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
 
                 fonts.DescriptionFont.PrintOptions2(screen, 85, 58, font.FontOptions{Scale: scale.ScaleAmount}, "Allows")
 
-                fonts.MediumFont.RenderWrapped(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Allows", 1) + float64(10), float64(59), allowsWrapped, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
+                fonts.MediumFont.RenderWrapped(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Allows", 1) + float64(10), float64(59), allowsWrapped, font.FontOptions{Scale: scale.ScaleAmount})
 
-                fonts.DescriptionFont.RenderWrapped(screen, 85, 108, descriptionWrapped, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
+                fonts.DescriptionFont.RenderWrapped(screen, 85, 108, descriptionWrapped, font.FontOptions{Scale: scale.ScaleAmount})
 
                 /*
                 helpEntries := help.GetEntriesByName(building.String())

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -12,6 +12,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
     // "github.com/kazzmir/master-of-magic/game/magic/combat"
@@ -122,8 +123,8 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
             mainInfo, err := imageCache.GetImage("unitview.lbx", 0, 0)
             if err == nil {
                 var options ebiten.DrawImageOptions
-                options.GeoM.Translate(float64(75 * data.ScreenScale), 0)
-                screen.DrawImage(mainInfo, &options)
+                options.GeoM.Translate(float64(75), 0)
+                scale.DrawScaled(screen, mainInfo, &options)
             }
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
@@ -145,7 +146,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
     var selectedElement *uilib.UIElement
 
     updateMainElementBuilding := func(building buildinglib.Building){
-        descriptionWrapped := fonts.DescriptionFont.CreateWrappedText(float64(155 * data.ScreenScale), float64(data.ScreenScale), buildDescriptions.Get(building))
+        descriptionWrapped := fonts.DescriptionFont.CreateWrappedText(float64(155), 1, buildDescriptions.Get(building))
 
         allowedBuildings := city.AllowedBuildings(building)
         allowedUnits := city.AllowedUnits(building)
@@ -159,7 +160,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
 
         allows := combineStrings(allowStrings)
 
-        allowsWrapped := fonts.MediumFont.CreateWrappedText(float64(100 * data.ScreenScale), float64(data.ScreenScale), allows)
+        allowsWrapped := fonts.MediumFont.CreateWrappedText(float64(100), 1, allows)
 
         ui.RemoveGroup(mainGroup)
         mainGroup = uilib.MakeGroup()
@@ -168,52 +169,52 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 images, err := imageCache.GetImages("cityscap.lbx", GetProducingBuildingIndex(building))
                 if err == nil {
-                    middleX := float64(103 * data.ScreenScale)
-                    middleY := float64(22 * data.ScreenScale)
+                    middleX := float64(103)
+                    middleY := float64(22)
                     index := (ui.Counter / 7) % uint64(len(images))
 
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(middleX, middleY)
                     options.GeoM.Translate(-float64(images[index].Bounds().Dx() / 2), -float64(images[index].Bounds().Dy() / 2))
 
-                    width := 44 * data.ScreenScale
-                    height := 36 * data.ScreenScale
+                    width := 44
+                    height := 36
                     clipRect := image.Rect(int(middleX) - width / 2, int(middleY) - height / 2, int(middleX) + width / 2, int(middleY) + height / 2)
-                    clip := screen.SubImage(clipRect).(*ebiten.Image)
+                    clip := screen.SubImage(scale.ScaleRect(clipRect)).(*ebiten.Image)
 
                     // vector.DrawFilledRect(clip, float32(clipRect.Min.X), float32(clipRect.Min.Y), float32(clipRect.Bounds().Dx()), float32(clipRect.Bounds().Dy()), color.RGBA{R: 255, G: 255, B: 255, A: 255}, true)
 
-                    clip.DrawImage(images[index], &options)
+                    scale.DrawScaled(clip, images[index], &options)
 
                     // vector.DrawFilledCircle(screen, float32(middleX), float32(middleY), 1, color.RGBA{255, 255, 255, 255}, true)
                 }
 
-                fonts.DescriptionFont.Print(screen, float64(130 * data.ScreenScale), float64(12 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, city.BuildingInfo.Name(building))
-                fonts.SmallFont.Print(screen, float64(130 * data.ScreenScale), float64(33 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Cost %v", city.BuildingInfo.ProductionCost(building)))
+                fonts.DescriptionFont.Print(screen, float64(130), float64(12), float64(data.ScreenScale), ebiten.ColorScale{}, city.BuildingInfo.Name(building))
+                fonts.SmallFont.Print(screen, float64(130), float64(33), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Cost %v", city.BuildingInfo.ProductionCost(building)))
 
-                fonts.DescriptionFont.Print(screen, float64(85 * data.ScreenScale), float64(48 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Maintenance")
+                fonts.DescriptionFont.Print(screen, float64(85), float64(48), float64(data.ScreenScale), ebiten.ColorScale{}, "Maintenance")
 
                 buildingMaintenance := city.BuildingInfo.UpkeepCost(building)
 
                 if buildingMaintenance == 0 {
-                    fonts.MediumFont.Print(screen, float64(85 * data.ScreenScale) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", float64(data.ScreenScale)) + float64(4 * data.ScreenScale), float64(49 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "0")
+                    fonts.MediumFont.Print(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", 1) + float64(4), float64(49), float64(data.ScreenScale), ebiten.ColorScale{}, "0")
                 } else {
                     smallCoin, err := imageCache.GetImage("backgrnd.lbx", 42, 0)
                     if err == nil {
                         var options ebiten.DrawImageOptions
-                        options.GeoM.Translate(float64(85 * data.ScreenScale) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", float64(data.ScreenScale)) + float64(3 * data.ScreenScale), float64(50 * data.ScreenScale))
+                        options.GeoM.Translate(float64(85) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", 1) + float64(3), float64(50))
                         for i := 0; i < buildingMaintenance; i++ {
-                            screen.DrawImage(smallCoin, &options)
-                            options.GeoM.Translate(float64(smallCoin.Bounds().Dx() + 2 * data.ScreenScale), 0)
+                            scale.DrawScaled(screen, smallCoin, &options)
+                            options.GeoM.Translate(float64(smallCoin.Bounds().Dx() + 2), 0)
                         }
                     }
                 }
 
-                fonts.DescriptionFont.Print(screen, float64(85 * data.ScreenScale), float64(58 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Allows")
+                fonts.DescriptionFont.Print(screen, float64(85), float64(58), float64(data.ScreenScale), ebiten.ColorScale{}, "Allows")
 
-                fonts.MediumFont.RenderWrapped(screen, float64(85 * data.ScreenScale) + fonts.DescriptionFont.MeasureTextWidth("Allows", float64(data.ScreenScale)) + float64(10 * data.ScreenScale), float64(59 * data.ScreenScale), allowsWrapped, ebiten.ColorScale{}, font.FontOptions{})
+                fonts.MediumFont.RenderWrapped(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Allows", 1) + float64(10), float64(59), allowsWrapped, ebiten.ColorScale{}, font.FontOptions{})
 
-                fonts.DescriptionFont.RenderWrapped(screen, float64(85 * data.ScreenScale), float64(108 * data.ScreenScale), descriptionWrapped, ebiten.ColorScale{}, font.FontOptions{})
+                fonts.DescriptionFont.RenderWrapped(screen, float64(85), float64(108), descriptionWrapped, ebiten.ColorScale{}, font.FontOptions{})
 
                 /*
                 helpEntries := help.GetEntriesByName(building.String())
@@ -239,15 +240,15 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
         mainGroup.AddElement(&uilib.UIElement{
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
-                options.GeoM.Translate(float64(104 * data.ScreenScale), float64(28 * data.ScreenScale))
+                options.GeoM.Translate(float64(104), float64(28))
                 unitview.RenderUnitViewImage(screen, imageCache, bannerUnit, options, false, 0)
 
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(130 * data.ScreenScale), float64(7 * data.ScreenScale))
+                options.GeoM.Translate(float64(130), float64(7))
                 unitview.RenderUnitInfoBuild(screen, imageCache, bannerUnit, fonts.DescriptionFont, fonts.SmallFont, options, productionCost)
 
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(85 * data.ScreenScale), float64(48 * data.ScreenScale))
+                options.GeoM.Translate(float64(85), float64(48))
                 unitview.RenderUnitInfoStats(screen, imageCache, bannerUnit, 10, fonts.DescriptionFont, fonts.SmallFont, options)
 
                 /*
@@ -260,7 +261,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
         var getAlpha util.AlphaFadeFunc = func () float32 {
             return 1
         }
-        mainGroup.AddElements(unitview.MakeUnitAbilitiesElements(mainGroup, cache, imageCache, bannerUnit, fonts.MediumFont, 85 * data.ScreenScale, 108 * data.ScreenScale, &ui.Counter, 0, &getAlpha, true, 0, false))
+        mainGroup.AddElements(unitview.MakeUnitAbilitiesElements(mainGroup, cache, imageCache, bannerUnit, fonts.MediumFont, 85, 108, &ui.Counter, 0, &getAlpha, true, 0, false))
         // ui.AddElements(mainElements)
     }
 
@@ -270,7 +271,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
             return cmp.Compare(city.BuildingInfo.GetBuildingIndex(a), city.BuildingInfo.GetBuildingIndex(b))
         }) {
             x1 := 0
-            y1 := 4 * data.ScreenScale + i * (buildingInfo.Bounds().Dy() + 1)
+            y1 := 4 + i * (buildingInfo.Bounds().Dy() + 1)
             x2 := x1 + buildingInfo.Bounds().Dx()
             y2 := y1 + buildingInfo.Bounds().Dy()
 
@@ -295,7 +296,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(x1), float64(y1))
-                    screen.DrawImage(buildingInfo, &options)
+                    scale.DrawScaled(screen, buildingInfo, &options)
 
                     use := fonts.TitleFont
 
@@ -304,7 +305,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                         use = fonts.TitleFontWhite
                     }
 
-                    use.Print(screen, float64(x1 + 2 * data.ScreenScale), float64(y1 + 1 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, city.BuildingInfo.Name(building))
+                    use.Print(screen, float64(x1 + 2), float64(y1 + 1), float64(data.ScreenScale), ebiten.ColorScale{}, city.BuildingInfo.Name(building))
                 },
             }
 
@@ -326,8 +327,8 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
             return cmp.Compare(a.Name, b.Name)
         }) {
 
-            x1 := 240 * data.ScreenScale
-            y1 := 4 * data.ScreenScale + i * (buildingInfo.Bounds().Dy() + 1)
+            x1 := 240
+            y1 := 4 + i * (buildingInfo.Bounds().Dy() + 1)
             x2 := x1 + unitInfo.Bounds().Dx()
             y2 := y1 + unitInfo.Bounds().Dy()
 
@@ -352,7 +353,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(x1), float64(y1))
-                    screen.DrawImage(unitInfo, &options)
+                    scale.DrawScaled(screen, unitInfo, &options)
 
                     use := fonts.TitleFont
 
@@ -361,7 +362,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                         use = fonts.TitleFontWhite
                     }
 
-                    use.Print(screen, float64(x1 + 2 * data.ScreenScale), float64(y1 + 1 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, unit.String())
+                    use.Print(screen, float64(x1 + 2), float64(y1 + 1), float64(data.ScreenScale), ebiten.ColorScale{}, unit.String())
                 },
             }
 
@@ -380,8 +381,8 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
     buttonBackground, err := imageCache.GetImage("backgrnd.lbx", 24, 0)
 
     if err == nil {
-        cancelX := 100 * data.ScreenScale
-        cancelY := 181 * data.ScreenScale
+        cancelX := 100
+        cancelY := 181
 
         // cancel button
         group.AddElement(&uilib.UIElement{
@@ -398,14 +399,14 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(cancelX), float64(cancelY))
-                screen.DrawImage(buttonBackground, &options)
+                scale.DrawScaled(screen, buttonBackground, &options)
 
-                fonts.OkCancelFont.PrintCenter(screen, float64(cancelX + buttonBackground.Bounds().Dx() / 2), float64(cancelY + 1 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Cancel")
+                fonts.OkCancelFont.PrintCenter(screen, float64(cancelX + buttonBackground.Bounds().Dx() / 2), float64(cancelY + 1), float64(data.ScreenScale), ebiten.ColorScale{}, "Cancel")
             },
         })
 
-        okX := 173 * data.ScreenScale
-        okY := 181 * data.ScreenScale
+        okX := 173
+        okY := 181
         // ok button
         group.AddElement(&uilib.UIElement{
             Rect: util.ImageRect(okX, okY, buttonBackground),
@@ -421,9 +422,9 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(okX), float64(okY))
-                screen.DrawImage(buttonBackground, &options)
+                scale.DrawScaled(screen, buttonBackground, &options)
 
-                fonts.OkCancelFont.PrintCenter(screen, float64(okX + buttonBackground.Bounds().Dx() / 2), float64(okY + 1 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Ok")
+                fonts.OkCancelFont.PrintCenter(screen, float64(okX + buttonBackground.Bounds().Dx() / 2), float64(okY + 1), float64(data.ScreenScale), ebiten.ColorScale{}, "Ok")
             },
         })
     }

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -188,15 +188,15 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                     // vector.DrawFilledCircle(screen, float32(middleX), float32(middleY), 1, color.RGBA{255, 255, 255, 255}, true)
                 }
 
-                fonts.DescriptionFont.PrintOptions2(screen, float64(130), float64(12), font.FontOptions{Scale: scale.ScaleAmount}, city.BuildingInfo.Name(building))
-                fonts.SmallFont.PrintOptions2(screen, float64(130), float64(33), font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost %v", city.BuildingInfo.ProductionCost(building)))
+                fonts.DescriptionFont.PrintOptions(screen, float64(130), float64(12), font.FontOptions{Scale: scale.ScaleAmount}, city.BuildingInfo.Name(building))
+                fonts.SmallFont.PrintOptions(screen, float64(130), float64(33), font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost %v", city.BuildingInfo.ProductionCost(building)))
 
-                fonts.DescriptionFont.PrintOptions2(screen, float64(85), float64(48), font.FontOptions{Scale: scale.ScaleAmount}, "Maintenance")
+                fonts.DescriptionFont.PrintOptions(screen, float64(85), float64(48), font.FontOptions{Scale: scale.ScaleAmount}, "Maintenance")
 
                 buildingMaintenance := city.BuildingInfo.UpkeepCost(building)
 
                 if buildingMaintenance == 0 {
-                    fonts.MediumFont.PrintOptions2(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", 1) + float64(4), float64(49), font.FontOptions{Scale: scale.ScaleAmount}, "0")
+                    fonts.MediumFont.PrintOptions(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Maintenance", 1) + float64(4), float64(49), font.FontOptions{Scale: scale.ScaleAmount}, "0")
                 } else {
                     smallCoin, err := imageCache.GetImage("backgrnd.lbx", 42, 0)
                     if err == nil {
@@ -209,7 +209,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                     }
                 }
 
-                fonts.DescriptionFont.PrintOptions2(screen, 85, 58, font.FontOptions{Scale: scale.ScaleAmount}, "Allows")
+                fonts.DescriptionFont.PrintOptions(screen, 85, 58, font.FontOptions{Scale: scale.ScaleAmount}, "Allows")
 
                 fonts.MediumFont.RenderWrapped(screen, float64(85) + fonts.DescriptionFont.MeasureTextWidth("Allows", 1) + float64(10), float64(59), allowsWrapped, font.FontOptions{Scale: scale.ScaleAmount})
 
@@ -304,7 +304,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                         use = fonts.TitleFontWhite
                     }
 
-                    use.PrintOptions2(screen, float64(x1 + 2), float64(y1 + 1), font.FontOptions{Scale: scale.ScaleAmount}, city.BuildingInfo.Name(building))
+                    use.PrintOptions(screen, float64(x1 + 2), float64(y1 + 1), font.FontOptions{Scale: scale.ScaleAmount}, city.BuildingInfo.Name(building))
                 },
             }
 
@@ -361,7 +361,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                         use = fonts.TitleFontWhite
                     }
 
-                    use.PrintOptions2(screen, float64(x1 + 2), float64(y1 + 1), font.FontOptions{Scale: scale.ScaleAmount}, unit.String())
+                    use.PrintOptions(screen, float64(x1 + 2), float64(y1 + 1), font.FontOptions{Scale: scale.ScaleAmount}, unit.String())
                 },
             }
 
@@ -400,7 +400,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 options.GeoM.Translate(float64(cancelX), float64(cancelY))
                 scale.DrawScaled(screen, buttonBackground, &options)
 
-                fonts.OkCancelFont.PrintOptions2(screen, float64(cancelX + buttonBackground.Bounds().Dx() / 2), float64(cancelY + 1), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Cancel")
+                fonts.OkCancelFont.PrintOptions(screen, float64(cancelX + buttonBackground.Bounds().Dx() / 2), float64(cancelY + 1), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Cancel")
             },
         })
 
@@ -423,7 +423,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 options.GeoM.Translate(float64(okX), float64(okY))
                 scale.DrawScaled(screen, buttonBackground, &options)
 
-                fonts.OkCancelFont.PrintOptions2(screen, float64(okX + buttonBackground.Bounds().Dx() / 2), float64(okY + 1), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Ok")
+                fonts.OkCancelFont.PrintOptions(screen, float64(okX + buttonBackground.Bounds().Dx() / 2), float64(okY + 1), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Ok")
             },
         })
     }

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -944,7 +944,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 area := screen.SubImage(scale.ScaleRect(enchantmentAreaRect)).(*ebiten.Image)
 
-                useFont.PrintOptions2(area, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, enchantment.Enchantment.Name())
+                useFont.PrintOptions(area, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, enchantment.Enchantment.Name())
             },
         }
 
@@ -1565,7 +1565,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
 
                     printX, printY := baseGeoM.Apply(float64(x + use.Bounds().Dx() / 2) + roadX, float64(y + 1) + roadY)
 
-                    useFont.PrintOptions2(screen, printX, printY, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, text)
+                    useFont.PrintOptions(screen, printX, printY, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, text)
                 }
             }
         }
@@ -1800,7 +1800,7 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
 
             titleX := infoX + infoLeftMargin + maxInfoWidth / 2
 
-            fonts.HelpTitleFont.PrintOptions2(window, float64(titleX), float64(infoY + infoTopMargin), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, title)
+            fonts.HelpTitleFont.PrintOptions(window, float64(titleX), float64(infoY + infoTopMargin), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, title)
 
             yPos := infoY + (infoTopMargin + fonts.HelpTitleFont.Height() + 1)
             xPos := (infoX + infoLeftMargin)
@@ -1811,7 +1811,7 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
             for _, usage := range resources {
                 if usage.Count < 0 {
                     x, y := options.GeoM.Apply(0, 1)
-                    fonts.HelpFont.PrintOptions2(window, x, y, font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, "-")
+                    fonts.HelpFont.PrintOptions(window, x, y, font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, "-")
                 }
 
                 cityScreen.drawIcons(int(math.Abs(float64(usage.Count))), smallIcon, bigIcon, options, window)
@@ -1823,7 +1823,7 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
                     text = fmt.Sprintf("%v (Replaced)", usage.Name)
                 }
                 text += fmt.Sprintf(" (%v)", usage.Count)
-                fonts.HelpFont.PrintOptions2(window, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, text)
+                fonts.HelpFont.PrintOptions(window, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, text)
                 yPos += (fonts.HelpFont.Height() + 1)
                 options.GeoM.Translate(0, float64((fonts.HelpFont.Height() + 1)))
             }
@@ -1881,7 +1881,7 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
                 options.GeoM.Translate(float64(infoWidth) - fonts.HelpFont.MeasureTextWidth("More", 1) - float64(18), -float64(fonts.HelpFont.Height()))
                 x, y := options.GeoM.Apply(0, 0)
 
-                fonts.HelpFont.PrintOptions2(window, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, "More")
+                fonts.HelpFont.PrintOptions(window, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, "More")
             },
             LeftClick: func(this *uilib.UIElement){
                 currentPage = (currentPage + 1) % len(renderPages)
@@ -2147,8 +2147,8 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
         scale.DrawScaled(screen, ui, &options)
     }
 
-    cityScreen.Fonts.BigFont.PrintOptions2(screen, 20, 3, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v of %s", cityScreen.City.GetSize(), cityScreen.City.Name))
-    cityScreen.Fonts.DescriptionFont.PrintOptions2(screen, 6, 19, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("%v", cityScreen.City.Race))
+    cityScreen.Fonts.BigFont.PrintOptions(screen, 20, 3, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v of %s", cityScreen.City.GetSize(), cityScreen.City.Name))
+    cityScreen.Fonts.DescriptionFont.PrintOptions(screen, 6, 19, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("%v", cityScreen.City.Race))
 
     deltaNumber := func(n int) string {
         if n > 0 {
@@ -2160,7 +2160,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
         }
     }
 
-    cityScreen.Fonts.DescriptionFont.PrintOptions2(screen, 210, 19, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("Population: %v (%v)", cityScreen.City.Population, deltaNumber(cityScreen.City.PopulationGrowthRate())))
+    cityScreen.Fonts.DescriptionFont.PrintOptions(screen, 210, 19, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("Population: %v (%v)", cityScreen.City.Population, deltaNumber(cityScreen.City.PopulationGrowthRate())))
 
     showWork := false
     workRequired := 0
@@ -2185,7 +2185,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             scale.DrawScaled(screen, producingPics[index], &options)
         }
 
-        cityScreen.Fonts.ProducingFont.PrintOptions2(screen, 237, 179, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, cityScreen.City.BuildingInfo.Name(cityScreen.City.ProducingBuilding))
+        cityScreen.Fonts.ProducingFont.PrintOptions(screen, 237, 179, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, cityScreen.City.BuildingInfo.Name(cityScreen.City.ProducingBuilding))
 
         // for all buildings besides trade goods and housing, show amount of work required to build
 
@@ -2217,7 +2217,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             options.GeoM.Translate(238, 168)
             unitview.RenderCombatTile(screen, &cityScreen.ImageCache, options)
             unitview.RenderCombatUnit(screen, use, options, cityScreen.City.ProducingUnit.Count, data.UnitEnchantmentNone, 0, nil)
-            cityScreen.Fonts.ProducingFont.PrintOptions2(screen, 237, 179, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, cityScreen.City.ProducingUnit.Name)
+            cityScreen.Fonts.ProducingFont.PrintOptions(screen, 237, 179, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, cityScreen.City.ProducingUnit.Name)
         }
 
         showWork = true
@@ -2233,7 +2233,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             turn = fmt.Sprintf("%v Turns", int(math.Ceil(turns)))
         }
 
-        cityScreen.Fonts.DescriptionFont.PrintOptions2(screen, 318, 140, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, turn)
+        cityScreen.Fonts.DescriptionFont.PrintOptions(screen, 318, 140, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, turn)
 
         workEmpty, err1 := cityScreen.ImageCache.GetImage("backgrnd.lbx", 11, 0)
         workFull, err2 := cityScreen.ImageCache.GetImage("backgrnd.lbx", 12, 0)
@@ -2361,12 +2361,12 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
             fontOptions := font.FontOptions{Options: &useOptions, Scale: scale.ScaleAmount}
 
             titleX, titleY := options.GeoM.Apply(float64(20), float64(3))
-            fonts.BigFont.PrintOptions2(screen, titleX, titleY, fontOptions, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
+            fonts.BigFont.PrintOptions(screen, titleX, titleY, fontOptions, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
             raceX, raceY := options.GeoM.Apply(float64(6), float64(19))
-            fonts.DescriptionFont.PrintOptions2(screen, raceX, raceY, fontOptions, fmt.Sprintf("%v", city.Race))
+            fonts.DescriptionFont.PrintOptions(screen, raceX, raceY, fontOptions, fmt.Sprintf("%v", city.Race))
 
             unitsX, unitsY := options.GeoM.Apply(float64(6), float64(43))
-            fonts.DescriptionFont.PrintOptions2(screen, unitsX, unitsY, fontOptions, fmt.Sprintf("Units   %v", currentUnitName))
+            fonts.DescriptionFont.PrintOptions(screen, unitsX, unitsY, fontOptions, fmt.Sprintf("Units   %v", currentUnitName))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -2477,7 +2477,7 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                     var options ebiten.DrawImageOptions
                     options.ColorScale.ScaleAlpha(getAlpha())
-                    useFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, enchantment.Enchantment.Name())
+                    useFont.PrintOptions(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, enchantment.Enchantment.Name())
                 },
                 LeftClick: func(element *uilib.UIElement) {
                     if enchantment.Owner == player.GetBanner() {

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -1749,7 +1749,7 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
     infoWidth := helpTop.Bounds().Dx()
     // infoHeight := screen.HelpTop.Bounds().Dy()
     infoLeftMargin := 18
-    infoTopMargin := 20
+    infoTopMargin := 24
     infoBodyMargin := 3
     maxInfoWidth := infoWidth - infoLeftMargin - infoBodyMargin - 14
 

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -564,7 +564,7 @@ func makeCityScapeElement(cache *lbx.LbxCache, group *uilib.UIElementGroup, city
             return nil, err
         }
 
-        rawImageCache[index] = imageCache.ApplyScale(util.AutoCrop(images[0]))
+        rawImageCache[index] = util.AutoCrop(images[0])
 
         return images[0], nil
     }
@@ -630,7 +630,10 @@ func makeCityScapeElement(cache *lbx.LbxCache, group *uilib.UIElementGroup, city
                         pixelX := x - x1
                         pixelY := y - y1
 
-                        _, _, _, a := pic.At(pixelX, pixelY).RGBA()
+                        // log.Printf("look x=%v y=%v inside %v %v,%v,%v,%v at %v,%v", x, y, buildingName, x1, y1, x2, y2, pixelX, pixelY)
+
+                        _, _, _, a := pic.At(pic.Bounds().Min.X + pixelX, pic.Bounds().Min.Y + pixelY).RGBA()
+                        // log.Printf("  pixel value %v", pic.At(pixelX, pixelY))
                         if a > 0 {
                             buildingLook = slot.Building
                             // log.Printf("look at building %v (%v,%v) in (%v,%v,%v,%v)", slot.Building, useX, useY, x1, y1, x2, y2)

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -17,6 +17,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/coroutine"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
@@ -569,17 +570,17 @@ func makeCityScapeElement(cache *lbx.LbxCache, group *uilib.UIElementGroup, city
     }
 
     roadX := 0.0
-    roadY := 18.0 * data.ScreenScale
+    roadY := 18.0
 
     buildingLook := buildinglib.BuildingNone
     buildingLookTime := uint64(0)
-    buildingView := image.Rect(x1, y1, x1 + 206 * data.ScreenScale, y1 + 96 * data.ScreenScale)
+    buildingView := image.Rect(x1, y1, x1 + 206, y1 + 96)
     element := &uilib.UIElement{
         Rect: buildingView,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
             var geom ebiten.GeoM
             geom.Translate(float64(x1), float64(y1))
-            cityScapeScreen := screen.SubImage(buildingView).(*ebiten.Image)
+            cityScapeScreen := screen.SubImage(scale.ScaleRect(buildingView)).(*ebiten.Image)
             drawCityScape(cityScapeScreen, city, buildings, buildingLook, buildingLookTime, newBuilding, group.Counter / 8, imageCache, fonts, player, geom, (*getAlpha)())
             // vector.StrokeRect(screen, float32(buildingView.Min.X), float32(buildingView.Min.Y), float32(buildingView.Dx()), float32(buildingView.Dy()), 1, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff}, true)
         },
@@ -617,8 +618,8 @@ func makeCityScapeElement(cache *lbx.LbxCache, group *uilib.UIElementGroup, city
 
                 pic, err := getRawImage(index)
                 if err == nil {
-                    x1 := int(roadX) + slot.Point.X * data.ScreenScale
-                    y1 := int(roadY) + slot.Point.Y * data.ScreenScale - pic.Bounds().Dy()
+                    x1 := int(roadX) + slot.Point.X
+                    y1 := int(roadY) + slot.Point.Y - pic.Bounds().Dy()
                     x2 := x1 + pic.Bounds().Dx()
                     y2 := y1 + pic.Bounds().Dy()
 
@@ -704,7 +705,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
 
     var getAlpha util.AlphaFadeFunc = func() float32 { return 1 }
 
-    group.AddElement(makeCityScapeElement(cityScreen.LbxCache, group, cityScreen.City, &help, &cityScreen.ImageCache, sellBuilding, cityScreen.Buildings, newBuilding, 4 * data.ScreenScale, 101 * data.ScreenScale, cityScreen.Fonts, cityScreen.Player, &getAlpha))
+    group.AddElement(makeCityScapeElement(cityScreen.LbxCache, group, cityScreen.City, &help, &cityScreen.ImageCache, sellBuilding, cityScreen.Buildings, newBuilding, 4, 101, cityScreen.Fonts, cityScreen.Player, &getAlpha))
 
     // returns the amount of gold and the amount of production that will be used to buy a building
     computeBuyAmount := func(cost int) (int, float32) {
@@ -751,8 +752,8 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     }
 
     buyIndex := 0
-    buyX := 214 * data.ScreenScale
-    buyY := 188 * data.ScreenScale
+    buyX := 214
+    buyY := 188
     group.AddElement(&uilib.UIElement{
         Rect: image.Rect(buyX, buyY, buyX + buyButtons[0].Bounds().Dx(), buyY + buyButtons[0].Bounds().Dy()),
         PlaySoundLeftClick: true,
@@ -810,15 +811,15 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                 use = buyIndex
             }
 
-            screen.DrawImage(buyButtons[use], &options)
+            scale.DrawScaled(screen, buyButtons[use], &options)
         },
     })
 
     // change button
     changeButton, err := cityScreen.ImageCache.GetImage("backgrnd.lbx", 8, 0)
     if err == nil {
-        changeX := 247 * data.ScreenScale
-        changeY := 188 * data.ScreenScale
+        changeX := 247
+        changeY := 188
         group.AddElement(&uilib.UIElement{
             Rect: image.Rect(changeX, changeY, changeX + changeButton.Bounds().Dx(), changeY + changeButton.Bounds().Dy()),
             PlaySoundLeftClick: true,
@@ -836,7 +837,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(element.Rect.Min.X), float64(element.Rect.Min.Y))
-                screen.DrawImage(changeButton, &options)
+                scale.DrawScaled(screen, changeButton, &options)
             },
         })
     }
@@ -844,8 +845,8 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     // ok button
     okButton, err := cityScreen.ImageCache.GetImage("backgrnd.lbx", 9, 0)
     if err == nil {
-        okX := 286 * data.ScreenScale
-        okY := 188 * data.ScreenScale
+        okX := 286
+        okY := 188
         group.AddElement(&uilib.UIElement{
             Rect: image.Rect(okX, okY, okX + okButton.Bounds().Dx(), okY + okButton.Bounds().Dy()),
             PlaySoundLeftClick: true,
@@ -861,13 +862,13 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(element.Rect.Min.X), float64(element.Rect.Min.Y))
-                screen.DrawImage(okButton, &options)
+                scale.DrawScaled(screen, okButton, &options)
             },
         })
     }
 
-    enchantmentAreaRect := image.Rect(140 * data.ScreenScale, 51 * data.ScreenScale, 140 * data.ScreenScale + 60 * data.ScreenScale, 93 * data.ScreenScale)
-    maxEnchantments := enchantmentAreaRect.Dy() / (cityScreen.Fonts.BannerFonts[data.BannerGreen].Height() * data.ScreenScale)
+    enchantmentAreaRect := image.Rect(140, 51, 140 + 60, 93)
+    maxEnchantments := enchantmentAreaRect.Dy() / (cityScreen.Fonts.BannerFonts[data.BannerGreen].Height())
 
     var enchantmentElements []*uilib.UIElement
 
@@ -876,10 +877,10 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
         return cmp.Compare(a.Enchantment.Name(), b.Enchantment.Name())
     }) {
         useFont := cityScreen.Fonts.BannerFonts[enchantment.Owner]
-        x := 140 * data.ScreenScale
-        y := (51 + i * useFont.Height()) * data.ScreenScale
+        x := 140
+        y := (51 + i * useFont.Height())
 
-        rect := image.Rect(x, y, x + int(useFont.MeasureTextWidth(enchantment.Enchantment.Name(), float64(data.ScreenScale))), y + useFont.Height() * data.ScreenScale)
+        rect := image.Rect(x, y, x + int(useFont.MeasureTextWidth(enchantment.Enchantment.Name(), 1)), y + useFont.Height())
         inside := false
         enchantmentElement := &uilib.UIElement{
             Rect: rect,
@@ -938,9 +939,9 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                 }
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                area := screen.SubImage(enchantmentAreaRect).(*ebiten.Image)
+                area := screen.SubImage(scale.ScaleRect(enchantmentAreaRect)).(*ebiten.Image)
 
-                useFont.Print(area, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), float64(data.ScreenScale), ebiten.ColorScale{}, enchantment.Enchantment.Name())
+                useFont.PrintOptions2(area, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, enchantment.Enchantment.Name())
             },
         }
 
@@ -953,16 +954,16 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
         // shift all enchantment rect's around depending on the scroll position
         updateElements := func(){
             fontHeight := cityScreen.Fonts.BannerFonts[data.BannerGreen].Height()
-            yOffset := enchantmentMin * fontHeight * data.ScreenScale
+            yOffset := enchantmentMin * fontHeight
             for i, element := range enchantmentElements {
-                y := (51 + i * fontHeight) * data.ScreenScale
+                y := (51 + i * fontHeight)
                 element.Rect.Min.Y = y - yOffset
-                element.Rect.Max.Y = element.Rect.Min.Y + fontHeight * data.ScreenScale
+                element.Rect.Max.Y = element.Rect.Min.Y + fontHeight
             }
         }
 
         upArrow, _ := cityScreen.ImageCache.GetImages("resource.lbx", 32)
-        upArrowRect := util.ImageRect(200 * data.ScreenScale, 51 * data.ScreenScale, upArrow[0])
+        upArrowRect := util.ImageRect(200, 51, upArrow[0])
         upUse := 1
         group.AddElement(&uilib.UIElement{
             Rect: upArrowRect,
@@ -978,12 +979,12 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(upArrowRect.Min.X), float64(upArrowRect.Min.Y))
-                screen.DrawImage(upArrow[upUse], &options)
+                scale.DrawScaled(screen, upArrow[upUse], &options)
             },
         })
 
         downArrow, _ := cityScreen.ImageCache.GetImages("resource.lbx", 33)
-        downArrowRect := util.ImageRect(200 * data.ScreenScale, 83 * data.ScreenScale, downArrow[0])
+        downArrowRect := util.ImageRect(200, 83, downArrow[0])
         downUse := 1
         group.AddElement(&uilib.UIElement{
             Rect: downArrowRect,
@@ -999,7 +1000,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(downArrowRect.Min.X), float64(downArrowRect.Min.Y))
-                screen.DrawImage(downArrow[downUse], &options)
+                scale.DrawScaled(screen, downArrow[downUse], &options)
             },
         })
 
@@ -1031,12 +1032,12 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     farmer, err := cityScreen.ImageCache.GetImage("backgrnd.lbx", getRaceFarmerIndex(cityScreen.City.Race), 0)
     var setupWorkers func()
     if err == nil {
-        workerY := float64(27 * data.ScreenScale)
+        workerY := float64(27)
         var workerElements []*uilib.UIElement
         setupWorkers = func(){
             ui.RemoveElements(workerElements)
             workerElements = nil
-            citizenX := 6 * data.ScreenScale
+            citizenX := 6
 
             // the city might not have enough the required subsistence farmers, so only show what is available
             subsistenceFarmers := min(cityScreen.City.ComputeSubsistenceFarmers(), cityScreen.City.Farmers)
@@ -1048,7 +1049,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                     Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                         var options ebiten.DrawImageOptions
                         options.GeoM.Translate(float64(posX), workerY)
-                        screen.DrawImage(farmer, &options)
+                        scale.DrawScaled(screen, farmer, &options)
                     },
                     LeftClick: func(element *uilib.UIElement) {
                         cityScreen.City.Farmers = subsistenceFarmers
@@ -1061,7 +1062,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
             }
 
             // the farmers that can be changed to workers
-            citizenX += 3 * data.ScreenScale
+            citizenX += 3
             for i := subsistenceFarmers; i < cityScreen.City.Farmers; i++ {
                 posX := citizenX
 
@@ -1072,7 +1073,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                     Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                         var options ebiten.DrawImageOptions
                         options.GeoM.Translate(float64(posX), workerY)
-                        screen.DrawImage(farmer, &options)
+                        scale.DrawScaled(screen, farmer, &options)
                     },
                     LeftClick: func(element *uilib.UIElement) {
                         cityScreen.City.Farmers = extraFarmer
@@ -1095,7 +1096,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                         Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                             var options ebiten.DrawImageOptions
                             options.GeoM.Translate(float64(posX), workerY)
-                            screen.DrawImage(worker, &options)
+                            scale.DrawScaled(screen, worker, &options)
                         },
                         LeftClick: func(element *uilib.UIElement) {
                             cityScreen.City.Workers -= workerNum + 1
@@ -1110,15 +1111,15 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
 
             rebel, err := cityScreen.ImageCache.GetImage("backgrnd.lbx", getRaceRebelIndex(cityScreen.City.Race), 0)
             if err == nil {
-                citizenX += 3 * data.ScreenScale
+                citizenX += 3
                 for i := 0; i < cityScreen.City.Rebels; i++ {
                     posX := citizenX
 
                     workerElements = append(workerElements, &uilib.UIElement{
                         Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                             var options ebiten.DrawImageOptions
-                            options.GeoM.Translate(float64(posX), workerY - float64(2 * data.ScreenScale))
-                            screen.DrawImage(rebel, &options)
+                            options.GeoM.Translate(float64(posX), workerY - float64(2))
+                            scale.DrawScaled(screen, rebel, &options)
                         },
                     })
 
@@ -1144,8 +1145,8 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     var garrisonUnits []*uilib.UIElement
     resetUnits = func(){
         ui.RemoveElements(garrisonUnits)
-        garrisonX := 216 * data.ScreenScale
-        garrisonY := 103 * data.ScreenScale
+        garrisonX := 216
+        garrisonY := 103
 
         garrisonRow := 0
 
@@ -1189,8 +1190,9 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                         var options colorm.DrawImageOptions
                         var matrix colorm.ColorM
                         options.GeoM.Translate(float64(posX), float64(posY))
+                        options.GeoM.Concat(scale.ScaledGeom)
                         colorm.DrawImage(screen, garrisonBackground, matrix, &options)
-                        options.GeoM.Translate(float64(data.ScreenScale), float64(data.ScreenScale))
+                        options.GeoM.Translate(1, 1)
 
                         // draw in grey scale if the unit is on patrol
                         if useUnit.GetBusy() == units.BusyStatusPatrol {
@@ -1208,8 +1210,8 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
                 garrisonRow += 1
                 if garrisonRow >= 5 {
                     garrisonRow = 0
-                    garrisonX = 216 * data.ScreenScale
-                    garrisonY += pic.Bounds().Dy() + 1 * data.ScreenScale
+                    garrisonX = 216
+                    garrisonY += pic.Bounds().Dy() + 1
                 }
             }()
         }
@@ -1403,7 +1405,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(alphaScale)
         options.GeoM = baseGeoM
-        screen.DrawImage(landBackground, &options)
+        scale.DrawScaled(screen, landBackground, &options)
     }
 
     // horizon
@@ -1434,13 +1436,13 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
             options.ColorScale.ScaleAlpha(alphaScale)
             options.GeoM = baseGeoM
             options.GeoM.Translate(0, -1)
-            screen.DrawImage(horizon, &options)
+            scale.DrawScaled(screen, horizon, &options)
         }
     }
 
     // roads
-    roadX := float64(0.0 * data.ScreenScale)
-    roadY := float64(18.0 * data.ScreenScale)
+    roadX := float64(0.0)
+    roadY := float64(18.0)
 
     animationIndex = 0
     if onMyrror {
@@ -1453,7 +1455,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
         options.ColorScale.ScaleAlpha(alphaScale)
         options.GeoM = baseGeoM
         options.GeoM.Translate(roadX, roadY)
-        screen.DrawImage(normalRoad, &options)
+        scale.DrawScaled(screen, normalRoad, &options)
     }
 
     drawName := func(){
@@ -1485,9 +1487,9 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(alphaScale)
             options.GeoM = baseGeoM
-            options.GeoM.Translate(float64(0 * data.ScreenScale), float64(-2 * data.ScreenScale))
+            options.GeoM.Translate(0, -2)
             index := animationCounter % uint64(len(river))
-            screen.DrawImage(river[index], &options)
+            scale.DrawScaled(screen, river[index], &options)
         }
     }
 
@@ -1499,7 +1501,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
             index = 105 + building.RubbleIndex
         }
 
-        x, y := building.Point.X * data.ScreenScale, building.Point.Y * data.ScreenScale
+        x, y := building.Point.X, building.Point.Y
 
         images, err := imageCache.GetImagesTransform("cityscap.lbx", index, "crop", util.AutoCrop)
         // images, err := imageCache.GetImages("cityscap.lbx", index)
@@ -1542,7 +1544,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
             // vector.DrawFilledCircle(screen, float32(dx), float32(dy), 2, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff}, false)
             // options.GeoM.Translate(float64(x) + roadX, float64(y - use.Bounds().Dy()) + roadY)
             options.GeoM.Translate(0, float64(-use.Bounds().Dy()))
-            screen.DrawImage(use, &options)
+            scale.DrawScaled(screen, use, &options)
 
             if buildingLook == building.Building {
                 drawName = func(){
@@ -1558,9 +1560,9 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
                         text = fmt.Sprintf("%v's Fortress", player.Wizard.Name)
                     }
 
-                    printX, printY := baseGeoM.Apply(float64(x + use.Bounds().Dx() / 2) + roadX, float64(y + 1 * data.ScreenScale) + roadY)
+                    printX, printY := baseGeoM.Apply(float64(x + use.Bounds().Dx() / 2) + roadX, float64(y + 1) + roadY)
 
-                    useFont.PrintOptions(screen, printX, printY, float64(data.ScreenScale), options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}, text)
+                    useFont.PrintOptions2(screen, printX, printY, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, text)
                 }
             }
         }
@@ -1584,7 +1586,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
                 }
 
                 use := images[0]
-                x, y := building.Point.X * data.ScreenScale, building.Point.Y * data.ScreenScale
+                x, y := building.Point.X, building.Point.Y
 
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(0.6)
@@ -1592,7 +1594,7 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
                 options.GeoM.Translate(float64(x) + roadX, float64(y) + roadY)
                 options.GeoM.Translate(float64(dx - use.Bounds().Dx())/2, float64(-use.Bounds().Dy()))
 
-                screen.DrawImage(use, &options)
+                scale.DrawScaled(screen, use, &options)
             }
         }
     }
@@ -1607,18 +1609,18 @@ func drawCityScape(screen *ebiten.Image, city *citylib.City, buildings []Buildin
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(alphaScale)
                 options.GeoM = baseGeoM
-                options.GeoM.Translate(0, float64(85 * data.ScreenScale))
+                options.GeoM.Translate(0, 85)
                 images, _ := imageCache.GetImages("cityscap.lbx", enchantment.Enchantment.LbxIndex())
                 index := animationCounter % uint64(len(images))
-                screen.DrawImage(images[index], &options)
+                scale.DrawScaled(screen, images[index], &options)
             case data.CityEnchantmentNaturesEye, data.CityEnchantmentProsperity, data.CityEnchantmentConsecration,
                 data.CityEnchantmentInspirations:
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(alphaScale)
                 options.GeoM = baseGeoM
-                options.GeoM.Translate(float64(enchantment.Enchantment.IconOffset() * data.ScreenScale), float64(82 * data.ScreenScale))
+                options.GeoM.Translate(float64(enchantment.Enchantment.IconOffset()), 82)
                 image, _ := imageCache.GetImage("cityscap.lbx", enchantment.Enchantment.LbxIndex(), 0)
-                screen.DrawImage(image, &options)
+                scale.DrawScaled(screen, image, &options)
         }
     }
 
@@ -1686,33 +1688,39 @@ func (cityScreen *CityScreen) drawIcons(total int, small *ebiten.Image, large *e
     totalIcons := total / 10 + total % 10
 
     if totalIcons > 3 {
-        largeGap -= 1 * data.ScreenScale
+        largeGap -= 1
     }
 
     if totalIcons > 5 {
-        largeGap -= 4 * data.ScreenScale
+        largeGap -= 4
     }
 
     for range total / 10 {
         if screen != nil {
+            oldGeom := optionsM.GeoM
             // screen.DrawImage(large, &options)
+            optionsM.GeoM.Concat(scale.ScaledGeom)
             colorm.DrawImage(screen, large, matrix, &optionsM)
+            optionsM.GeoM = oldGeom
         }
         optionsM.GeoM.Translate(float64(largeGap), 0)
     }
 
     smallGap := small.Bounds().Dx() + 1
     if totalIcons > 4 {
-        smallGap -= 1 * data.ScreenScale
+        smallGap -= 1
     }
     if totalIcons >= 8 {
-        smallGap -= 1 * data.ScreenScale
+        smallGap -= 1
     }
 
     for range total % 10 {
         if screen != nil {
             // screen.DrawImage(small, &options)
+            oldGeom := optionsM.GeoM
+            optionsM.GeoM.Concat(scale.ScaledGeom)
             colorm.DrawImage(screen, small, matrix, &optionsM)
+            optionsM.GeoM = oldGeom
         }
         optionsM.GeoM.Translate(float64(smallGap), 0)
     }
@@ -1754,13 +1762,13 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
     bottom := helpTextY + textHeight
 
     // only draw as much of the top scroll as there are lines of text
-    topImage := helpTop.SubImage(image.Rect(0, 0, helpTop.Bounds().Dx(), int(bottom) * data.ScreenScale)).(*ebiten.Image)
+    topImage := helpTop.SubImage(image.Rect(0, 0, helpTop.Bounds().Dx(), int(bottom))).(*ebiten.Image)
     helpBottom, err := cityScreen.ImageCache.GetImage("help.lbx", 1, 0)
     if err != nil {
         return nil
     }
 
-    infoY := (data.ScreenHeight - bottom * data.ScreenScale - helpBottom.Bounds().Dy()) / 2
+    infoY := (data.ScreenHeight - bottom - helpBottom.Bounds().Dy()) / 2
 
     makeRenderPage := func(resources []ResourceUsage) func (screen *ebiten.Image) {
         widestResources := float64(0)
@@ -1775,13 +1783,13 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
 
         return func (window *ebiten.Image){
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(infoX * data.ScreenScale), float64(infoY))
+            options.GeoM.Translate(float64(infoX), float64(infoY))
             options.ColorScale.ScaleAlpha(getAlpha())
-            window.DrawImage(topImage, &options)
+            scale.DrawScaled(window, topImage, &options)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(infoX * data.ScreenScale), float64(bottom * data.ScreenScale + infoY))
-            window.DrawImage(helpBottom, &options)
+            options.GeoM.Translate(float64(infoX), float64(bottom + infoY))
+            scale.DrawScaled(window, helpBottom, &options)
 
             // for debugging
             // vector.StrokeRect(window, float32(infoX), float32(infoY), float32(infoWidth), float32(infoHeight), 1, color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}, true)
@@ -1789,10 +1797,10 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
 
             titleX := infoX + infoLeftMargin + maxInfoWidth / 2
 
-            fonts.HelpTitleFont.PrintCenter(window, float64(titleX * data.ScreenScale), float64(infoY + infoTopMargin * data.ScreenScale), 1, options.ColorScale, title)
+            fonts.HelpTitleFont.PrintOptions2(window, float64(titleX), float64(infoY + infoTopMargin), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, title)
 
-            yPos := infoY + (infoTopMargin + fonts.HelpTitleFont.Height() + 1) * data.ScreenScale
-            xPos := (infoX + infoLeftMargin) * data.ScreenScale
+            yPos := infoY + (infoTopMargin + fonts.HelpTitleFont.Height() + 1)
+            xPos := (infoX + infoLeftMargin)
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(xPos), float64(yPos))
@@ -1800,21 +1808,21 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
             for _, usage := range resources {
                 if usage.Count < 0 {
                     x, y := options.GeoM.Apply(0, 1)
-                    fonts.HelpFont.PrintRight(window, x, y, float64(data.ScreenScale), options.ColorScale, "-")
+                    fonts.HelpFont.PrintOptions2(window, x, y, font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, "-")
                 }
 
                 cityScreen.drawIcons(int(math.Abs(float64(usage.Count))), smallIcon, bigIcon, options, window)
 
-                x, y := options.GeoM.Apply(widestResources + float64(5 * data.ScreenScale), 0)
+                x, y := options.GeoM.Apply(widestResources + float64(5), 0)
 
                 text := usage.Name
                 if usage.Replaced {
                     text = fmt.Sprintf("%v (Replaced)", usage.Name)
                 }
                 text += fmt.Sprintf(" (%v)", usage.Count)
-                fonts.HelpFont.Print(window, x, y, float64(data.ScreenScale), options.ColorScale, text)
-                yPos += (fonts.HelpFont.Height() + 1) * data.ScreenScale
-                options.GeoM.Translate(0, float64((fonts.HelpFont.Height() + 1) * data.ScreenScale))
+                fonts.HelpFont.PrintOptions2(window, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, text)
+                yPos += (fonts.HelpFont.Height() + 1)
+                options.GeoM.Translate(0, float64((fonts.HelpFont.Height() + 1)))
             }
         }
     }
@@ -1848,12 +1856,12 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
     })
 
     if len(renderPages) > 1 {
-        width := fonts.HelpFont.MeasureTextWidth("More", float64(data.ScreenScale))
-        height := float64(fonts.HelpFont.Height() * data.ScreenScale)
+        width := fonts.HelpFont.MeasureTextWidth("More", 1)
+        height := float64(fonts.HelpFont.Height())
 
         var geom ebiten.GeoM
-        geom.Translate(float64(infoX * data.ScreenScale), float64(bottom * data.ScreenScale + infoY))
-        geom.Translate(float64(infoWidth) - width - float64(18 * data.ScreenScale), -height)
+        geom.Translate(float64(infoX), float64(bottom + infoY))
+        geom.Translate(float64(infoWidth) - width - float64(18), -height)
         x1, y1 := geom.Apply(0, 0)
         x2, y2 := geom.Apply(width, height)
 
@@ -1866,11 +1874,11 @@ func (cityScreen *CityScreen) MakeResourceDialog(title string, smallIcon *ebiten
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(infoX * data.ScreenScale), float64(bottom * data.ScreenScale + infoY))
-                options.GeoM.Translate(float64(infoWidth) - fonts.HelpFont.MeasureTextWidth("More", float64(data.ScreenScale)) - float64(18 * data.ScreenScale), -float64(fonts.HelpFont.Height() * data.ScreenScale))
+                options.GeoM.Translate(float64(infoX), float64(bottom + infoY))
+                options.GeoM.Translate(float64(infoWidth) - fonts.HelpFont.MeasureTextWidth("More", 1) - float64(18), -float64(fonts.HelpFont.Height()))
                 x, y := options.GeoM.Apply(0, 0)
 
-                fonts.HelpFont.Print(window, x, y, float64(data.ScreenScale), options.ColorScale, "More")
+                fonts.HelpFont.PrintOptions2(window, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, "More")
             },
             LeftClick: func(this *uilib.UIElement){
                 currentPage = (currentPage + 1) % len(renderPages)
@@ -2023,7 +2031,7 @@ func (cityScreen *CityScreen) CreateResourceIcons(ui *uilib.UI) []*uilib.UIEleme
 
     var elements []*uilib.UIElement
 
-    foodRect := image.Rect(6 * data.ScreenScale, 52 * data.ScreenScale, 6 * data.ScreenScale + 9 * bigFood.Bounds().Dx(), 52 * data.ScreenScale + bigFood.Bounds().Dy())
+    foodRect := image.Rect(6, 52, 6 + 9 * bigFood.Bounds().Dx(), 52 + bigFood.Bounds().Dy())
     elements = append(elements, &uilib.UIElement{
         Rect: foodRect,
         LeftClick: func(element *uilib.UIElement) {
@@ -2034,13 +2042,13 @@ func (cityScreen *CityScreen) CreateResourceIcons(ui *uilib.UI) []*uilib.UIEleme
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(foodRect.Min.X), float64(foodRect.Min.Y))
             options.GeoM = cityScreen.drawIcons(foodRequired, smallFood, bigFood, options, screen)
-            options.GeoM.Translate(float64(5 * data.ScreenScale), 0)
+            options.GeoM.Translate(float64(5), 0)
             cityScreen.drawIcons(foodSurplus, smallFood, bigFood, options, screen)
         },
     })
 
     production := cityScreen.City.WorkProductionRate()
-    workRect := image.Rect(6 * data.ScreenScale, 60 * data.ScreenScale, 6 * data.ScreenScale + 9 * bigHammer.Bounds().Dx(), 60 * data.ScreenScale + bigHammer.Bounds().Dy())
+    workRect := image.Rect(6, 60, 6 + 9 * bigHammer.Bounds().Dx(), 60 + bigHammer.Bounds().Dy())
     elements = append(elements, &uilib.UIElement{
         Rect: workRect,
         LeftClick: func(element *uilib.UIElement) {
@@ -2061,7 +2069,7 @@ func (cityScreen *CityScreen) CreateResourceIcons(ui *uilib.UI) []*uilib.UIEleme
 
     // FIXME: if income - upkeep < 0 then show greyed out icons for gold
 
-    goldMaintenanceRect := image.Rect(6 * data.ScreenScale, 68 * data.ScreenScale, 6 * data.ScreenScale + int(x), 68 * data.ScreenScale + bigCoin.Bounds().Dy())
+    goldMaintenanceRect := image.Rect(6, 68, 6 + int(x), 68 + bigCoin.Bounds().Dy())
     elements = append(elements, &uilib.UIElement{
         Rect: goldMaintenanceRect,
         LeftClick: func(element *uilib.UIElement) {
@@ -2081,7 +2089,7 @@ func (cityScreen *CityScreen) CreateResourceIcons(ui *uilib.UI) []*uilib.UIEleme
 
     goldGeom = cityScreen.drawIcons(goldSurplus, smallCoin, bigCoin, goldUpkeepOptions, nil)
     x, _ = goldGeom.Apply(0, 0)
-    goldSurplusRect := image.Rect(goldMaintenanceRect.Max.X + 6 * data.ScreenScale, 68 * data.ScreenScale, goldMaintenanceRect.Max.X + 6 * data.ScreenScale + int(x), 68 * data.ScreenScale + bigCoin.Bounds().Dy())
+    goldSurplusRect := image.Rect(goldMaintenanceRect.Max.X + 6, 68, goldMaintenanceRect.Max.X + 6 + int(x), 68 + bigCoin.Bounds().Dy())
     elements = append(elements, &uilib.UIElement{
         Rect: goldSurplusRect,
         LeftClick: func(element *uilib.UIElement) {
@@ -2096,7 +2104,7 @@ func (cityScreen *CityScreen) CreateResourceIcons(ui *uilib.UI) []*uilib.UIEleme
         },
     })
 
-    powerRect := image.Rect(6 * data.ScreenScale, 76 * data.ScreenScale, 6 * data.ScreenScale + 9 * bigMagic.Bounds().Dx(), 76 * data.ScreenScale + bigMagic.Bounds().Dy())
+    powerRect := image.Rect(6, 76, 6 + 9 * bigMagic.Bounds().Dx(), 76 + bigMagic.Bounds().Dy())
     elements = append(elements, &uilib.UIElement{
         Rect: powerRect,
         LeftClick: func(element *uilib.UIElement) {
@@ -2110,7 +2118,7 @@ func (cityScreen *CityScreen) CreateResourceIcons(ui *uilib.UI) []*uilib.UIEleme
         },
     })
 
-    researchRect := image.Rect(6 * data.ScreenScale, 84 * data.ScreenScale, 6 * data.ScreenScale + 9 * bigResearch.Bounds().Dx(), 84 * data.ScreenScale + bigResearch.Bounds().Dy())
+    researchRect := image.Rect(6, 84, 6 + 9 * bigResearch.Bounds().Dx(), 84 + bigResearch.Bounds().Dy())
     elements = append(elements, &uilib.UIElement{
         Rect: researchRect,
         LeftClick: func(element *uilib.UIElement) {
@@ -2133,11 +2141,11 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
     ui, err := cityScreen.ImageCache.GetImage("backgrnd.lbx", 6, 0)
     if err == nil {
         var options ebiten.DrawImageOptions
-        screen.DrawImage(ui, &options)
+        scale.DrawScaled(screen, ui, &options)
     }
 
-    cityScreen.Fonts.BigFont.PrintOptions(screen, float64(20 * data.ScreenScale), float64(3 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{DropShadow: true}, fmt.Sprintf("%v of %s", cityScreen.City.GetSize(), cityScreen.City.Name))
-    cityScreen.Fonts.DescriptionFont.Print(screen, float64(6 * data.ScreenScale), float64(19 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", cityScreen.City.Race))
+    cityScreen.Fonts.BigFont.PrintOptions2(screen, 20, 3, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v of %s", cityScreen.City.GetSize(), cityScreen.City.Name))
+    cityScreen.Fonts.DescriptionFont.PrintOptions2(screen, 6, 19, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("%v", cityScreen.City.Race))
 
     deltaNumber := func(n int) string {
         if n > 0 {
@@ -2149,7 +2157,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
         }
     }
 
-    cityScreen.Fonts.DescriptionFont.PrintRight(screen, float64(210 * data.ScreenScale), float64(19 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Population: %v (%v)", cityScreen.City.Population, deltaNumber(cityScreen.City.PopulationGrowthRate())))
+    cityScreen.Fonts.DescriptionFont.PrintOptions2(screen, 210, 19, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("Population: %v (%v)", cityScreen.City.Population, deltaNumber(cityScreen.City.PopulationGrowthRate())))
 
     showWork := false
     workRequired := 0
@@ -2170,11 +2178,11 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             index := animationCounter % uint64(len(producingPics))
 
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(217 * data.ScreenScale), float64(144 * data.ScreenScale))
-            screen.DrawImage(producingPics[index], &options)
+            options.GeoM.Translate(float64(217), float64(144))
+            scale.DrawScaled(screen, producingPics[index], &options)
         }
 
-        cityScreen.Fonts.ProducingFont.PrintOptions(screen, float64(237 * data.ScreenScale), float64(179 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}, cityScreen.City.BuildingInfo.Name(cityScreen.City.ProducingBuilding))
+        cityScreen.Fonts.ProducingFont.PrintOptions2(screen, 237, 179, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, cityScreen.City.BuildingInfo.Name(cityScreen.City.ProducingBuilding))
 
         // for all buildings besides trade goods and housing, show amount of work required to build
 
@@ -2182,8 +2190,8 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             producingBackground, err := cityScreen.ImageCache.GetImage("backgrnd.lbx", 13, 0)
             if err == nil {
                 var options ebiten.DrawImageOptions
-                options.GeoM.Translate(float64(260 * data.ScreenScale), float64(149 * data.ScreenScale))
-                screen.DrawImage(producingBackground, &options)
+                options.GeoM.Translate(float64(260), float64(149))
+                scale.DrawScaled(screen, producingBackground, &options)
             }
 
             description := ""
@@ -2192,7 +2200,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
                 case buildinglib.BuildingHousing: description = "Increases population growth rate."
             }
 
-            cityScreen.Fonts.ProducingFont.PrintWrap(screen, float64(285 * data.ScreenScale), float64(155 * data.ScreenScale), float64(60 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}, description)
+            cityScreen.Fonts.ProducingFont.PrintWrap(screen, 285, 155, 60, 1, ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, description)
         } else {
             showWork = true
             workRequired = cityScreen.City.BuildingInfo.ProductionCost(cityScreen.City.ProducingBuilding)
@@ -2203,10 +2211,10 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             var options ebiten.DrawImageOptions
             use := images[2]
 
-            options.GeoM.Translate(float64(238 * data.ScreenScale), float64(168 * data.ScreenScale))
+            options.GeoM.Translate(238, 168)
             unitview.RenderCombatTile(screen, &cityScreen.ImageCache, options)
             unitview.RenderCombatUnit(screen, use, options, cityScreen.City.ProducingUnit.Count, data.UnitEnchantmentNone, 0, nil)
-            cityScreen.Fonts.ProducingFont.PrintOptions(screen, float64(237 * data.ScreenScale), float64(179 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}, cityScreen.City.ProducingUnit.Name)
+            cityScreen.Fonts.ProducingFont.PrintOptions2(screen, 237, 179, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, cityScreen.City.ProducingUnit.Name)
         }
 
         showWork = true
@@ -2222,22 +2230,22 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
             turn = fmt.Sprintf("%v Turns", int(math.Ceil(turns)))
         }
 
-        cityScreen.Fonts.DescriptionFont.PrintRight(screen, float64(318 * data.ScreenScale), float64(140 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, turn)
+        cityScreen.Fonts.DescriptionFont.PrintOptions2(screen, 318, 140, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, turn)
 
         workEmpty, err1 := cityScreen.ImageCache.GetImage("backgrnd.lbx", 11, 0)
         workFull, err2 := cityScreen.ImageCache.GetImage("backgrnd.lbx", 12, 0)
         if err1 == nil && err2 == nil {
-            startX := 262 * data.ScreenScale
+            startX := 262
 
             x := startX
-            y := 151 * data.ScreenScale
+            y := 151
 
             coinsPerRow := 10
-            xSpacing := 5 * data.ScreenScale
+            xSpacing := 5
 
             if workRequired / 10 > 50 {
                 coinsPerRow = 20
-                xSpacing = 2 * data.ScreenScale
+                xSpacing = 2
             }
 
             coinsProduced := float64(cityScreen.City.Production) / 10.0
@@ -2250,15 +2258,15 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
                 if coinsProduced > float64(i) {
                     leftOver := coinsProduced - float64(i)
                     if leftOver >= 1 {
-                        screen.DrawImage(workFull, &options)
+                        scale.DrawScaled(screen, workFull, &options)
                     } else if leftOver > 0.05 {
-                        screen.DrawImage(workEmpty, &options)
+                        scale.DrawScaled(screen, workEmpty, &options)
                         part := workFull.SubImage(image.Rect(0, 0, int(float64(workFull.Bounds().Dx()) * leftOver), workFull.Bounds().Dy())).(*ebiten.Image)
-                        screen.DrawImage(part, &options)
+                        scale.DrawScaled(screen, part, &options)
                     }
 
                 } else {
-                    screen.DrawImage(workEmpty, &options)
+                    scale.DrawScaled(screen, workEmpty, &options)
                 }
 
                 row += 1
@@ -2274,11 +2282,11 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
     }
 
     // draw a few squares of the map
-    mapX := 215 * data.ScreenScale
-    mapY := 4 * data.ScreenScale
-    mapWidth := 100 * data.ScreenScale
-    mapHeight := 88 * data.ScreenScale
-    mapPart := screen.SubImage(image.Rect(mapX, mapY, mapX + mapWidth, mapY + mapHeight)).(*ebiten.Image)
+    mapX := 215
+    mapY := 4
+    mapWidth := 100
+    mapHeight := 88
+    mapPart := screen.SubImage(scale.ScaleRect(image.Rect(mapX, mapY, mapX + mapWidth, mapY + mapHeight))).(*ebiten.Image)
     var mapGeom ebiten.GeoM
     mapGeom.Translate(float64(mapX), float64(mapY))
     mapView(mapPart, mapGeom, cityScreen.Counter)
@@ -2345,15 +2353,17 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
             useOptions := options
             useOptions.ColorScale.ScaleAlpha(getAlpha())
 
-            screen.DrawImage(background, &useOptions)
+            scale.DrawScaled(screen, background, &useOptions)
 
-            titleX, titleY := options.GeoM.Apply(float64(20 * data.ScreenScale), float64(3 * data.ScreenScale))
-            fonts.BigFont.Print(screen, titleX, titleY, float64(data.ScreenScale), useOptions.ColorScale, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
-            raceX, raceY := options.GeoM.Apply(float64(6 * data.ScreenScale), float64(19 * data.ScreenScale))
-            fonts.DescriptionFont.Print(screen, raceX, raceY, float64(data.ScreenScale), useOptions.ColorScale, fmt.Sprintf("%v", city.Race))
+            fontOptions := font.FontOptions{Options: &useOptions, Scale: scale.ScaleAmount}
 
-            unitsX, unitsY := options.GeoM.Apply(float64(6 * data.ScreenScale), float64(43 * data.ScreenScale))
-            fonts.DescriptionFont.Print(screen, unitsX, unitsY, float64(data.ScreenScale), useOptions.ColorScale, fmt.Sprintf("Units   %v", currentUnitName))
+            titleX, titleY := options.GeoM.Apply(float64(20), float64(3))
+            fonts.BigFont.PrintOptions2(screen, titleX, titleY, fontOptions, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
+            raceX, raceY := options.GeoM.Apply(float64(6), float64(19))
+            fonts.DescriptionFont.PrintOptions2(screen, raceX, raceY, fontOptions, fmt.Sprintf("%v", city.Race))
+
+            unitsX, unitsY := options.GeoM.Apply(float64(6), float64(43))
+            fonts.DescriptionFont.PrintOptions2(screen, unitsX, unitsY, fontOptions, fmt.Sprintf("Units   %v", currentUnitName))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -2374,7 +2384,7 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
         ui.RemoveGroup(group)
         group = uilib.MakeGroup()
         ui.AddGroup(group)
-        x1, y1 := options.GeoM.Apply(float64(5 * data.ScreenScale), float64(102 * data.ScreenScale))
+        x1, y1 := options.GeoM.Apply(5, 102)
 
         cityScapeElement := makeCityScapeElement(cache, group, city, &help, &imageCache, func(buildinglib.Building){}, buildings, buildinglib.BuildingNone, int(x1), int(y1), fonts, otherPlayer, &getAlpha)
 
@@ -2385,33 +2395,33 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 localOptions := options
                 localOptions.ColorScale.ScaleAlpha(getAlpha())
-                localOptions.GeoM.Translate(float64(6 * data.ScreenScale), float64(27 * data.ScreenScale))
+                localOptions.GeoM.Translate(float64(6), float64(27))
                 farmer, _ := imageCache.GetImage("backgrnd.lbx", getRaceFarmerIndex(city.Race), 0)
                 worker, _ := imageCache.GetImage("backgrnd.lbx", getRaceWorkerIndex(city.Race), 0)
                 rebel, _ := imageCache.GetImage("backgrnd.lbx", getRaceRebelIndex(city.Race), 0)
                 subsistenceFarmers := city.ComputeSubsistenceFarmers()
 
                 for range subsistenceFarmers {
-                    screen.DrawImage(farmer, &localOptions)
+                    scale.DrawScaled(screen, farmer, &localOptions)
                     localOptions.GeoM.Translate(float64(farmer.Bounds().Dx()), 0)
                 }
 
-                localOptions.GeoM.Translate(float64(3 * data.ScreenScale), 0)
+                localOptions.GeoM.Translate(float64(3), 0)
 
                 for range city.Farmers - subsistenceFarmers {
-                    screen.DrawImage(farmer, &localOptions)
+                    scale.DrawScaled(screen, farmer, &localOptions)
                     localOptions.GeoM.Translate(float64(farmer.Bounds().Dx()), 0)
                 }
 
                 for range city.Workers {
-                    screen.DrawImage(worker, &localOptions)
+                    scale.DrawScaled(screen, worker, &localOptions)
                     localOptions.GeoM.Translate(float64(worker.Bounds().Dx()), 0)
                 }
 
-                localOptions.GeoM.Translate(float64(3 * data.ScreenScale), float64(-2 * data.ScreenScale))
+                localOptions.GeoM.Translate(float64(3), float64(-2))
 
                 for range city.Rebels {
-                    screen.DrawImage(rebel, &localOptions)
+                    scale.DrawScaled(screen, rebel, &localOptions)
                     localOptions.GeoM.Translate(float64(rebel.Bounds().Dx()), 0)
                 }
             },
@@ -2421,10 +2431,10 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
         if stack != nil && player.IsVisible(city.X, city.Y, city.Plane) {
             inside := 0
             for i, unit := range stack.Units() {
-                x, y := options.GeoM.Apply(float64(8 * data.ScreenScale), float64(52 * data.ScreenScale))
+                x, y := options.GeoM.Apply(float64(8), float64(52))
 
-                x += float64((i % 6) * 20 * data.ScreenScale)
-                y += float64((i / 6) * 20 * data.ScreenScale)
+                x += float64((i % 6) * 20)
+                y += float64((i / 6) * 20)
 
                 pic, _ := imageCache.GetImageTransform(unit.GetLbxFile(), unit.GetLbxIndex(), 0, unit.GetBanner().String(), units.MakeUpdateUnitColorsFunc(unit.GetBanner()))
                 rect := image.Rect(int(x), int(y), int(x) + pic.Bounds().Dx(), int(y) + pic.Bounds().Dy())
@@ -2443,7 +2453,7 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
                         var localOptions ebiten.DrawImageOptions
                         localOptions.ColorScale.ScaleAlpha(getAlpha())
                         localOptions.GeoM.Translate(x, y)
-                        screen.DrawImage(pic, &localOptions)
+                        scale.DrawScaled(screen, pic, &localOptions)
                     },
                 })
             }
@@ -2457,14 +2467,14 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
             if useFont == nil {
                 continue
             }
-            x, y := options.GeoM.Apply(float64(142 * data.ScreenScale), float64((51 + i * useFont.Height()) * data.ScreenScale))
-            rect := image.Rect(int(x), int(y), int(x + useFont.MeasureTextWidth(enchantment.Enchantment.Name(), float64(data.ScreenScale))), int(y) + useFont.Height() * data.ScreenScale)
+            x, y := options.GeoM.Apply(float64(142), float64((51 + i * useFont.Height())))
+            rect := image.Rect(int(x), int(y), int(x + useFont.MeasureTextWidth(enchantment.Enchantment.Name(), 1)), int(y) + useFont.Height())
             group.AddElement(&uilib.UIElement{
                 Rect: rect,
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                    var scale ebiten.ColorScale
-                    scale.ScaleAlpha(getAlpha())
-                    useFont.Print(screen, x, y, float64(data.ScreenScale), scale, enchantment.Enchantment.Name())
+                    var options ebiten.DrawImageOptions
+                    options.ColorScale.ScaleAlpha(getAlpha())
+                    useFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, enchantment.Enchantment.Name())
                 },
                 LeftClick: func(element *uilib.UIElement) {
                     if enchantment.Owner == player.GetBanner() {

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -2203,7 +2203,7 @@ func (cityScreen *CityScreen) Draw(screen *ebiten.Image, mapView func (screen *e
                 case buildinglib.BuildingHousing: description = "Increases population growth rate."
             }
 
-            cityScreen.Fonts.ProducingFont.PrintWrap(screen, 285, 155, 60, 1, ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, description)
+            cityScreen.Fonts.ProducingFont.PrintWrap(screen, 285, 155, 60, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, description)
         } else {
             showWork = true
             workRequired = cityScreen.City.BuildingInfo.ProductionCost(cityScreen.City.ProducingBuilding)

--- a/game/magic/cityview/enchantment.go
+++ b/game/magic/cityview/enchantment.go
@@ -6,8 +6,10 @@ import (
     "image"
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -28,7 +30,7 @@ func MakeNewBuildingView(cache *lbx.LbxCache, city *citylib.City, player *player
     }
 
     geom := ebiten.GeoM{}
-    geom.Translate(float64(30 * data.ScreenScale), float64(30 * data.ScreenScale))
+    geom.Translate(float64(30), float64(30))
 
     var getAlpha util.AlphaFadeFunc
     fadeSpeed := uint64(7)
@@ -50,23 +52,23 @@ func MakeNewBuildingView(cache *lbx.LbxCache, city *citylib.City, player *player
             options.ColorScale.ScaleAlpha(getAlpha())
             options.GeoM = geom
 
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
-            titleX, titleY := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(7 * data.ScreenScale))
+            titleX, titleY := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(7))
 
-            fonts.BigFont.PrintCenter(screen, titleX, titleY, float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
+            fonts.BigFont.PrintOptions2(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
 
-            descriptionX, descriptionY := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(background.Bounds().Dy() - fonts.CastFont.Height() * data.ScreenScale - 2 * data.ScreenScale))
-            fonts.CastFont.PrintCenter(screen, descriptionX, descriptionY, float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("You cast %v", name))
+            descriptionX, descriptionY := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(background.Bounds().Dy() - fonts.CastFont.Height() - 2))
+            fonts.CastFont.PrintOptions2(screen, descriptionX, descriptionY, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options}, fmt.Sprintf("You cast %v", name))
 
             geom2 := geom
-            geom2.Translate(float64(5 * data.ScreenScale), float64(27 * data.ScreenScale))
+            geom2.Translate(5, 27)
 
             x1, y1 := geom2.Apply(0, 0)
             // FIXME: get this rectangle from city-screen.go
-            x2, y2 := geom2.Apply(float64(206 * data.ScreenScale), float64(96 * data.ScreenScale))
+            x2, y2 := geom2.Apply(206, 96)
 
-            cityScapeScreen := screen.SubImage(image.Rect(int(x1), int(y1), int(x2), int(y2))).(*ebiten.Image)
+            cityScapeScreen := screen.SubImage(scale.ScaleRect(image.Rect(int(x1), int(y1), int(x2), int(y2)))).(*ebiten.Image)
             drawCityScape(cityScapeScreen, city, buildingSlots, buildinglib.BuildingNone, 0, newBuilding, ui.Counter / 8, &imageCache, fonts, player, geom2, getAlpha())
         },
     }

--- a/game/magic/cityview/enchantment.go
+++ b/game/magic/cityview/enchantment.go
@@ -56,10 +56,10 @@ func MakeNewBuildingView(cache *lbx.LbxCache, city *citylib.City, player *player
 
             titleX, titleY := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(7))
 
-            fonts.BigFont.PrintOptions2(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
+            fonts.BigFont.PrintOptions(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v of %s", city.GetSize(), city.Name))
 
             descriptionX, descriptionY := options.GeoM.Apply(float64(background.Bounds().Dx()) / 2, float64(background.Bounds().Dy() - fonts.CastFont.Height() - 2))
-            fonts.CastFont.PrintOptions2(screen, descriptionX, descriptionY, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options}, fmt.Sprintf("You cast %v", name))
+            fonts.CastFont.PrintOptions(screen, descriptionX, descriptionY, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options}, fmt.Sprintf("You cast %v", name))
 
             geom2 := geom
             geom2.Translate(5, 27)

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -2379,7 +2379,7 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
     combat.UpdateAnimations()
 
     // hudY := data.ScreenHeightOriginal - hudImage.Bounds().Dy()
-    hudY := (data.ScreenHeightOriginal - hudImage.Bounds().Dy())
+    hudY := (data.ScreenHeight - hudImage.Bounds().Dy())
 
     var keys []ebiten.Key
     keys = inpututil.AppendPressedKeys(keys)

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -359,7 +359,7 @@ func (combat *CombatScreen) GetCameraMatrix() ebiten.GeoM {
 func (combat *CombatScreen) ScreenToTile(x float64, y float64) (float64, float64) {
     // tile0, _ := combat.ImageCache.GetImage("cmbgrass.lbx", 0, 0)
     screenToTile := combat.GetCameraMatrix()
-    screenToTile.Scale(data.ScreenScale2, data.ScreenScale2)
+    screenToTile.Scale(scale.ScaleAmount, scale.ScaleAmount)
     screenToTile.Invert()
 
     // return screenToTile.Apply(x - float64(tile0.Bounds().Dx()/3) * combat.CameraScale, y - float64(tile0.Bounds().Dy()/3) * combat.CameraScale)
@@ -1712,7 +1712,7 @@ func (combat *CombatScreen) doSelectTile(yield coroutine.YieldFunc, selecter Tea
 
     selectElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
+            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(scale.Scale(1)), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
         },
     }
 
@@ -1806,7 +1806,7 @@ func (combat *CombatScreen) doSelectUnit(yield coroutine.YieldFunc, selecter Tea
 
     selectElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
+            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(scale.Scale(1)), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
         },
     }
 

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -23,6 +23,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/audio"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
@@ -56,16 +57,6 @@ func (state CombatState) String() string {
     }
 
     return ""
-}
-
-func applyGeomScale(geom ebiten.GeoM) ebiten.GeoM {
-    geom.Scale(data.ScreenScale2, data.ScreenScale2)
-    return geom
-}
-
-func applyScale(options ebiten.DrawImageOptions) *ebiten.DrawImageOptions {
-    options.GeoM.Scale(data.ScreenScale2, data.ScreenScale2)
-    return &options
 }
 
 type CombatEvent interface {
@@ -311,7 +302,7 @@ func MakeCombatScreen(cache *lbx.LbxCache, defendingArmy *Army, attackingArmy *A
     // coordinates.Scale(float64(tile0.Bounds().Dx())/2, float64(tile0.Bounds().Dy())/2)
     // FIXME: this math is hacky, but it works for now
     coordinates.Scale(float64(tile0.Bounds().Dx()) * 3 / 4 - 2, float64(tile0.Bounds().Dy()) * 3 / 4 - 1)
-    coordinates.Translate(float64(-220 * data.ScreenScale), float64(80 * data.ScreenScale))
+    coordinates.Translate(float64(-220), float64(80))
 
     events := make(chan CombatEvent, 1000)
 
@@ -429,7 +420,7 @@ func (combat *CombatScreen) createSkyProjectile(target *ArmyUnit, images []*ebit
     y := -rand.Float64() * 40
 
     // FIXME: make this a parameter?
-    speed := 2.2 * float64(data.ScreenScale)
+    speed := 2.2
 
     angle := math.Atan2(screenY - y, screenX - x)
 
@@ -464,7 +455,7 @@ func (combat *CombatScreen) createVerticalSkyProjectile(target *ArmyUnit, images
     y := -40.0
 
     // FIXME: make this a parameter?
-    speed := 2.5 * float64(data.ScreenScale)
+    speed := 2.5
 
     angle := math.Pi / 2
 
@@ -705,7 +696,7 @@ func (combat *CombatScreen) CreateWarpLightningProjectile(target *ArmyUnit) *Pro
     matrix := combat.GetCameraMatrix()
     screenX, screenY := matrix.Apply(float64(target.X), float64(target.Y))
     // screenY += 13
-    screenX += 3 * float64(data.ScreenScale)
+    screenX += 3
 
     // screenY -= float64(images[0].Bounds().Dy())
 
@@ -1139,53 +1130,49 @@ func (combat *CombatScreen) CreateMagicVortex(x int, y int) *OtherUnit {
 func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
     var elements []*uilib.UIElement
 
-    scaledOptions := applyGeomScale(ebiten.GeoM{})
-
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             hudImage, _ := combat.ImageCache.GetImage("backgrnd.lbx", 3, 0)
             options.GeoM.Reset()
             options.GeoM.Translate(0, float64(200 - hudImage.Bounds().Dy()))
-            options.GeoM.Scale(data.ScreenScale2, data.ScreenScale2)
-            screen.DrawImage(hudImage, &options)
+            scale.DrawScaled(screen, hudImage, &options)
 
             if combat.Model.AttackingArmy.Player == player && (combat.DoSelectUnit || combat.DoSelectTile) {
             } else {
-                x, y := scaledOptions.Apply(280, 167)
-                combat.AttackingWizardFont.PrintCenter(screen, x, y, float64(data.ScreenScale2), ebiten.ColorScale{}, combat.Model.AttackingArmy.Player.Wizard.Name)
+                combat.AttackingWizardFont.PrintOptions2(screen, 280, 167, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, combat.Model.AttackingArmy.Player.Wizard.Name)
 
                 options.GeoM.Reset()
                 options.GeoM.Translate(246, 179)
                 for _, enchantment := range combat.Model.AttackingArmy.Enchantments {
                     image, _ := combat.ImageCache.GetImage("compix.lbx", enchantment.LbxIndex(), 0)
-                    screen.DrawImage(image, applyScale(options))
+                    scale.DrawScaled(screen, image, &options)
                     options.GeoM.Translate(float64(image.Bounds().Dx()), 0)
                 }
             }
 
             y := 173
             right := 239
-            combat.HudFont.Print(screen, float64(200 * data.ScreenScale), float64(y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Skill:")
-            combat.HudFont.PrintRight(screen, float64(right * data.ScreenScale), float64(y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", combat.Model.AttackingArmy.ManaPool))
+            combat.HudFont.PrintOptions2(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Skill:")
+            combat.HudFont.PrintOptions2(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.AttackingArmy.ManaPool))
             y += combat.HudFont.Height() + 2
 
-            combat.HudFont.Print(screen, float64(200 * data.ScreenScale), float64(y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Mana:")
-            combat.HudFont.PrintRight(screen, float64(right * data.ScreenScale), float64(y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", combat.Model.AttackingArmy.Player.Mana))
+            combat.HudFont.PrintOptions2(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Mana:")
+            combat.HudFont.PrintOptions2(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.AttackingArmy.Player.Mana))
             y += combat.HudFont.Height() + 2
 
-            combat.HudFont.Print(screen, float64(200 * data.ScreenScale), float64(y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Range:")
-            combat.HudFont.PrintRight(screen, float64(right * data.ScreenScale), float64(y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%vx", combat.Model.AttackingArmy.Range.ToFloat()))
+            combat.HudFont.PrintOptions2(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Range:")
+            combat.HudFont.PrintOptions2(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%vx", combat.Model.AttackingArmy.Range.ToFloat()))
 
             if combat.Model.DefendingArmy.Player == player && (combat.DoSelectUnit || combat.DoSelectTile) {
             } else {
-                combat.DefendingWizardFont.PrintCenter(screen, float64(40 * data.ScreenScale), float64(167 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, combat.Model.DefendingArmy.Player.Wizard.Name)
+                combat.DefendingWizardFont.PrintOptions2(screen, 40, 167, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, combat.Model.DefendingArmy.Player.Wizard.Name)
 
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(7 * data.ScreenScale), float64(179 * data.ScreenScale))
+                options.GeoM.Translate(float64(7), float64(179))
                 for _, enchantment := range combat.Model.DefendingArmy.Enchantments {
                     image, _ := combat.ImageCache.GetImage("compix.lbx", enchantment.LbxIndex(), 0)
-                    screen.DrawImage(image, &options)
+                    scale.DrawScaled(screen, image, &options)
                     options.GeoM.Translate(float64(image.Bounds().Dx()), 0)
                 }
             }
@@ -1194,32 +1181,32 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
 
                 rightImage, _ := combat.ImageCache.GetImageTransform(combat.Model.SelectedUnit.Unit.GetCombatLbxFile(), combat.Model.SelectedUnit.Unit.GetCombatIndex(units.FacingRight), 0, player.Wizard.Banner.String(), units.MakeUpdateUnitColorsFunc(player.Wizard.Banner))
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(85 * data.ScreenScale), float64(170 * data.ScreenScale))
-                screen.DrawImage(rightImage, &options)
+                options.GeoM.Translate(85, 170)
+                scale.DrawScaled(screen, rightImage, &options)
 
-                combat.HudFont.Print(screen, float64(96 * data.ScreenScale), float64(166 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, combat.Model.SelectedUnit.Unit.GetName())
+                combat.HudFont.PrintOptions2(screen, 96, 166, font.FontOptions{Scale: scale.ScaleAmount}, combat.Model.SelectedUnit.Unit.GetName())
 
                 plainAttack, _ := combat.ImageCache.GetImage("compix.lbx", 29, 0)
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(130 * data.ScreenScale), float64(173 * data.ScreenScale))
-                screen.DrawImage(plainAttack, &options)
-                combat.HudFont.PrintRight(screen, float64(130 * data.ScreenScale), float64(174 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetMeleeAttackPower()))
+                options.GeoM.Translate(130, 173)
+                scale.DrawScaled(screen, plainAttack, &options)
+                combat.HudFont.PrintOptions2(screen, 130, 174, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetMeleeAttackPower()))
 
                 if combat.Model.SelectedUnit.RangedAttacks > 0 {
-                    y := float64(180 * data.ScreenScale)
+                    y := float64(180)
                     switch combat.Model.SelectedUnit.Unit.GetRangedAttackDamageType() {
                         case units.DamageRangedPhysical:
                             arrow, _ := combat.ImageCache.GetImage("compix.lbx", 34, 0)
                             options.GeoM.Reset()
-                            options.GeoM.Translate(float64(130 * data.ScreenScale), y)
-                            screen.DrawImage(arrow, &options)
-                            combat.HudFont.PrintRight(screen, float64(130 * data.ScreenScale), y+float64(2 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
+                            options.GeoM.Translate(float64(130), y)
+                            scale.DrawScaled(screen, arrow, &options)
+                            combat.HudFont.PrintOptions2(screen, 130, y+float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
                         case units.DamageRangedMagical:
                             magic, _ := combat.ImageCache.GetImage("compix.lbx", 30, 0)
                             options.GeoM.Reset()
-                            options.GeoM.Translate(float64(130 * data.ScreenScale), y)
-                            screen.DrawImage(magic, &options)
-                            combat.HudFont.PrintRight(screen, float64(130 * data.ScreenScale), y+float64(2 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
+                            options.GeoM.Translate(float64(130), y)
+                            scale.DrawScaled(screen, magic, &options)
+                            combat.HudFont.PrintOptions2(screen, 130, y+float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
                     }
                 }
 
@@ -1231,9 +1218,9 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                 }
 
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(130 * data.ScreenScale), float64(188 * data.ScreenScale))
-                screen.DrawImage(movementImage, &options)
-                combat.HudFont.PrintRight(screen, float64(130 * data.ScreenScale), float64(190 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", combat.Model.SelectedUnit.MovesLeft.ToFloat()))
+                options.GeoM.Translate(130, 188)
+                scale.DrawScaled(screen, movementImage, &options)
+                combat.HudFont.PrintOptions2(screen, 130, 190, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", combat.Model.SelectedUnit.MovesLeft.ToFloat()))
 
                 combat.DrawHealthBar(screen, 123, 197, combat.Model.SelectedUnit)
             }
@@ -1246,8 +1233,8 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
         },
     }
 
-    buttonX := float64(144 * data.ScreenScale)
-    buttonY := float64(168 * data.ScreenScale)
+    buttonX := float64(144)
+    buttonY := float64(168)
 
     makeButton := func(lbxIndex int, x int, y int, action func()) *uilib.UIElement {
         buttons, _ := combat.ImageCache.GetImages("compix.lbx", lbxIndex)
@@ -1265,7 +1252,7 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
-                screen.DrawImage(buttons[index], &options)
+                scale.DrawScaled(screen, buttons[index], &options)
             },
         }
     }
@@ -1620,7 +1607,7 @@ func (combat *CombatScreen) createUnitToUnitProjectile(attacker *ArmyUnit, targe
     }
     */
 
-    speed := 2.8 * float64(data.ScreenScale)
+    speed := 2.8 
 
     angle := math.Atan2(targetY - screenY, targetX - screenX)
 
@@ -1725,12 +1712,12 @@ func (combat *CombatScreen) doSelectTile(yield coroutine.YieldFunc, selecter Tea
 
     selectElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            combat.WhiteFont.PrintWrap(screen, float64(x * data.ScreenScale), float64(y * data.ScreenScale), float64(75 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
+            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
         },
     }
 
     cancelImages, _ := combat.ImageCache.GetImages("compix.lbx", 22)
-    cancelRect := image.Rect(0, 0, cancelImages[0].Bounds().Dx(), cancelImages[0].Bounds().Dy()).Add(image.Point{(x + 15) * data.ScreenScale, (y + 15) * data.ScreenScale})
+    cancelRect := image.Rect(0, 0, cancelImages[0].Bounds().Dx(), cancelImages[0].Bounds().Dy()).Add(image.Point{(x + 15), (y + 15)})
     cancelIndex := 0
     cancelElement := &uilib.UIElement{
         Rect: cancelRect,
@@ -1744,7 +1731,7 @@ func (combat *CombatScreen) doSelectTile(yield coroutine.YieldFunc, selecter Tea
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancelImages[cancelIndex], &options)
+            scale.DrawScaled(screen, cancelImages[cancelIndex], &options)
         },
     }
 
@@ -1767,12 +1754,12 @@ func (combat *CombatScreen) doSelectTile(yield coroutine.YieldFunc, selecter Tea
         combat.MouseTileX = int(math.Round(tileX))
         combat.MouseTileY = int(math.Round(tileY))
 
-        if mouseY >= hudY {
+        if mouseY >= scale.Scale(hudY) {
             combat.MouseState = CombatClickHud
         } else {
             combat.MouseState = CombatCast
 
-            if inputmanager.LeftClick() && mouseY < hudY {
+            if inputmanager.LeftClick() && mouseY < scale.Scale(hudY) {
                 sound, err := combat.AudioCache.GetSound(spell.Sound)
                 if err == nil {
                     sound.Play()
@@ -1819,14 +1806,14 @@ func (combat *CombatScreen) doSelectUnit(yield coroutine.YieldFunc, selecter Tea
 
     selectElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            combat.WhiteFont.PrintWrap(screen, float64(x * data.ScreenScale), float64(y * data.ScreenScale), float64(75 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
+            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
         },
     }
 
     quit := false
 
     cancelImages, _ := combat.ImageCache.GetImages("compix.lbx", 22)
-    cancelRect := image.Rect(0, 0, cancelImages[0].Bounds().Dx(), cancelImages[0].Bounds().Dy()).Add(image.Point{(x + 15) * data.ScreenScale, (y + 15) * data.ScreenScale})
+    cancelRect := image.Rect(0, 0, cancelImages[0].Bounds().Dx(), cancelImages[0].Bounds().Dy()).Add(image.Point{(x + 15), (y + 15)})
     cancelIndex := 0
     cancelElement := &uilib.UIElement{
         Rect: cancelRect,
@@ -1840,7 +1827,7 @@ func (combat *CombatScreen) doSelectUnit(yield coroutine.YieldFunc, selecter Tea
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancelImages[cancelIndex], &options)
+            scale.DrawScaled(screen, cancelImages[cancelIndex], &options)
         },
     }
 
@@ -1865,7 +1852,7 @@ func (combat *CombatScreen) doSelectUnit(yield coroutine.YieldFunc, selecter Tea
 
         combat.MouseState = CombatCast
 
-        if mouseY >= hudY {
+        if mouseY >= scale.Scale(hudY) {
             combat.MouseState = CombatClickHud
         } else {
             unit := combat.Model.GetUnit(combat.MouseTileX, combat.MouseTileY)
@@ -1873,7 +1860,7 @@ func (combat *CombatScreen) doSelectUnit(yield coroutine.YieldFunc, selecter Tea
                 combat.MouseState = CombatNotOk
             }
 
-            if unit != nil && canTarget(unit) && inputmanager.LeftClick() && mouseY < hudY {
+            if unit != nil && canTarget(unit) && inputmanager.LeftClick() && mouseY < scale.Scale(hudY) {
                 // log.Printf("Click unit at %v,%v -> %v", combat.MouseTileX, combat.MouseTileY, unit)
                 if selectTeam == TeamEither || unit.Team == selectTeam {
 
@@ -1919,7 +1906,7 @@ func (combat *CombatScreen) doCastEnchantment(yield coroutine.YieldFunc, caster 
 
     castDescription := fmt.Sprintf("%v cast %v", caster.Wizard.Name, spellName)
 
-    text := combat.EnchantmentFont.MeasureTextWidth(castDescription, float64(data.ScreenScale))
+    text := combat.EnchantmentFont.MeasureTextWidth(castDescription, 1)
 
     interpolate := func (counter int) uint8 {
         if counter < counterMax / 2 {
@@ -1932,14 +1919,14 @@ func (combat *CombatScreen) doCastEnchantment(yield coroutine.YieldFunc, caster 
     combat.Drawer = func (screen *ebiten.Image){
         oldDrawer(screen)
 
-        x1 := float64(data.ScreenWidth / 2) - text / 2 - float64(1 * data.ScreenScale)
-        x2 := float64(data.ScreenWidth / 2) + text / 2 + float64(1 * data.ScreenScale)
+        x1 := float64(data.ScreenWidth / 2) - text / 2 - float64(1)
+        x2 := float64(data.ScreenWidth / 2) + text / 2 + float64(1)
         y := 4
 
-        vector.DrawFilledRect(screen, float32(x1), float32(y * data.ScreenScale), float32(x2 - x1), float32((combat.EnchantmentFont.Height() + 1) * data.ScreenScale), color.RGBA{R: 0, G: 0, B: 0x0, A: 120}, false)
-        combat.EnchantmentFont.PrintCenter(screen, float64(data.ScreenWidth / 2), float64((y + 1) * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, castDescription)
+        vector.DrawFilledRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y)), float32(scale.Scale(x2 - x1)), float32(scale.Scale(combat.EnchantmentFont.Height() + 1)), color.RGBA{R: 0, G: 0, B: 0x0, A: 120}, false)
+        combat.EnchantmentFont.PrintOptions2(screen, float64(data.ScreenWidth / 2), float64((y + 1)), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, castDescription)
 
-        vector.StrokeRect(screen, float32(x1), float32(y * data.ScreenScale), float32(x2 - x1), float32((combat.EnchantmentFont.Height() + 1) * data.ScreenScale), 1, color.RGBA{R: 0xff, G: 0xff, B: 0x0, A: 0xff}, false)
+        vector.StrokeRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y)), float32(scale.Scale(x2 - x1)), float32(scale.Scale(combat.EnchantmentFont.Height() + 1)), float32(scale.Scale(1)), color.RGBA{R: 0xff, G: 0xff, B: 0x0, A: 0xff}, false)
 
         vector.DrawFilledRect(screen, 0, 0, float32(screen.Bounds().Dx()), float32(screen.Bounds().Dy()), util.PremultiplyAlpha(value), false)
     }
@@ -2392,12 +2379,12 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
     combat.UpdateAnimations()
 
     // hudY := data.ScreenHeightOriginal - hudImage.Bounds().Dy()
-    hudY := (data.ScreenHeightOriginal - hudImage.Bounds().Dy()) * int(data.ScreenScale2)
+    hudY := (data.ScreenHeightOriginal - hudImage.Bounds().Dy())
 
     var keys []ebiten.Key
     keys = inpututil.AppendPressedKeys(keys)
     for _, key := range keys {
-        speed := 0.8 * data.ScreenScale2
+        speed := 0.8
         switch key {
             case ebiten.KeyDown:
                 combat.Coordinates.Translate(0, -speed)
@@ -2489,7 +2476,7 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
         return CombatStateRunning
     }
 
-    if combat.UI.GetHighestLayerValue() > 0 || mouseY >= hudY {
+    if combat.UI.GetHighestLayerValue() > 0 || mouseY >= scale.Scale(hudY) {
         combat.MouseState = CombatClickHud
     } else if combat.Model.SelectedUnit != nil && combat.Model.SelectedUnit.Moving {
         combat.MouseState = CombatClickHud
@@ -2523,7 +2510,7 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
     // also don't allow clicks into the game if the ui is showing some overlay
     if combat.UI.GetHighestLayerValue() == 0 &&
        inputmanager.LeftClick() &&
-       mouseY < hudY {
+       mouseY < scale.Scale(hudY) {
 
         if combat.TileIsEmpty(combat.MouseTileX, combat.MouseTileY) && combat.Model.CanMoveTo(combat.Model.SelectedUnit, combat.MouseTileX, combat.MouseTileY){
             path, _ := combat.Model.FindPath(combat.Model.SelectedUnit, combat.MouseTileX, combat.MouseTileY)
@@ -2547,7 +2534,7 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
 
     if combat.UI.GetHighestLayerValue() == 0 &&
        inputmanager.RightClick() &&
-       mouseY < hudY {
+       mouseY < scale.Scale(hudY) {
 
        showUnit := combat.Model.GetUnit(combat.MouseTileX, combat.MouseTileY)
        if showUnit != nil {
@@ -2582,7 +2569,7 @@ func (combat *CombatScreen) DrawHighlightedTile(screen *ebiten.Image, x int, y i
     tx, ty := matrix.Apply(float64(x), float64(y))
     useMatrix.Scale(combat.CameraScale, combat.CameraScale)
     useMatrix.Translate(tx, ty)
-    useMatrix = applyGeomScale(useMatrix)
+    useMatrix = scale.ScaleGeom(useMatrix)
 
     // log.Printf("tx=%v, ty=%v", tx, ty)
 
@@ -2594,17 +2581,6 @@ func (combat *CombatScreen) DrawHighlightedTile(screen *ebiten.Image, x int, y i
     x3, y3 := useMatrix.Apply(float64(tile0.Bounds().Dx()/2), 0)
     // bottom
     x4, y4 := useMatrix.Apply(0, float64(tile0.Bounds().Dy()/2))
-
-    /*
-    x1 = tx - data.ScreenScale2 * float64(tile0.Bounds().Dx()/2)
-    y1 = ty
-    x2 = tx
-    y2 = ty - data.ScreenScale2 * float64(tile0.Bounds().Dy()/2)
-    x3 = tx + data.ScreenScale2 * float64(tile0.Bounds().Dx()/2)
-    y3 = ty
-    x4 = tx
-    y4 = ty + data.ScreenScale2 * float64(tile0.Bounds().Dy()/2)
-    */
 
     gradient := (math.Sin(float64(combat.Counter)/6) + 1)
 
@@ -2657,32 +2633,32 @@ func (combat *CombatScreen) ShowUnitInfo(screen *ebiten.Image, unit *ArmyUnit){
     y1 := 5
     width := 65
     height := 45
-    vector.DrawFilledRect(screen, float32(x1 * data.ScreenScale), float32(y1 * data.ScreenScale), float32(width * data.ScreenScale), float32(height * data.ScreenScale), color.RGBA{R: 0, G: 0, B: 0, A: 100}, false)
-    vector.StrokeRect(screen, float32(x1 * data.ScreenScale), float32(y1 * data.ScreenScale), float32(width * data.ScreenScale), float32(height * data.ScreenScale), float32(data.ScreenScale), util.PremultiplyAlpha(color.RGBA{R: 0x27, G: 0x4e, B: 0xdc, A: 100}), false)
-    combat.InfoFont.PrintOptions(screen, float64(x1 + 35) * float64(data.ScreenScale), float64(y1 + 2) * float64(data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}, fmt.Sprintf("%v", unit.Unit.GetName()))
+    vector.DrawFilledRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y1)), float32(scale.Scale(width)), float32(scale.Scale(height)), color.RGBA{R: 0, G: 0, B: 0, A: 100}, false)
+    vector.StrokeRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y1)), float32(scale.Scale(width)), float32(scale.Scale(height)), float32(scale.Scale(1)), util.PremultiplyAlpha(color.RGBA{R: 0x27, G: 0x4e, B: 0xdc, A: 100}), false)
+    combat.InfoFont.PrintOptions2(screen, float64(x1 + 35), float64(y1 + 2), font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.Unit.GetName()))
 
     meleeImage, _ := combat.ImageCache.GetImage("compix.lbx", 61, 0)
     var options ebiten.DrawImageOptions
-    options.GeoM.Translate(float64(x1 + 14) * float64(data.ScreenScale), float64(y1 + 10) * float64(data.ScreenScale))
-    screen.DrawImage(meleeImage, &options)
+    options.GeoM.Translate(float64(x1 + 14), float64(y1 + 10))
+    scale.DrawScaled(screen, meleeImage, &options)
     ax, ay := options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}, fmt.Sprintf("%v", unit.GetMeleeAttackPower()))
+    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetMeleeAttackPower()))
 
     switch unit.Unit.GetRangedAttackDamageType() {
         case units.DamageRangedMagical:
             fire, _ := combat.ImageCache.GetImage("compix.lbx", 62, 0)
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(x1 + 14) * float64(data.ScreenScale), float64(y1 + 18) * float64(data.ScreenScale))
-            screen.DrawImage(fire, &options)
+            options.GeoM.Translate(float64(x1 + 14), float64(y1 + 18))
+            scale.DrawScaled(screen, fire, &options)
             ax, ay := options.GeoM.Apply(0, 2)
-            combat.InfoFont.PrintOptions(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
+            combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
         case units.DamageRangedPhysical:
             arrow, _ := combat.ImageCache.GetImage("compix.lbx", 66, 0)
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(x1 + 14) * float64(data.ScreenScale), float64(y1 + 18) * float64(data.ScreenScale))
-            screen.DrawImage(arrow, &options)
+            options.GeoM.Translate(float64(x1 + 14), float64(y1 + 18))
+            scale.DrawScaled(screen, arrow, &options)
             ax, ay := options.GeoM.Apply(0, 2)
-            combat.InfoFont.PrintOptions(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
+            combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
     }
 
     movementImage, _ := combat.ImageCache.GetImage("compix.lbx", 72, 0)
@@ -2691,26 +2667,26 @@ func (combat *CombatScreen) ShowUnitInfo(screen *ebiten.Image, unit *ArmyUnit){
     }
 
     options.GeoM.Reset()
-    options.GeoM.Translate(float64(x1 + 14) * float64(data.ScreenScale), float64(y1 + 26) * float64(data.ScreenScale))
-    screen.DrawImage(movementImage, &options)
+    options.GeoM.Translate(float64(x1 + 14), float64(y1 + 26))
+    scale.DrawScaled(screen, movementImage, &options)
     ax, ay = options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}, fmt.Sprintf("%v", unit.MovesLeft.ToFloat()))
+    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.MovesLeft.ToFloat()))
 
     armorImage, _ := combat.ImageCache.GetImage("compix.lbx", 70, 0)
     options.GeoM.Reset()
-    options.GeoM.Translate(float64(x1 + 48) * float64(data.ScreenScale), float64(y1 + 10) * float64(data.ScreenScale))
-    screen.DrawImage(armorImage, &options)
+    options.GeoM.Translate(float64(x1 + 48), float64(y1 + 10))
+    scale.DrawScaled(screen, armorImage, &options)
     ax, ay = options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}, fmt.Sprintf("%v", unit.GetDefense()))
+    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetDefense()))
 
     resistanceImage, _ := combat.ImageCache.GetImage("compix.lbx", 75, 0)
     options.GeoM.Reset()
-    options.GeoM.Translate(float64(x1 + 48) * float64(data.ScreenScale), float64(y1 + 18) * float64(data.ScreenScale))
-    screen.DrawImage(resistanceImage, &options)
+    options.GeoM.Translate(float64(x1 + 48), float64(y1 + 18))
+    scale.DrawScaled(screen, resistanceImage, &options)
     ax, ay = options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions(screen, ax, ay, float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}, fmt.Sprintf("%v", unit.GetResistance()))
+    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetResistance()))
 
-    combat.InfoFont.PrintOptions(screen, float64(x1 + 14) * float64(data.ScreenScale), float64(y1 + 37) * float64(data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}, "Hits")
+    combat.InfoFont.PrintOptions2(screen, float64(x1 + 14), float64(y1 + 37), font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, "Hits")
 
     combat.DrawHealthBar(screen, x1 + 25, y1 + 40, unit)
 }
@@ -2725,7 +2701,7 @@ func (combat *CombatScreen) DrawHealthBar(screen *ebiten.Image, x int, y int, un
     lowHealth := color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}
     healthWidth := 15
 
-    vector.StrokeLine(screen, float32(x * data.ScreenScale), float32(y * data.ScreenScale), float32(x + healthWidth) * float32(data.ScreenScale), float32(y * data.ScreenScale), float32(data.ScreenScale), color.RGBA{R: 0, G: 0, B: 0, A: 0xff}, false)
+    vector.StrokeLine(screen, float32(scale.Scale(x)), float32(scale.Scale(y)), float32(scale.Scale(x + healthWidth)), float32(scale.Scale(y)), float32(scale.Scale(1)), color.RGBA{R: 0, G: 0, B: 0, A: 0xff}, false)
 
     healthPercent := float64(unit.Unit.GetHealth()) / float64(unit.Unit.GetMaxHealth())
     healthLength := float64(healthWidth) * healthPercent
@@ -2744,7 +2720,7 @@ func (combat *CombatScreen) DrawHealthBar(screen *ebiten.Image, x int, y int, un
         useColor = highHealth
     }
 
-    vector.StrokeLine(screen, float32(x * data.ScreenScale), float32(y * data.ScreenScale), (float32(x) + float32(healthLength)) * float32(data.ScreenScale), float32(y * data.ScreenScale), float32(data.ScreenScale), useColor, false)
+    vector.StrokeLine(screen, float32(scale.Scale(x)), float32(scale.Scale(y)), scale.Scale(float32(x) + float32(healthLength)), float32(scale.Scale(y)), float32(scale.Scale(1)), useColor, false)
 }
 
 func (combat *CombatScreen) DrawWall(screen *ebiten.Image, x int, y int, tilePosition func(float64, float64) (float64, float64), animationIndex uint64){
@@ -2808,7 +2784,7 @@ func (combat *CombatScreen) DrawWall(screen *ebiten.Image, x int, y int, tilePos
 
         options.GeoM.Concat(geom)
 
-        screen.DrawImage(drawImage, &options)
+        scale.DrawScaled(screen, drawImage, &options)
     }
 
     // lbx indices for fire
@@ -2939,7 +2915,7 @@ func (combat *CombatScreen) DrawWall(screen *ebiten.Image, x int, y int, tilePos
 
             options.GeoM.Concat(geom)
 
-            screen.DrawImage(drawImage, &options)
+            scale.DrawScaled(screen, drawImage, &options)
         }
 
         drewNorth := false
@@ -3063,12 +3039,12 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
         tx, ty := tilePosition(float64(x), float64(y))
         options.GeoM.Scale(combat.CameraScale, combat.CameraScale)
         options.GeoM.Translate(tx, ty)
-        screen.DrawImage(image, applyScale(options))
+        scale.DrawScaled(screen, image, &options)
 
         if combat.Model.Tiles[y][x].Mud {
             mudTiles, _ := combat.ImageCache.GetImages("cmbtcity.lbx", 118)
             index := animationIndex % uint64(len(mudTiles))
-            screen.DrawImage(mudTiles[index], &options)
+            scale.DrawScaled(screen, mudTiles[index], &options)
         }
 
         // vector.DrawFilledCircle(screen, float32(tx), float32(ty), 2, color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}, false)
@@ -3082,7 +3058,7 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
         options.GeoM.Scale(combat.CameraScale, combat.CameraScale)
         options.GeoM.Translate(tx, ty)
         options.GeoM.Translate(0, float64(tile0.Bounds().Dy())/2)
-        screen.DrawImage(road, &options)
+        scale.DrawScaled(screen, road, &options)
 
     }
 
@@ -3098,7 +3074,7 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
             options.GeoM.Scale(combat.CameraScale, combat.CameraScale)
             options.GeoM.Translate(tx, ty)
 
-            extra.Drawer(screen, &combat.ImageCache, applyScale(options), combat.Counter)
+            extra.Drawer(screen, &combat.ImageCache, &options, combat.Counter)
         } else if extra.Index != -1 {
             options.GeoM.Reset()
             // tx,ty is the middle of the tile
@@ -3124,7 +3100,7 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
 
             options.GeoM.Concat(geom)
 
-            screen.DrawImage(extraImage, applyScale(options))
+            scale.DrawScaled(screen, extraImage, &options)
 
             // vector.DrawFilledCircle(screen, float32(tx), float32(ty), 2, color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}, false)
         }
@@ -3164,8 +3140,7 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
                 options.GeoM.Reset()
                 options.GeoM.Scale(combat.CameraScale, combat.CameraScale)
                 options.GeoM.Translate(tx, ty)
-                options.GeoM = applyGeomScale(options.GeoM)
-                screen.DrawImage(movementImage, &options)
+                scale.DrawScaled(screen, movementImage, &options)
             }
         }
 
@@ -3270,37 +3245,37 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
                         index := animationIndex % uint64(len(images))
                         use := images[index]
 
-                        screen.DrawImage(use, &unitOptions)
+                        scale.DrawScaled(screen, use, &unitOptions)
                     case data.UnitCurseWeakness:
                         images, _ := combat.ImageCache.GetImages("resource.lbx", 80)
                         index := animationIndex % uint64(len(images))
                         use := images[index]
 
-                        screen.DrawImage(use, &unitOptions)
+                        scale.DrawScaled(screen, use, &unitOptions)
                     case data.UnitCurseVertigo:
                         images, _ := combat.ImageCache.GetImages("cmbtfx.lbx", 17)
                         index := animationIndex % uint64(len(images))
                         use := images[index]
 
-                        screen.DrawImage(use, &unitOptions)
+                        scale.DrawScaled(screen, use, &unitOptions)
                     case data.UnitCurseShatter:
                         images, _ := combat.ImageCache.GetImages("resource.lbx", 79)
                         index := animationIndex % uint64(len(images))
                         use := images[index]
 
-                        screen.DrawImage(use, &unitOptions)
+                        scale.DrawScaled(screen, use, &unitOptions)
                     case data.UnitCurseConfusion:
                         images, _ := combat.ImageCache.GetImages("resource.lbx", 76)
                         index := animationIndex % uint64(len(images))
                         use := images[index]
 
-                        screen.DrawImage(use, &unitOptions)
+                        scale.DrawScaled(screen, use, &unitOptions)
                 }
             }
 
             if unit.IsWebbed() {
                 image, _ := combat.ImageCache.GetImage("resource.lbx", 82, 0)
-                screen.DrawImage(image, &unitOptions)
+                scale.DrawScaled(screen, image, &unitOptions)
             }
         }
     }
@@ -3354,7 +3329,7 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
 
         frame := unit.Animation.Frame()
         unitOptions.GeoM.Translate(float64(-frame.Bounds().Dx()/2), float64(-frame.Bounds().Dy()))
-        screen.DrawImage(frame, &unitOptions)
+        scale.DrawScaled(screen, frame, &unitOptions)
     }
 
     combat.UI.Draw(combat.UI, screen)
@@ -3375,7 +3350,7 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
             options.GeoM.Scale(combat.CameraScale, combat.CameraScale)
             options.GeoM.Translate(float64(-frame.Bounds().Dx()/2), float64(-frame.Bounds().Dy())/2)
             options.GeoM.Translate(projectile.X, projectile.Y)
-            screen.DrawImage(frame, &options)
+            scale.DrawScaled(screen, frame, &options)
         }
     }
 }

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1712,7 +1712,7 @@ func (combat *CombatScreen) doSelectTile(yield coroutine.YieldFunc, selecter Tea
 
     selectElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(scale.Scale(1)), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
+            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
         },
     }
 
@@ -1806,7 +1806,7 @@ func (combat *CombatScreen) doSelectUnit(yield coroutine.YieldFunc, selecter Tea
 
     selectElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), float64(scale.Scale(1)), ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
+            combat.WhiteFont.PrintWrap(screen, float64(x), float64(y), float64(75), font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Select a target for a %v spell.", spell.Name))
         },
     }
 

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1140,7 +1140,7 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
 
             if combat.Model.AttackingArmy.Player == player && (combat.DoSelectUnit || combat.DoSelectTile) {
             } else {
-                combat.AttackingWizardFont.PrintOptions2(screen, 280, 167, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, combat.Model.AttackingArmy.Player.Wizard.Name)
+                combat.AttackingWizardFont.PrintOptions(screen, 280, 167, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, combat.Model.AttackingArmy.Player.Wizard.Name)
 
                 options.GeoM.Reset()
                 options.GeoM.Translate(246, 179)
@@ -1153,20 +1153,20 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
 
             y := 173
             right := 239
-            combat.HudFont.PrintOptions2(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Skill:")
-            combat.HudFont.PrintOptions2(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.AttackingArmy.ManaPool))
+            combat.HudFont.PrintOptions(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Skill:")
+            combat.HudFont.PrintOptions(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.AttackingArmy.ManaPool))
             y += combat.HudFont.Height() + 2
 
-            combat.HudFont.PrintOptions2(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Mana:")
-            combat.HudFont.PrintOptions2(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.AttackingArmy.Player.Mana))
+            combat.HudFont.PrintOptions(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Mana:")
+            combat.HudFont.PrintOptions(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.AttackingArmy.Player.Mana))
             y += combat.HudFont.Height() + 2
 
-            combat.HudFont.PrintOptions2(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Range:")
-            combat.HudFont.PrintOptions2(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%vx", combat.Model.AttackingArmy.Range.ToFloat()))
+            combat.HudFont.PrintOptions(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Range:")
+            combat.HudFont.PrintOptions(screen, float64(right), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%vx", combat.Model.AttackingArmy.Range.ToFloat()))
 
             if combat.Model.DefendingArmy.Player == player && (combat.DoSelectUnit || combat.DoSelectTile) {
             } else {
-                combat.DefendingWizardFont.PrintOptions2(screen, 40, 167, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, combat.Model.DefendingArmy.Player.Wizard.Name)
+                combat.DefendingWizardFont.PrintOptions(screen, 40, 167, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, combat.Model.DefendingArmy.Player.Wizard.Name)
 
                 options.GeoM.Reset()
                 options.GeoM.Translate(float64(7), float64(179))
@@ -1184,13 +1184,13 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                 options.GeoM.Translate(85, 170)
                 scale.DrawScaled(screen, rightImage, &options)
 
-                combat.HudFont.PrintOptions2(screen, 96, 166, font.FontOptions{Scale: scale.ScaleAmount}, combat.Model.SelectedUnit.Unit.GetName())
+                combat.HudFont.PrintOptions(screen, 96, 166, font.FontOptions{Scale: scale.ScaleAmount}, combat.Model.SelectedUnit.Unit.GetName())
 
                 plainAttack, _ := combat.ImageCache.GetImage("compix.lbx", 29, 0)
                 options.GeoM.Reset()
                 options.GeoM.Translate(130, 173)
                 scale.DrawScaled(screen, plainAttack, &options)
-                combat.HudFont.PrintOptions2(screen, 130, 174, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetMeleeAttackPower()))
+                combat.HudFont.PrintOptions(screen, 130, 174, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetMeleeAttackPower()))
 
                 if combat.Model.SelectedUnit.RangedAttacks > 0 {
                     y := float64(180)
@@ -1200,13 +1200,13 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                             options.GeoM.Reset()
                             options.GeoM.Translate(float64(130), y)
                             scale.DrawScaled(screen, arrow, &options)
-                            combat.HudFont.PrintOptions2(screen, 130, y+float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
+                            combat.HudFont.PrintOptions(screen, 130, y+float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
                         case units.DamageRangedMagical:
                             magic, _ := combat.ImageCache.GetImage("compix.lbx", 30, 0)
                             options.GeoM.Reset()
                             options.GeoM.Translate(float64(130), y)
                             scale.DrawScaled(screen, magic, &options)
-                            combat.HudFont.PrintOptions2(screen, 130, y+float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
+                            combat.HudFont.PrintOptions(screen, 130, y+float64(2), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, fmt.Sprintf("%v", combat.Model.SelectedUnit.GetRangedAttackPower()))
                     }
                 }
 
@@ -1220,7 +1220,7 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                 options.GeoM.Reset()
                 options.GeoM.Translate(130, 188)
                 scale.DrawScaled(screen, movementImage, &options)
-                combat.HudFont.PrintOptions2(screen, 130, 190, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", combat.Model.SelectedUnit.MovesLeft.ToFloat()))
+                combat.HudFont.PrintOptions(screen, 130, 190, font.FontOptions{Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", combat.Model.SelectedUnit.MovesLeft.ToFloat()))
 
                 combat.DrawHealthBar(screen, 123, 197, combat.Model.SelectedUnit)
             }
@@ -1924,7 +1924,7 @@ func (combat *CombatScreen) doCastEnchantment(yield coroutine.YieldFunc, caster 
         y := 4
 
         vector.DrawFilledRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y)), float32(scale.Scale(x2 - x1)), float32(scale.Scale(combat.EnchantmentFont.Height() + 1)), color.RGBA{R: 0, G: 0, B: 0x0, A: 120}, false)
-        combat.EnchantmentFont.PrintOptions2(screen, float64(data.ScreenWidth / 2), float64((y + 1)), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, castDescription)
+        combat.EnchantmentFont.PrintOptions(screen, float64(data.ScreenWidth / 2), float64((y + 1)), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, castDescription)
 
         vector.StrokeRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y)), float32(scale.Scale(x2 - x1)), float32(scale.Scale(combat.EnchantmentFont.Height() + 1)), float32(scale.Scale(1)), color.RGBA{R: 0xff, G: 0xff, B: 0x0, A: 0xff}, false)
 
@@ -2635,14 +2635,14 @@ func (combat *CombatScreen) ShowUnitInfo(screen *ebiten.Image, unit *ArmyUnit){
     height := 45
     vector.DrawFilledRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y1)), float32(scale.Scale(width)), float32(scale.Scale(height)), color.RGBA{R: 0, G: 0, B: 0, A: 100}, false)
     vector.StrokeRect(screen, float32(scale.Scale(x1)), float32(scale.Scale(y1)), float32(scale.Scale(width)), float32(scale.Scale(height)), float32(scale.Scale(1)), util.PremultiplyAlpha(color.RGBA{R: 0x27, G: 0x4e, B: 0xdc, A: 100}), false)
-    combat.InfoFont.PrintOptions2(screen, float64(x1 + 35), float64(y1 + 2), font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.Unit.GetName()))
+    combat.InfoFont.PrintOptions(screen, float64(x1 + 35), float64(y1 + 2), font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.Unit.GetName()))
 
     meleeImage, _ := combat.ImageCache.GetImage("compix.lbx", 61, 0)
     var options ebiten.DrawImageOptions
     options.GeoM.Translate(float64(x1 + 14), float64(y1 + 10))
     scale.DrawScaled(screen, meleeImage, &options)
     ax, ay := options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetMeleeAttackPower()))
+    combat.InfoFont.PrintOptions(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetMeleeAttackPower()))
 
     switch unit.Unit.GetRangedAttackDamageType() {
         case units.DamageRangedMagical:
@@ -2651,14 +2651,14 @@ func (combat *CombatScreen) ShowUnitInfo(screen *ebiten.Image, unit *ArmyUnit){
             options.GeoM.Translate(float64(x1 + 14), float64(y1 + 18))
             scale.DrawScaled(screen, fire, &options)
             ax, ay := options.GeoM.Apply(0, 2)
-            combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
+            combat.InfoFont.PrintOptions(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
         case units.DamageRangedPhysical:
             arrow, _ := combat.ImageCache.GetImage("compix.lbx", 66, 0)
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(x1 + 14), float64(y1 + 18))
             scale.DrawScaled(screen, arrow, &options)
             ax, ay := options.GeoM.Apply(0, 2)
-            combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
+            combat.InfoFont.PrintOptions(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
     }
 
     movementImage, _ := combat.ImageCache.GetImage("compix.lbx", 72, 0)
@@ -2670,23 +2670,23 @@ func (combat *CombatScreen) ShowUnitInfo(screen *ebiten.Image, unit *ArmyUnit){
     options.GeoM.Translate(float64(x1 + 14), float64(y1 + 26))
     scale.DrawScaled(screen, movementImage, &options)
     ax, ay = options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.MovesLeft.ToFloat()))
+    combat.InfoFont.PrintOptions(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.MovesLeft.ToFloat()))
 
     armorImage, _ := combat.ImageCache.GetImage("compix.lbx", 70, 0)
     options.GeoM.Reset()
     options.GeoM.Translate(float64(x1 + 48), float64(y1 + 10))
     scale.DrawScaled(screen, armorImage, &options)
     ax, ay = options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetDefense()))
+    combat.InfoFont.PrintOptions(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetDefense()))
 
     resistanceImage, _ := combat.ImageCache.GetImage("compix.lbx", 75, 0)
     options.GeoM.Reset()
     options.GeoM.Translate(float64(x1 + 48), float64(y1 + 18))
     scale.DrawScaled(screen, resistanceImage, &options)
     ax, ay = options.GeoM.Apply(0, 2)
-    combat.InfoFont.PrintOptions2(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetResistance()))
+    combat.InfoFont.PrintOptions(screen, ax, ay, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v", unit.GetResistance()))
 
-    combat.InfoFont.PrintOptions2(screen, float64(x1 + 14), float64(y1 + 37), font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, "Hits")
+    combat.InfoFont.PrintOptions(screen, float64(x1 + 14), float64(y1 + 37), font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}, "Hits")
 
     combat.DrawHealthBar(screen, x1 + 25, y1 + 40, unit)
 }

--- a/game/magic/combat/end-screen.go
+++ b/game/magic/combat/end-screen.go
@@ -203,7 +203,7 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
 
             if extraText2 != "" {
                 extraY += float64((extraFont.Height() + 1))
-                extraFont.RenderWrapped(screen, extraX, extraY, extraText2Render, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount})
+                extraFont.RenderWrapped(screen, extraX, extraY, extraText2Render, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
             }
         },
     }

--- a/game/magic/combat/end-screen.go
+++ b/game/magic/combat/end-screen.go
@@ -10,6 +10,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -152,7 +153,7 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
             pic, _ = end.ImageCache.GetImage("scroll.lbx", 11, 0)
     }
 
-    extraText2Render := extraFont.CreateWrappedText(float64(pic.Bounds().Dx() - 2 * data.ScreenScale), float64(data.ScreenScale), extraText2)
+    extraText2Render := extraFont.CreateWrappedText(float64(pic.Bounds().Dx() - 2), 1, extraText2)
 
     element := &uilib.UIElement{
         Rect: image.Rect(0, 0, data.ScreenWidth, data.ScreenHeight),
@@ -169,39 +170,40 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
             fontY := picLength
 
             if extraText2 != "" {
-                picLength += extraFont.Height() * data.ScreenScale
+                picLength += extraFont.Height()
             }
 
             picLength += extraFont.Height()
 
-            subPic := pic.SubImage(image.Rect(0, 0, pic.Bounds().Dx(), picLength * data.ScreenScale)).(*ebiten.Image)
+            subPic := pic.SubImage(image.Rect(0, 0, pic.Bounds().Dx(), picLength)).(*ebiten.Image)
 
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(50 * data.ScreenScale), float64(30 * data.ScreenScale))
+            options.GeoM.Translate(float64(50), float64(30))
             options.ColorScale.ScaleAlpha(getAlpha())
             screen.DrawImage(subPic, &options)
 
-            titleX, titleY := options.GeoM.Apply(float64(110 * data.ScreenScale), float64(25 * data.ScreenScale))
+            fontOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
+
+            titleX, titleY := options.GeoM.Apply(float64(110), float64(25))
             switch end.Result {
                 case CombatEndScreenResultWin:
-                    titleFont.PrintCenter(screen, titleX, titleY, float64(data.ScreenScale), options.ColorScale, "You are triumphant")
+                    titleFont.PrintOptions2(screen, titleX, titleY, fontOptions, "You are triumphant")
                 case CombatEndScreenResultLoose:
-                    titleFont.PrintCenter(screen, titleX, titleY, float64(data.ScreenScale), options.ColorScale, "You have been defeated")
+                    titleFont.PrintOptions2(screen, titleX, titleY, fontOptions, "You have been defeated")
                 case CombatEndScreenResultRetreat:
-                    titleFont.PrintCenter(screen, titleX, titleY, float64(data.ScreenScale), options.ColorScale, "Your forces have retreated")
+                    titleFont.PrintOptions2(screen, titleX, titleY, fontOptions, "Your forces have retreated")
             }
 
-            extraX, extraY := options.GeoM.Apply(float64(110 * data.ScreenScale), float64(fontY * data.ScreenScale))
+            extraX, extraY := options.GeoM.Apply(float64(110), float64(fontY))
 
-            options.GeoM.Translate(0, float64(picLength * data.ScreenScale))
+            options.GeoM.Translate(0, float64(picLength))
             screen.DrawImage(bottom, &options)
 
-            extraFont.PrintCenter(screen, extraX, extraY, float64(data.ScreenScale), options.ColorScale, extraText)
+            extraFont.PrintOptions2(screen, extraX, extraY, fontOptions, extraText)
 
             if extraText2 != "" {
-                extraY += float64((extraFont.Height() + 1) * data.ScreenScale)
-                // extraFont.PrintCenter(screen, extraX, extraY, float64(data.ScreenScale), options.ColorScale, extraText2)
-                extraFont.RenderWrapped(screen, extraX, extraY, extraText2Render, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter})
+                extraY += float64((extraFont.Height() + 1))
+                extraFont.RenderWrapped(screen, extraX, extraY, extraText2Render, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount})
             }
         },
     }

--- a/game/magic/combat/end-screen.go
+++ b/game/magic/combat/end-screen.go
@@ -187,11 +187,11 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
             titleX, titleY := options.GeoM.Apply(float64(110), float64(25))
             switch end.Result {
                 case CombatEndScreenResultWin:
-                    titleFont.PrintOptions2(screen, titleX, titleY, fontOptions, "You are triumphant")
+                    titleFont.PrintOptions(screen, titleX, titleY, fontOptions, "You are triumphant")
                 case CombatEndScreenResultLoose:
-                    titleFont.PrintOptions2(screen, titleX, titleY, fontOptions, "You have been defeated")
+                    titleFont.PrintOptions(screen, titleX, titleY, fontOptions, "You have been defeated")
                 case CombatEndScreenResultRetreat:
-                    titleFont.PrintOptions2(screen, titleX, titleY, fontOptions, "Your forces have retreated")
+                    titleFont.PrintOptions(screen, titleX, titleY, fontOptions, "Your forces have retreated")
             }
 
             extraX, extraY := options.GeoM.Apply(float64(110), float64(fontY))
@@ -199,7 +199,7 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
             options.GeoM.Translate(0, float64(picLength))
             screen.DrawImage(bottom, &options)
 
-            extraFont.PrintOptions2(screen, extraX, extraY, fontOptions, extraText)
+            extraFont.PrintOptions(screen, extraX, extraY, fontOptions, extraText)
 
             if extraText2 != "" {
                 extraY += float64((extraFont.Height() + 1))

--- a/game/magic/combat/end-screen.go
+++ b/game/magic/combat/end-screen.go
@@ -180,7 +180,7 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(50), float64(30))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(subPic, &options)
+            scale.DrawScaled(screen, subPic, &options)
 
             fontOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
 
@@ -197,7 +197,7 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
             extraX, extraY := options.GeoM.Apply(float64(110), float64(fontY))
 
             options.GeoM.Translate(0, float64(picLength))
-            screen.DrawImage(bottom, &options)
+            scale.DrawScaled(screen, bottom, &options)
 
             extraFont.PrintOptions(screen, extraX, extraY, fontOptions, extraText)
 

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -350,7 +350,7 @@ func makeTiles(width int, height int, landscape CombatLandscape, plane data.Plan
                 scale.DrawScaled(screen, base, options)
 
                 top, _ := imageCache.GetImage("chriver.lbx", 24 + int((counter / 4) % 8), 0)
-                options.GeoM.Translate(float64(16 * data.ScreenScale), float64(-3 * data.ScreenScale))
+                options.GeoM.Translate(float64(16), float64(-3))
                 scale.DrawScaled(screen, top, options)
             },
         }

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -18,6 +18,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/util"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
 
@@ -346,12 +347,11 @@ func makeTiles(width int, height int, landscape CombatLandscape, plane data.Plan
         tiles[TownCenterY-1][TownCenterX].ExtraObject = TileTop{
             Drawer: func(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64) {
                 base, _ := imageCache.GetImageTransform("chriver.lbx", 32, 0, "crop", util.AutoCrop)
-                screen.DrawImage(base, options)
+                scale.DrawScaled(screen, base, options)
 
                 top, _ := imageCache.GetImage("chriver.lbx", 24 + int((counter / 4) % 8), 0)
                 options.GeoM.Translate(float64(16 * data.ScreenScale), float64(-3 * data.ScreenScale))
-                screen.DrawImage(top, options)
-
+                scale.DrawScaled(screen, top, options)
             },
         }
     }

--- a/game/magic/combat/unit-view.go
+++ b/game/magic/combat/unit-view.go
@@ -9,7 +9,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -82,33 +82,33 @@ func MakeUnitView(cache *lbx.LbxCache, ui *uilib.UI, unit *ArmyUnit) *uilib.UIEl
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
-            options.GeoM.Translate(float64(25 * data.ScreenScale), float64(30 * data.ScreenScale))
+            options.GeoM.Translate(float64(25), float64(30))
             portaitUnit, ok := unit.Unit.(unitview.PortraitUnit)
             if ok {
                 lbxFile, index := portaitUnit.GetPortraitLbxInfo()
                 portait, err := imageCache.GetImage(lbxFile, index, 0)
                 if err == nil {
-                    options.GeoM.Translate(0, float64(-7 * data.ScreenScale))
+                    options.GeoM.Translate(0, float64(-7))
                     options.GeoM.Translate(float64(-portait.Bounds().Dx()/2), float64(-portait.Bounds().Dy()/2))
-                    screen.DrawImage(portait, &options)
+                    scale.DrawScaled(screen, portait, &options)
                 }
             } else {
                 unitview.RenderUnitViewImage(screen, &imageCache, unit, options, unit.IsAsleep(), ui.Counter)
             }
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
-            options.GeoM.Translate(float64(51 * data.ScreenScale), float64(6 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(51), float64(6))
 
             RenderUnitInfo(screen, &imageCache, unit, fonts, options)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
-            options.GeoM.Translate(float64(10 * data.ScreenScale), float64(50 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(10), float64(50))
             unitview.RenderUnitInfoStats(screen, &imageCache, unit, 15, fonts.DescriptionFont, fonts.SmallFont, options)
 
             /*
@@ -118,7 +118,7 @@ func MakeUnitView(cache *lbx.LbxCache, ui *uilib.UI, unit *ArmyUnit) *uilib.UIEl
         },
     })
 
-    group.AddElements(unitview.MakeUnitAbilitiesElements(group, cache, &imageCache, unit, fonts.MediumFont, 40 * data.ScreenScale, 114 * data.ScreenScale, &ui.Counter, 1, &getAlpha, false, 0, false))
+    group.AddElements(unitview.MakeUnitAbilitiesElements(group, cache, &imageCache, unit, fonts.MediumFont, 40, 114, &ui.Counter, 1, &getAlpha, false, 0, false))
 
     return group
 }
@@ -129,11 +129,11 @@ func RenderUnitInfo(screen *ebiten.Image, imageCache *util.ImageCache, unit *Arm
     // FIXME: if the unit is a hero and has a title then the title should show up on the next line after the name
     name := unit.Unit.GetFullName()
 
-    fonts.DescriptionFont.PrintOptions(screen, x, y + float64(2 * data.ScreenScale), float64(data.ScreenScale), defaultOptions.ColorScale, font.FontOptions{DropShadow: true}, name)
+    fonts.DescriptionFont.PrintOptions2(screen, x, y + float64(2), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
 
-    y += float64((fonts.DescriptionFont.Height() + 6) * data.ScreenScale)
+    y += float64((fonts.DescriptionFont.Height() + 6))
 
-    fonts.SmallFont.PrintOptions(screen, x, y, float64(data.ScreenScale), defaultOptions.ColorScale, font.FontOptions{DropShadow: true}, "Moves")
+    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
 
     unitMoves := unit.GetMovementSpeed()
 
@@ -143,14 +143,14 @@ func RenderUnitInfo(screen *ebiten.Image, imageCache *util.ImageCache, unit *Arm
         var options ebiten.DrawImageOptions
         options = defaultOptions
         options.GeoM.Reset()
-        options.GeoM.Translate(x + fonts.SmallFont.MeasureTextWidth("Damage ", float64(data.ScreenScale)), y)
+        options.GeoM.Translate(x + fonts.SmallFont.MeasureTextWidth("Damage ", 1), y)
 
         for i := 0; i < unitMoves; i++ {
-            screen.DrawImage(smallBoot, &options)
+            scale.DrawScaled(screen, smallBoot, &options)
             options.GeoM.Translate(float64(smallBoot.Bounds().Dx()), 0)
         }
     }
 
-    y += float64((fonts.SmallFont.Height() + 3) * data.ScreenScale)
-    fonts.SmallFont.PrintOptions(screen, x, y, float64(data.ScreenScale), defaultOptions.ColorScale, font.FontOptions{DropShadow: true}, fmt.Sprintf("Damage %v", unit.GetDamage()))
+    y += float64((fonts.SmallFont.Height() + 3))
+    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, fmt.Sprintf("Damage %v", unit.GetDamage()))
 }

--- a/game/magic/combat/unit-view.go
+++ b/game/magic/combat/unit-view.go
@@ -129,11 +129,11 @@ func RenderUnitInfo(screen *ebiten.Image, imageCache *util.ImageCache, unit *Arm
     // FIXME: if the unit is a hero and has a title then the title should show up on the next line after the name
     name := unit.Unit.GetFullName()
 
-    fonts.DescriptionFont.PrintOptions2(screen, x, y + float64(2), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
+    fonts.DescriptionFont.PrintOptions(screen, x, y + float64(2), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
 
     y += float64((fonts.DescriptionFont.Height() + 6))
 
-    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
+    fonts.SmallFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
 
     unitMoves := unit.GetMovementSpeed()
 
@@ -152,5 +152,5 @@ func RenderUnitInfo(screen *ebiten.Image, imageCache *util.ImageCache, unit *Arm
     }
 
     y += float64((fonts.SmallFont.Height() + 3))
-    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, fmt.Sprintf("Damage %v", unit.GetDamage()))
+    fonts.SmallFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, fmt.Sprintf("Damage %v", unit.GetDamage()))
 }

--- a/game/magic/console/console.go
+++ b/game/magic/console/console.go
@@ -8,7 +8,7 @@ import (
     "image/color"
 
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
 
@@ -191,15 +191,15 @@ func (console *Console) Update() {
     const speed = 9
 
     if console.State == ConsoleOpen {
-        if console.PosY < ConsoleHeight * int(data.ScreenScale2) {
-            console.PosY += speed * int(data.ScreenScale2)
-            if console.PosY > ConsoleHeight * int(data.ScreenScale2) {
-                console.PosY = ConsoleHeight * int(data.ScreenScale2)
+        if console.PosY < ConsoleHeight * int(scale.ScaleAmount) {
+            console.PosY += speed * int(scale.ScaleAmount)
+            if console.PosY > ConsoleHeight * int(scale.ScaleAmount) {
+                console.PosY = ConsoleHeight * int(scale.ScaleAmount)
             }
         }
     } else {
         if console.PosY > 0 {
-            console.PosY -= speed * int(data.ScreenScale2)
+            console.PosY -= speed * int(scale.ScaleAmount)
         }
     }
 
@@ -227,7 +227,7 @@ func (console *Console) Draw(screen *ebiten.Image) {
 
         face := &text.GoTextFace{
             Source: console.Font,
-            Size: float64(8 * data.ScreenScale2),
+            Size: float64(8 * scale.ScaleAmount),
         }
 
         textOptions := text.DrawOptions{}
@@ -235,7 +235,7 @@ func (console *Console) Draw(screen *ebiten.Image) {
         textOptions.Blend.BlendFactorSourceAlpha = ebiten.BlendFactorOne
         textOptions.Blend.BlendFactorDestinationAlpha = ebiten.BlendFactorZero
         */
-        textOptions.GeoM.Translate(2, float64(console.PosY) - face.Size - float64(1 * data.ScreenScale2))
+        textOptions.GeoM.Translate(2, float64(console.PosY) - face.Size - float64(1 * scale.ScaleAmount))
         text.Draw(screen, "> " + console.CurrentLine + "|", face, &textOptions)
 
         for i, count := len(console.Lines) - 1, 0; i >= 0; i, count = i-1, count+1 {

--- a/game/magic/data/data.go
+++ b/game/magic/data/data.go
@@ -1,6 +1,5 @@
 package data
 
-var ScreenScale = 1
 const ScreenWidth = 320
 const ScreenHeight = 200
 var ScreenScaleAlgorithm = ScaleAlgorithmNormal

--- a/game/magic/data/data.go
+++ b/game/magic/data/data.go
@@ -1,11 +1,8 @@
 package data
 
-const ScreenWidthOriginal = 320
-const ScreenHeightOriginal = 200
-
 var ScreenScale = 1
-var ScreenWidth = ScreenWidthOriginal
-var ScreenHeight = ScreenHeightOriginal
+const ScreenWidth = 320
+const ScreenHeight = 200
 var ScreenScaleAlgorithm = ScaleAlgorithmNormal
 
 type ScaleAlgorithm int

--- a/game/magic/data/data.go
+++ b/game/magic/data/data.go
@@ -2,27 +2,6 @@ package data
 
 const ScreenWidth = 320
 const ScreenHeight = 200
-var ScreenScaleAlgorithm = ScaleAlgorithmNormal
-
-type ScaleAlgorithm int
-
-const (
-    // the scale2x
-    // https://www.scale2x.it/
-    ScaleAlgorithmScale ScaleAlgorithm = iota
-    ScaleAlgorithmXbr
-    ScaleAlgorithmNormal
-)
-
-func (algorithm ScaleAlgorithm) String() string {
-    switch algorithm {
-        case ScaleAlgorithmScale: return "scale"
-        case ScaleAlgorithmXbr: return "xbr"
-        case ScaleAlgorithmNormal: return "normal"
-    }
-
-    return ""
-}
 
 type BannerType int
 const (

--- a/game/magic/data/data.go
+++ b/game/magic/data/data.go
@@ -4,7 +4,6 @@ const ScreenWidthOriginal = 320
 const ScreenHeightOriginal = 200
 
 var ScreenScale = 1
-var ScreenScale2 = 3.0
 var ScreenWidth = ScreenWidthOriginal
 var ScreenHeight = ScreenHeightOriginal
 var ScreenScaleAlgorithm = ScaleAlgorithmNormal

--- a/game/magic/diplomacy/diplomacy.go
+++ b/game/magic/diplomacy/diplomacy.go
@@ -38,7 +38,7 @@ func (talk *Talk) SetTitle(title string) {
 
     newElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            talk.TitleFont.RenderWrapped(screen, float64(50), float64(140), wrap, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
+            talk.TitleFont.RenderWrapped(screen, float64(50), float64(140), wrap, font.FontOptions{Scale: scale.ScaleAmount})
         },
     }
 

--- a/game/magic/diplomacy/diplomacy.go
+++ b/game/magic/diplomacy/diplomacy.go
@@ -106,7 +106,7 @@ func (talk *Talk) AddItem(item string, available bool, action func()){
 
             }
 
-            talk.Font.PrintOptions2(screen, 70, float64(posY), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, item)
+            talk.Font.PrintOptions(screen, 70, float64(posY), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, item)
         },
     }
 

--- a/game/magic/diplomacy/diplomacy.go
+++ b/game/magic/diplomacy/diplomacy.go
@@ -12,6 +12,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
@@ -33,11 +34,11 @@ type Talk struct {
 }
 
 func (talk *Talk) SetTitle(title string) {
-    wrap := talk.TitleFont.CreateWrappedText(float64(220 * data.ScreenScale), float64(data.ScreenScale), title)
+    wrap := talk.TitleFont.CreateWrappedText(float64(220), 1, title)
 
     newElement := &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            talk.TitleFont.RenderWrapped(screen, float64(50 * data.ScreenScale), float64(140 * data.ScreenScale), wrap, ebiten.ColorScale{}, font.FontOptions{})
+            talk.TitleFont.RenderWrapped(screen, float64(50), float64(140), wrap, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
         },
     }
 
@@ -57,14 +58,14 @@ func (talk *Talk) AddItem(item string, available bool, action func()){
         Action: action,
     })
 
-    posY := 150 * data.ScreenScale
+    posY := 150
     for range len(talk.Elements) {
-        posY += (talk.Font.Height() + 1) * data.ScreenScale
+        posY += (talk.Font.Height() + 1)
     }
 
-    textWidth := talk.Font.MeasureTextWidth(item, float64(data.ScreenScale))
+    textWidth := talk.Font.MeasureTextWidth(item, 1)
 
-    rect := image.Rect(70 * data.ScreenScale, posY, 70 * data.ScreenScale + int(textWidth), posY + talk.Font.Height() * data.ScreenScale)
+    rect := image.Rect(70, posY, 70 + int(textWidth), posY + talk.Font.Height())
 
     highlight := false
 
@@ -86,26 +87,26 @@ func (talk *Talk) AddItem(item string, available bool, action func()){
             }
         },
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            scale := ebiten.ColorScale{}
+            var options ebiten.DrawImageOptions
 
             // FIXME: if this option is not available then show the text in grey scale
 
             if !available {
-                scale.SetR(0.5)
-                scale.SetG(0.5)
-                scale.SetB(0.5)
+                options.ColorScale.SetR(0.5)
+                options.ColorScale.SetG(0.5)
+                options.ColorScale.SetB(0.5)
             }
 
             if highlight {
-                scale.SetR(2)
-                scale.SetG(2)
-                scale.SetB(2)
+                options.ColorScale.SetR(2)
+                options.ColorScale.SetG(2)
+                options.ColorScale.SetB(2)
 
-                vector.DrawFilledRect(screen, float32(rect.Min.X), float32(rect.Min.Y), float32(220 * data.ScreenScale), float32(talk.Font.Height() * data.ScreenScale), color.RGBA{R: 0x00, G: 0x00, B: 0x00, A: 50}, false)
+                vector.DrawFilledRect(screen, scale.Scale(float32(rect.Min.X)), scale.Scale(float32(rect.Min.Y)), scale.Scale(float32(220)), scale.Scale(float32(talk.Font.Height())), color.RGBA{R: 0x00, G: 0x00, B: 0x00, A: 50}, false)
 
             }
 
-            talk.Font.Print(screen, float64(70 * data.ScreenScale), float64(posY), float64(data.ScreenScale), scale, item)
+            talk.Font.PrintOptions2(screen, 70, float64(posY), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, item)
         },
     }
 
@@ -312,7 +313,7 @@ func ShowDiplomacyScreen(cache *lbx.LbxCache, player *playerlib.Player, enemy *p
     draw := func (screen *ebiten.Image) {
         background, _ := imageCache.GetImage("diplomac.lbx", 0, 0)
         var options ebiten.DrawImageOptions
-        screen.DrawImage(background, &options)
+        scale.DrawScaled(screen, background, &options)
 
         // red left eye
         leftEye, _ := imageCache.GetImage("diplomac.lbx", 2, 0)
@@ -320,15 +321,15 @@ func ShowDiplomacyScreen(cache *lbx.LbxCache, player *playerlib.Player, enemy *p
         // red right eye
         rightEye, _ := imageCache.GetImage("diplomac.lbx", 13, 0)
 
-        options.GeoM.Translate(float64(63 * data.ScreenScale), float64(58 * data.ScreenScale))
-        screen.DrawImage(leftEye, &options)
+        options.GeoM.Translate(63, 58)
+        scale.DrawScaled(screen, leftEye, &options)
 
-        options.GeoM.Translate(float64(170 * data.ScreenScale), 0)
-        screen.DrawImage(rightEye, &options)
+        options.GeoM.Translate(170, 0)
+        scale.DrawScaled(screen, rightEye, &options)
 
         options.GeoM.Reset()
-        options.GeoM.Translate(float64(106 * data.ScreenScale), 11)
-        screen.DrawImage(wizardAnimation.Frame(), &options)
+        options.GeoM.Translate(106, 11)
+        scale.DrawScaled(screen, wizardAnimation.Frame(), &options)
 
         ui.Draw(ui, screen)
 

--- a/game/magic/game/cast-select-wizard.go
+++ b/game/magic/game/cast-select-wizard.go
@@ -10,7 +10,7 @@ import (
 	uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
     "github.com/kazzmir/master-of-magic/game/magic/audio"
-	"github.com/kazzmir/master-of-magic/game/magic/data"
+	"github.com/kazzmir/master-of-magic/game/magic/scale"
 	"github.com/kazzmir/master-of-magic/game/magic/mirror"
 	"github.com/kazzmir/master-of-magic/game/magic/util"
 	"github.com/kazzmir/master-of-magic/lib/lbx"
@@ -43,8 +43,8 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
                 background, _ := imageCache.GetImage("specfx.lbx", 40, frameToShow)
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
-                options.GeoM.Translate(float64(faceRect.Min.X - 5 * data.ScreenScale), float64(faceRect.Min.Y - 10 * data.ScreenScale))
-                screen.DrawImage(background, &options)
+                options.GeoM.Translate(float64(faceRect.Min.X - 5), float64(faceRect.Min.Y - 10))
+                scale.DrawScaled(screen, background, &options)
             },
         }
     }
@@ -57,11 +57,11 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
             background, _ := imageCache.GetImage("spellscr.lbx", 72, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(x * data.ScreenScale), float64(y * data.ScreenScale))
-            screen.DrawImage(background, &options)
+            options.GeoM.Translate(float64(x), float64(y))
+            scale.DrawScaled(screen, background, &options)
 
-            mx, my := options.GeoM.Apply(float64(84 * data.ScreenScale), float64(10 * data.ScreenScale))
-            fonts.BigOrange.PrintWrapCenter(screen, mx, my, 120. * float64(data.ScreenScale), float64(data.ScreenScale), options.ColorScale, header)
+            mx, my := options.GeoM.Apply(float64(84), float64(10))
+            fonts.BigOrange.PrintWrapCenter(screen, mx, my, 120, scale.ScaleAmount, options.ColorScale, header)
         },
         Order: 0,
     })
@@ -78,7 +78,7 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
             continue
         }
         portrait, _ := imageCache.GetImage("lilwiz.lbx", mirror.GetWizardPortraitIndex(target.Wizard.Base, target.Wizard.Banner), 0)
-        faceRect := util.ImageRect((x + wizardFacesOffsets[index].X) * data.ScreenScale, (y + wizardFacesOffsets[index].Y) * data.ScreenScale, portrait)
+        faceRect := util.ImageRect((x + wizardFacesOffsets[index].X), (y + wizardFacesOffsets[index].Y), portrait)
         group.AddElement(&uilib.UIElement{
             Layer: layer+1,
             Rect: faceRect,
@@ -115,9 +115,9 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(faceRect.Min.X), float64(faceRect.Min.Y))
                 if target.Defeated {
-                    screen.DrawImage(brokenCrystalPicture, &options)
+                    scale.DrawScaled(screen, brokenCrystalPicture, &options)
                 } else {
-                    screen.DrawImage(portrait, &options)
+                    scale.DrawScaled(screen, portrait, &options)
                     // Draw current spell being cast
                     spellText := "None"
                     if target.CastingSpell.Valid() {
@@ -125,12 +125,12 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
                     }
                     fonts.InfoOrange.PrintWrapCenter(
                         screen, 
-                        float64(faceRect.Min.X + faceRect.Dx()/2), float64(faceRect.Max.Y + 6 * data.ScreenScale),
-                        120. * float64(data.ScreenScale), float64(data.ScreenScale), options.ColorScale, spellText,
+                        float64(faceRect.Min.X + faceRect.Dx()/2), float64(faceRect.Max.Y + 6),
+                        120, scale.ScaleAmount, options.ColorScale, spellText,
                     )
                     // Draw current spell cost/progress
                     if currentMouseoverPlayer == target {
-                        fonts.BigOrange.PrintWrapCenter(screen, float64((x + 47) * data.ScreenScale), float64((y + 159) * data.ScreenScale), 120. * float64(data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%d MP", target.CastingSpellProgress))
+                        fonts.BigOrange.PrintWrapCenter(screen, float64(x + 47), float64(y + 159), 120, scale.ScaleAmount, options.ColorScale, fmt.Sprintf("%d MP", target.CastingSpellProgress))
                     }
                 }
             },
@@ -139,11 +139,11 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
     }
     // Empty crystals
     for emptyPlaceIndex := drawnWizardFaces; emptyPlaceIndex < 4; emptyPlaceIndex++ {
-        crystalRect := util.ImageRect((x + wizardFacesOffsets[emptyPlaceIndex].X) * data.ScreenScale, (y + wizardFacesOffsets[emptyPlaceIndex].Y) * data.ScreenScale, crystalPicture)
+        crystalRect := util.ImageRect((x + wizardFacesOffsets[emptyPlaceIndex].X), (y + wizardFacesOffsets[emptyPlaceIndex].Y), crystalPicture)
         crystalToDraw := crystalPicture
         if emptyPlaceIndex > playersInGame - 1 {
             crystalToDraw = brokenCrystalPicture
-            crystalRect = crystalRect.Add(image.Point{-1 * data.ScreenScale, -1 * data.ScreenScale})
+            crystalRect = crystalRect.Add(image.Point{-1, -1})
         }
         group.AddElement(&uilib.UIElement{
             Layer: layer - 1, // That's correct, gems are behind the UI form itself (should fit into transparent windows)
@@ -152,7 +152,7 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(crystalRect.Min.X), float64(crystalRect.Min.Y))
-                screen.DrawImage(crystalToDraw, &options)
+                scale.DrawScaled(screen, crystalToDraw, &options)
             },
         })
     }
@@ -160,7 +160,7 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
     // cancel button
     cancel, _ := imageCache.GetImages("spellscr.lbx", 71)
     cancelIndex := 0
-    cancelRect := util.ImageRect((x + 83) * data.ScreenScale, (y + 155) * data.ScreenScale, cancel[0])
+    cancelRect := util.ImageRect((x + 83), (y + 155), cancel[0])
     group.AddElement(&uilib.UIElement{
         Layer: layer+1,
         Rect: cancelRect,
@@ -175,7 +175,7 @@ func makeSelectSpellBlastTargetUI(finish context.CancelFunc, cache *lbx.LbxCache
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancel[cancelIndex], &options)
+            scale.DrawScaled(screen, cancel[cancelIndex], &options)
         },
     })
 
@@ -211,8 +211,8 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
                 background, _ := imageCache.GetImage("specfx.lbx", sparksGraphicIndex, frameToShow)
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
-                options.GeoM.Translate(float64(faceRect.Min.X - 8 * data.ScreenScale), float64(faceRect.Min.Y - 5 * data.ScreenScale))
-                screen.DrawImage(background, &options)
+                options.GeoM.Translate(float64(faceRect.Min.X - 8), float64(faceRect.Min.Y - 5))
+                scale.DrawScaled(screen, background, &options)
             },
         }
     }
@@ -225,11 +225,11 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
             background, _ := imageCache.GetImage("spellscr.lbx", 0, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(x * data.ScreenScale), float64(y * data.ScreenScale))
-            screen.DrawImage(background, &options)
+            options.GeoM.Translate(float64(x), float64(y))
+            scale.DrawScaled(screen, background, &options)
 
-            mx, my := options.GeoM.Apply(float64(84 * data.ScreenScale), float64(10 * data.ScreenScale))
-            fonts.BigOrange.PrintWrapCenter(screen, mx, my, 150. * float64(data.ScreenScale), float64(data.ScreenScale), options.ColorScale, header)
+            mx, my := options.GeoM.Apply(float64(84), float64(10))
+            fonts.BigOrange.PrintWrapCenter(screen, mx, my, 150, scale.ScaleAmount, options.ColorScale, header)
         },
         Order: 0,
     })
@@ -246,7 +246,7 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
             continue
         }
         portrait, _ := imageCache.GetImage("lilwiz.lbx", mirror.GetWizardPortraitIndex(target.Wizard.Base, target.Wizard.Banner), 0)
-        faceRect := util.ImageRect((x + wizardFacesOffsets[index].X) * data.ScreenScale, (y + wizardFacesOffsets[index].Y) * data.ScreenScale, portrait)
+        faceRect := util.ImageRect((x + wizardFacesOffsets[index].X), (y + wizardFacesOffsets[index].Y), portrait)
         // FIXME: right click should open the wizard's mirror info screen
         group.AddElement(&uilib.UIElement{
             Layer: layer+1,
@@ -285,15 +285,15 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(faceRect.Min.X), float64(faceRect.Min.Y))
                 if target.Defeated {
-                    screen.DrawImage(brokenCrystalPicture, &options)
+                    scale.DrawScaled(screen, brokenCrystalPicture, &options)
                 } else {
-                    screen.DrawImage(portrait, &options)
+                    scale.DrawScaled(screen, portrait, &options)
                     // FIXME: draw actual relation (restless/peaceful/alliance etc) when the relations code will be done
                     diplomaticRelation := target.Wizard.Name // Temporary solution
                     fonts.InfoOrange.PrintWrapCenter(
                         screen, 
-                        float64(faceRect.Min.X + faceRect.Dx()/2), float64(faceRect.Max.Y + 6 * data.ScreenScale),
-                        120. * float64(data.ScreenScale), float64(data.ScreenScale), options.ColorScale, diplomaticRelation,
+                        float64(faceRect.Min.X + faceRect.Dx()/2), float64(faceRect.Max.Y + 6),
+                        120, scale.ScaleAmount, options.ColorScale, diplomaticRelation,
                     )
                 }
             },
@@ -302,11 +302,11 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
     }
     // Empty crystals
     for emptyPlaceIndex := drawnWizardFaces; emptyPlaceIndex < 4; emptyPlaceIndex++ {
-        crystalRect := util.ImageRect((x + wizardFacesOffsets[emptyPlaceIndex].X) * data.ScreenScale, (y + wizardFacesOffsets[emptyPlaceIndex].Y) * data.ScreenScale, crystalPicture)
+        crystalRect := util.ImageRect((x + wizardFacesOffsets[emptyPlaceIndex].X), (y + wizardFacesOffsets[emptyPlaceIndex].Y), crystalPicture)
         crystalToDraw := crystalPicture
         if emptyPlaceIndex > playersInGame - 1 {
             crystalToDraw = brokenCrystalPicture
-            crystalRect = crystalRect.Add(image.Point{-1 * data.ScreenScale, -1 * data.ScreenScale})
+            crystalRect = crystalRect.Add(image.Point{-1, -1})
         }
         group.AddElement(&uilib.UIElement{
             Layer: layer - 1, // That's correct, gems are behind the UI form itself (should fit into transparent windows)
@@ -315,7 +315,7 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(crystalRect.Min.X), float64(crystalRect.Min.Y))
-                screen.DrawImage(crystalToDraw, &options)
+                scale.DrawScaled(screen, crystalToDraw, &options)
             },
         })
     }
@@ -323,7 +323,7 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
     // cancel button
     cancel, _ := imageCache.GetImages("spellscr.lbx", 71)
     cancelIndex := 0
-    cancelRect := util.ImageRect((x + 45) * data.ScreenScale, (y + 155) * data.ScreenScale, cancel[0])
+    cancelRect := util.ImageRect((x + 45), (y + 155), cancel[0])
     group.AddElement(&uilib.UIElement{
         Layer: layer+1,
         Rect: cancelRect,
@@ -338,7 +338,7 @@ func makeSelectTargetWizardUI(finish context.CancelFunc, cache *lbx.LbxCache, im
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancel[cancelIndex], &options)
+            scale.DrawScaled(screen, cancel[cancelIndex], &options)
         },
     })
 

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -15,6 +15,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/maplib"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     "github.com/kazzmir/master-of-magic/game/magic/cityview"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -909,15 +910,15 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             mainHud, _ := game.ImageCache.GetImage("main.lbx", 0, 0)
-            screen.DrawImage(mainHud, &options)
+            scale.DrawScaled(screen, mainHud, &options)
 
             landImage, _ := game.ImageCache.GetImage("main.lbx", 57, 0)
-            options.GeoM.Translate(float64(240 * data.ScreenScale), float64(77 * data.ScreenScale))
-            screen.DrawImage(landImage, &options)
+            options.GeoM.Translate(float64(240), float64(77))
+            scale.DrawScaled(screen, landImage, &options)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(240 * data.ScreenScale), float64(174 * data.ScreenScale))
-            screen.DrawImage(cancelBackground, &options)
+            options.GeoM.Translate(float64(240), float64(174))
+            scale.DrawScaled(screen, cancelBackground, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -925,12 +926,12 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
                 }
             })
 
-            game.Fonts.WhiteFont.PrintRight(screen, float64(276 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v GP", game.Players[0].Gold))
-            game.Fonts.WhiteFont.PrintRight(screen, float64(313 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v MP", game.Players[0].Mana))
+            game.Fonts.WhiteFont.PrintRight(screen, float64(276), float64(68), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v GP", game.Players[0].Gold))
+            game.Fonts.WhiteFont.PrintRight(screen, float64(313), float64(68), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v MP", game.Players[0].Mana))
 
-            castingFont.PrintCenter(screen, float64(280 * data.ScreenScale), float64(81 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Casting")
+            castingFont.PrintCenter(screen, float64(280), float64(81), scale.ScaleAmount, ebiten.ColorScale{}, "Casting")
 
-            whiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), float64(120 * data.ScreenScale), float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, selectMessage)
+            whiteFont.PrintWrapCenter(screen, float64(280), float64(120), float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, selectMessage)
         },
     }
 
@@ -939,10 +940,10 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     makeButton := func(lbxIndex int, x int, y int) *uilib.UIElement {
         button, _ := game.ImageCache.GetImage("main.lbx", lbxIndex, 0)
         var options ebiten.DrawImageOptions
-        options.GeoM.Translate(float64(x * data.ScreenScale), float64(y * data.ScreenScale))
+        options.GeoM.Translate(float64(x), float64(y))
         return &uilib.UIElement{
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                screen.DrawImage(button, &options)
+                scale.DrawScaled(screen, button, &options)
             },
         }
     }
@@ -973,7 +974,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
     // cancel button at bottom
     cancel, _ := game.ImageCache.GetImages("main.lbx", 41)
     cancelIndex := 0
-    cancelRect := util.ImageRect(263 * data.ScreenScale, 182 * data.ScreenScale, cancel[0])
+    cancelRect := util.ImageRect(263, 182, cancel[0])
     ui.AddElement(&uilib.UIElement{
         Rect: cancelRect,
         LeftClick: func(element *uilib.UIElement){
@@ -986,7 +987,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancel[cancelIndex], &options)
+            scale.DrawScaled(screen, cancel[cancelIndex], &options)
         },
     })
 
@@ -995,11 +996,11 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
         overworld.DrawOverworld(screen, ebiten.GeoM{})
 
         var miniGeom ebiten.GeoM
-        miniGeom.Translate(float64(250 * data.ScreenScale), float64(20 * data.ScreenScale))
+        miniGeom.Translate(float64(250), float64(20))
         mx, my := miniGeom.Apply(0, 0)
-        miniWidth := 60 * data.ScreenScale
-        miniHeight := 31 * data.ScreenScale
-        mini := screen.SubImage(image.Rect(int(mx), int(my), int(mx) + miniWidth, int(my) + miniHeight)).(*ebiten.Image)
+        miniWidth := 60
+        miniHeight := 31
+        mini := screen.SubImage(scale.ScaleRect(image.Rect(int(mx), int(my), int(mx) + miniWidth, int(my) + miniHeight))).(*ebiten.Image)
         overworld.DrawMinimap(mini)
 
         ui.Draw(ui, screen)
@@ -1259,7 +1260,7 @@ func (game *Game) doCastOnMap(yield coroutine.YieldFunc, tileX int, tileY int, a
 
         var options ebiten.DrawImageOptions
         options.GeoM.Translate(float64(x - animation.Frame().Bounds().Dx() / 2), float64(y - animation.Frame().Bounds().Dy() / 2))
-        screen.DrawImage(animation.Frame(), &options)
+        scale.DrawScaled(screen, animation.Frame(), &options)
     }
 
     if newSound {
@@ -1572,7 +1573,7 @@ func (game *Game) doCastGlobalEnchantment(yield coroutine.YieldFunc, player *pla
 
     fader := util.MakeFadeIn(uint64(fadeSpeed), &game.Counter)
 
-    offset := -35 * data.ScreenScale
+    offset := -35
 
     game.Drawer = func(screen *ebiten.Image, game *Game){
         oldDrawer(screen, game)
@@ -1580,28 +1581,28 @@ func (game *Game) doCastGlobalEnchantment(yield coroutine.YieldFunc, player *pla
         options.GeoM.Translate(float64(data.ScreenWidth / 2), float64(data.ScreenHeight / 2))
         options.GeoM.Translate(float64(offset), 0)
         options.GeoM.Translate(float64(-frame.Bounds().Dx() / 2), float64(-frame.Bounds().Dy() / 2))
-        screen.DrawImage(frame, &options)
+        scale.DrawScaled(screen, frame, &options)
 
         options.ColorScale.ScaleAlpha(fader())
 
         // first draw the wizard
         if doDraw == 0 {
             mood, _ := game.ImageCache.GetImageTransform("moodwiz.lbx", animationIndex, 2, "cutout", makeCutoutMask)
-            options.GeoM.Translate(float64(13 * data.ScreenScale), float64(13 * data.ScreenScale))
-            screen.DrawImage(mood, &options)
+            options.GeoM.Translate(float64(13), float64(13))
+            scale.DrawScaled(screen, mood, &options)
 
             text := "You have finished casting"
             if !player.IsHuman() {
                 text = fmt.Sprintf("%v has cast", player.Wizard.Name)
             }
 
-            fonts.InfoFont.PrintCenter(screen, float64(data.ScreenWidth / 2 + offset), float64(data.ScreenHeight / 2 + frame.Bounds().Dy() / 2), float64(data.ScreenScale), options.ColorScale, text)
+            fonts.InfoFont.PrintCenter(screen, float64(data.ScreenWidth / 2 + offset), float64(data.ScreenHeight / 2 + frame.Bounds().Dy() / 2), scale.ScaleAmount, options.ColorScale, text)
         } else {
             // then draw the spell image
-            options.GeoM.Translate(float64(9 * data.ScreenScale), float64(8 * data.ScreenScale))
-            screen.DrawImage(spellImage, &options)
+            options.GeoM.Translate(float64(9), float64(8))
+            scale.DrawScaled(screen, spellImage, &options)
 
-            fonts.InfoFont.PrintCenter(screen, float64(data.ScreenWidth / 2 + offset), float64(data.ScreenHeight / 2 + frame.Bounds().Dy() / 2), float64(data.ScreenScale), options.ColorScale, enchantment.String())
+            fonts.InfoFont.PrintCenter(screen, float64(data.ScreenWidth / 2 + offset), float64(data.ScreenHeight / 2 + frame.Bounds().Dy() / 2), scale.ScaleAmount, options.ColorScale, enchantment.String())
         }
 
     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5671,13 +5671,13 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                         var options ebiten.DrawImageOptions
                         options.GeoM.Translate(float64(unitRect.Min.X), float64(unitRect.Min.Y))
-                        screen.DrawImage(unitBackground, scale.ScaleOptions(options))
+                        scale.DrawScaled(screen, unitBackground, &options)
 
                         options.GeoM.Translate(1, 1)
 
                         if stack.IsActive(unit){
                             unitBack, _ := units.GetUnitBackgroundImage(unit.GetBanner(), &game.ImageCache)
-                            screen.DrawImage(unitBack, scale.ScaleOptions(options))
+                            scale.DrawScaled(screen, unitBack, &options)
                         }
 
                         options.GeoM.Translate(1, 1)
@@ -5691,7 +5691,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                                 matrix.ChangeHSV(0, 0, 1)
                                 colorm.DrawImage(screen, unitImage, matrix, &patrolOptions)
                             } else {
-                                screen.DrawImage(unitImage, scale.ScaleOptions(options))
+                                scale.DrawScaled(screen, unitImage, &options)
                             }
 
                             // draw the first enchantment on the unit
@@ -5792,15 +5792,15 @@ func (game *Game) MakeHudUI() *uilib.UI {
                         }
 
                         badgeOptions := options
-                        badgeOptions.GeoM.Translate(float64(1 * data.ScreenScale), float64(21 * data.ScreenScale))
+                        badgeOptions.GeoM.Translate(1, 21)
                         for i := 0; i < count; i++ {
                             pic, _ := game.ImageCache.GetImage("main.lbx", index, 0)
-                            screen.DrawImage(pic, scale.ScaleOptions(badgeOptions))
-                            badgeOptions.GeoM.Translate(float64(4), 0)
+                            scale.DrawScaled(screen, pic, &badgeOptions)
+                            badgeOptions.GeoM.Translate(4, 0)
                         }
 
                         weaponOptions := options
-                        weaponOptions.GeoM.Translate(float64(12), float64(18))
+                        weaponOptions.GeoM.Translate(12, 18)
                         var weapon *ebiten.Image
                         switch unit.GetWeaponBonus() {
                         case data.WeaponMagic:
@@ -5812,7 +5812,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                         }
 
                         if weapon != nil {
-                            screen.DrawImage(weapon, scale.ScaleOptions(weaponOptions))
+                            scale.DrawScaled(screen, weapon, &weaponOptions)
                         }
 
                         useGeom := scale.ScaleGeom(options.GeoM)
@@ -5857,7 +5857,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     var options ebiten.DrawImageOptions
                     options.ColorScale.ScaleWithColorScale(colorScale)
                     options.GeoM.Translate(float64(doneRect.Min.X), float64(doneRect.Min.Y))
-                    screen.DrawImage(doneImages[doneIndex], scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, doneImages[doneIndex], &options)
                 },
                 Inside: func(this *uilib.UIElement, x int, y int){
                     doneCounter += 1
@@ -5897,7 +5897,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(patrolRect.Min.X), float64(patrolRect.Min.Y))
                     options.ColorScale.ScaleWithColorScale(colorScale)
-                    screen.DrawImage(patrolImages[patrolIndex], scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, patrolImages[patrolIndex], &options)
                 },
                 Inside: func(this *uilib.UIElement, x int, y int){
                     patrolCounter += 1
@@ -5941,7 +5941,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(waitRect.Min.X), float64(waitRect.Min.Y))
                     options.ColorScale.ScaleWithColorScale(colorScale)
-                    screen.DrawImage(waitImages[waitIndex], scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, waitImages[waitIndex], &options)
                 },
                 Inside: func(this *uilib.UIElement, x int, y int){
                     waitCounter += 1
@@ -6113,7 +6113,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
 
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(246 + float64(60), 167)
-                    screen.DrawImage(useIcon, scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, useIcon, &options)
                 }
             },
         })
@@ -6147,10 +6147,10 @@ func (game *Game) MakeHudUI() *uilib.UI {
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(240, 174)
-                screen.DrawImage(nextTurnImage, scale.ScaleOptions(options))
+                scale.DrawScaled(screen, nextTurnImage, &options)
                 if nextTurnClicked {
                     options.GeoM.Translate(6, 5)
-                    screen.DrawImage(nextTurnImageClicked, scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, nextTurnImageClicked, &options)
                 }
             },
         })
@@ -6169,7 +6169,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     goldFood, _ := game.ImageCache.GetImage("main.lbx", 34, 0)
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(240, 77)
-                    screen.DrawImage(goldFood, scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, goldFood, &options)
 
                     negativeScale := ebiten.ColorScale{}
 
@@ -7641,7 +7641,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
             // then move the city image so that the center of the image is at the center of the tile
             options.GeoM.Translate(float64(-cityPic.Bounds().Dx()) / 2.0, float64(-cityPic.Bounds().Dy()) / 2.0)
             options.GeoM.Concat(geom)
-            screen.DrawImage(cityPic, scale.ScaleOptions(options))
+            scale.DrawScaled(screen, cityPic, &options)
 
             /*
             tx, ty := geom.Apply(float64(x), float64(y))
@@ -7696,7 +7696,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
 
             unitBack, err := units.GetUnitBackgroundImage(leader.GetBanner(), overworld.ImageCache)
             if err == nil {
-                screen.DrawImage(unitBack, scale.ScaleOptions(options))
+                scale.DrawScaled(screen, unitBack, &options)
             }
 
             pic, err := GetUnitImage(leader, overworld.ImageCache, leader.GetBanner())
@@ -7711,7 +7711,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
                     matrix.ChangeHSV(0, 0, 1)
                     colorm.DrawImage(screen, pic, matrix, &patrolOptions)
                 } else {
-                    screen.DrawImage(pic, scale.ScaleOptions(options))
+                    scale.DrawScaled(screen, pic, &options)
                 }
 
                 enchantment := util.First(leader.GetEnchantments(), data.UnitEnchantmentNone)
@@ -7743,7 +7743,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
             v := float32(1 + (math.Sin(float64(overworld.Counter * 4 + uint64(pointI) * 60) * math.Pi / 180) / 2 + 0.5) / 2)
             options.ColorScale.Scale(v, v, v, 1)
 
-            screen.DrawImage(boot, scale.ScaleOptions(options))
+            scale.DrawScaled(screen, boot, &options)
         }
     }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3078,6 +3078,8 @@ func (game *Game) RefreshUI() {
 }
 
 // returns screen coordinates in pixels of the middle of the given tile
+// warning: this does not apply the screen scaling to the coordinates so you must still use
+// scale.DrawScaled() to draw the image at the correct size/position
 func (game *Game) TileToScreen(tileX int, tileY int) (int, int) {
     tileWidth := game.CurrentMap().TileWidth()
     tileHeight := game.CurrentMap().TileHeight()
@@ -3088,7 +3090,7 @@ func (game *Game) TileToScreen(tileX int, tileY int) (int, int) {
     geom.Translate(float64(x + tileWidth / 2.0), float64(y + tileHeight / 2.0))
     geom.Translate(-game.Camera.GetZoomedX() * float64(tileWidth), -game.Camera.GetZoomedY() * float64(tileHeight))
     geom.Scale(game.Camera.GetAnimatedZoom(), game.Camera.GetAnimatedZoom())
-    geom.Concat(scale.ScaledGeom)
+    // geom.Concat(scale.ScaledGeom)
 
     outX, outY := geom.Apply(0, 0)
     return int(outX), int(outY)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1219,10 +1219,10 @@ func (game *Game) showNewBuilding(yield coroutine.YieldFunc, city *citylib.City,
         options.GeoM.Translate(float64(8), float64(60))
         scale.DrawScaled(screen, background, &options)
         iconOptions := options
-        iconOptions.GeoM.Translate(float64(6), float64(-10))
+        iconOptions.GeoM.Translate(float64(2), float64(-10))
         scale.DrawScaled(screen, animal, &iconOptions)
 
-        x, y := options.GeoM.Apply(float64(8 + animal.Bounds().Dx()), float64(9))
+        x, y := options.GeoM.Apply(80, 9)
         fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
         options.GeoM.Translate(float64(background.Bounds().Dx()), 0)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4283,23 +4283,23 @@ func (game *Game) doTreasurePopup(yield coroutine.YieldFunc, player *playerlib.P
             left, _ := game.ImageCache.GetImage("resource.lbx", 56, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(10 * data.ScreenScale), float64(50 * data.ScreenScale))
+            options.GeoM.Translate(float64(10), float64(50))
 
-            fontX, fontY := options.GeoM.Apply(float64(10 * data.ScreenScale), float64(10 * data.ScreenScale))
+            fontX, fontY := options.GeoM.Apply(float64(10), float64(10))
 
-            screen.DrawImage(left, &options)
+            scale.DrawScaled(screen, left, &options)
             right, _ := game.ImageCache.GetImage("resource.lbx", 58, 0)
             options.GeoM.Translate(float64(left.Bounds().Dx()), 0)
             rightGeom := options.GeoM
 
             chest, _ := game.ImageCache.GetImage("reload.lbx", 20, 0)
-            options.GeoM.Translate(float64(6 * data.ScreenScale), float64(8 * data.ScreenScale))
-            screen.DrawImage(chest, &options)
+            options.GeoM.Translate(float64(6), float64(8))
+            scale.DrawScaled(screen, chest, &options)
 
             options.GeoM = rightGeom
-            screen.DrawImage(right, &options)
+            scale.DrawScaled(screen, right, &options)
 
-            fonts.TreasureFont.PrintWrap(screen, fontX, fontY, float64(left.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, font.FontOptions{DropShadow: true}, treasure.String())
+            fonts.TreasureFont.PrintWrap(screen, fontX, fontY, float64(left.Bounds().Dx() - 5), 1, options.ColorScale, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, treasure.String())
         },
     }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1082,7 +1082,7 @@ func (game *Game) doInput(yield coroutine.YieldFunc, title string, name string, 
 
     fonts := fontslib.MakeInputFonts(game.Cache)
 
-    maxLength := float64(84 * data.ScreenScale)
+    maxLength := float64(84)
 
     quit := false
 
@@ -1110,7 +1110,7 @@ func (game *Game) doInput(yield coroutine.YieldFunc, title string, name string, 
         TextEntry: func(element *uilib.UIElement, text string) string {
             name = text
 
-            for len(name) > 0 && fonts.NameFont.MeasureTextWidth(name, float64(data.ScreenScale)) > maxLength {
+            for len(name) > 0 && fonts.NameFont.MeasureTextWidth(name, 1) > maxLength {
                 name = name[:len(name)-1]
             }
 
@@ -1139,18 +1139,18 @@ func (game *Game) doInput(yield coroutine.YieldFunc, title string, name string, 
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := game.ImageCache.GetImage("backgrnd.lbx", 33, 0)
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(topX * data.ScreenScale), float64(topY * data.ScreenScale))
-            screen.DrawImage(background, &options)
+            options.GeoM.Translate(float64(topX), float64(topY))
+            scale.DrawScaled(screen, background, &options)
 
-            x, y := options.GeoM.Apply(float64(13 * data.ScreenScale), float64(20 * data.ScreenScale))
+            x, y := options.GeoM.Apply(float64(13), float64(20))
 
-            fonts.NameFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, name)
+            fonts.NameFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, name)
 
-            tx, ty := options.GeoM.Apply(float64(9 * data.ScreenScale), float64(6 * data.ScreenScale))
-            fonts.TitleFont.Print(screen, tx, ty, float64(data.ScreenScale), options.ColorScale, title)
+            tx, ty := options.GeoM.Apply(float64(9), float64(6))
+            fonts.TitleFont.Print(screen, tx, ty, scale.ScaleAmount, options.ColorScale, title)
 
             // draw cursor
-            cursorX := x + fonts.NameFont.MeasureTextWidth(name, float64(data.ScreenScale))
+            cursorX := x + fonts.NameFont.MeasureTextWidth(name, 1)
 
             util.DrawTextCursor(screen, source, cursorX, y, game.Counter)
         },
@@ -1193,7 +1193,7 @@ func (game *Game) showNewBuilding(yield coroutine.YieldFunc, city *citylib.City,
     }
     animal, _ := game.ImageCache.GetImageTransform("resource.lbx", animalIndex, 0, "crop", util.AutoCrop)
 
-    wrappedText := fonts.BigFont.CreateWrappedText(float64(175 * data.ScreenScale), float64(1 * data.ScreenScale), fmt.Sprintf("The %s of %s has completed the construction of a %s.", city.GetSize(), city.Name, game.BuildingInfo.Name(building)))
+    wrappedText := fonts.BigFont.CreateWrappedText(float64(175), 1, fmt.Sprintf("The %s of %s has completed the construction of a %s.", city.GetSize(), city.Name, game.BuildingInfo.Name(building)))
 
     rightSide, _ := game.ImageCache.GetImage("resource.lbx", 41, 0)
 
@@ -1216,36 +1216,36 @@ func (game *Game) showNewBuilding(yield coroutine.YieldFunc, city *citylib.City,
 
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(getAlpha())
-        options.GeoM.Translate(float64(8 * data.ScreenScale), float64(60 * data.ScreenScale))
-        screen.DrawImage(background, &options)
+        options.GeoM.Translate(float64(8), float64(60))
+        scale.DrawScaled(screen, background, &options)
         iconOptions := options
-        iconOptions.GeoM.Translate(float64(6 * data.ScreenScale), float64(-10 * data.ScreenScale))
-        screen.DrawImage(animal, &iconOptions)
+        iconOptions.GeoM.Translate(float64(6), float64(-10))
+        scale.DrawScaled(screen, animal, &iconOptions)
 
-        x, y := options.GeoM.Apply(float64(8 * data.ScreenScale + animal.Bounds().Dx()), float64(9 * data.ScreenScale))
-        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, options.ColorScale, font.FontOptions{})
+        x, y := options.GeoM.Apply(float64(8 + animal.Bounds().Dx()), float64(9))
+        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
         options.GeoM.Translate(float64(background.Bounds().Dx()), 0)
-        screen.DrawImage(rightSide, &options)
+        scale.DrawScaled(screen, rightSide, &options)
 
-        x, y = options.GeoM.Apply(float64(4 * data.ScreenScale), float64(6 * data.ScreenScale))
-        buildingSpace := screen.SubImage(image.Rect(int(x), int(y), int(x) + 45 * data.ScreenScale, int(y) + 47 * data.ScreenScale)).(*ebiten.Image)
+        x, y = options.GeoM.Apply(float64(4), float64(6))
+        buildingSpace := screen.SubImage(scale.ScaleRect(image.Rect(int(x), int(y), int(x) + 45, int(y) + 47))).(*ebiten.Image)
 
         // buildingSpace.Fill(color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff})
         // vector.DrawFilledRect(buildingSpace, float32(x), float32(y), float32(buildingSpace.Bounds().Dx()), float32(buildingSpace.Bounds().Dy()), color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}, false)
 
         landOptions := options
-        landOptions.GeoM.Translate(float64(-10 * data.ScreenScale), float64(-10 * data.ScreenScale))
-        buildingSpace.DrawImage(landBackground, &landOptions)
+        landOptions.GeoM.Translate(float64(-10), float64(-10))
+        scale.DrawScaled(buildingSpace, landBackground, &landOptions)
 
         buildingOptions := options
         // translate to the center of the building space, and then draw the image centered by translating
         // by -width/2, -height/2
         buildingOptions.GeoM.Reset()
         buildingOptions.GeoM.Translate(x, y)
-        buildingOptions.GeoM.Translate(float64(buildingSpace.Bounds().Dx()/2), float64(buildingSpace.Bounds().Dy() - 10 * data.ScreenScale))
+        buildingOptions.GeoM.Translate(scale.Unscale(float64(buildingSpace.Bounds().Dx()/2)), scale.Unscale(float64(buildingSpace.Bounds().Dy() - 10)))
         buildingOptions.GeoM.Translate(float64(buildingPicsAnimation.Frame().Bounds().Dx()) / -2, -float64(buildingPicsAnimation.Frame().Bounds().Dy()))
-        buildingSpace.DrawImage(buildingPicsAnimation.Frame(), &buildingOptions)
+        scale.DrawScaled(buildingSpace, buildingPicsAnimation.Frame(), &buildingOptions)
     }
 
     quit := false
@@ -1277,11 +1277,11 @@ func (game *Game) showNewBuilding(yield coroutine.YieldFunc, city *citylib.City,
 func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text string){
     fonts := fontslib.MakeScrollFonts(game.Cache)
 
-    wrappedText := fonts.SmallFont.CreateWrappedText(float64(180 * data.ScreenScale), float64(data.ScreenScale), text)
+    wrappedText := fonts.SmallFont.CreateWrappedText(float64(180), 1, text)
 
     scrollImages, _ := game.ImageCache.GetImages("scroll.lbx", 2)
 
-    totalImages := int((wrappedText.TotalHeight + float64(fonts.BigFont.Height() * data.ScreenScale)) / float64(5 * data.ScreenScale)) + 1
+    totalImages := int((wrappedText.TotalHeight + float64(fonts.BigFont.Height())) / float64(5)) + 1
 
     if totalImages < 3 {
         totalImages = 3
@@ -1300,7 +1300,7 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
         game.Drawer = drawer
     }()
 
-    scrollLength := 30 * data.ScreenScale
+    scrollLength := 30
 
     getAlpha := util.MakeFadeIn(7, &game.Counter)
 
@@ -1310,7 +1310,7 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(getAlpha())
 
-        options.GeoM.Translate(float64(65 * data.ScreenScale), float64(25 * data.ScreenScale))
+        options.GeoM.Translate(float64(65), float64(25))
 
         middleY := pageBackground.Bounds().Dy() / 2
         length := scrollLength / 2
@@ -1320,21 +1320,24 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
         pagePart := pageBackground.SubImage(image.Rect(0, middleY - length, pageBackground.Bounds().Dx(), middleY + length)).(*ebiten.Image)
 
         pageOptions := options
-        pageOptions.GeoM.Translate(0, float64(middleY - length) + float64(5 * data.ScreenScale))
-        screen.DrawImage(pagePart, &pageOptions)
+        pageOptions.GeoM.Translate(0, float64(middleY - length) + float64(5))
+        scale.DrawScaled(screen, pagePart, &pageOptions)
 
         // make the text fade out a little more than the rest of the scroll
         textScale := options.ColorScale
         textScale.ScaleAlpha(getAlpha())
 
-        x, y := options.GeoM.Apply(float64(pageBackground.Bounds().Dx()) / 2, float64(middleY) - wrappedText.TotalHeight / 2 - float64(fonts.BigFont.Height() * data.ScreenScale) / 2 + 5)
-        fonts.BigFont.PrintCenter(screen, x, y, float64(data.ScreenScale), textScale, title)
-        y += float64(fonts.BigFont.Height() * data.ScreenScale) + 1
-        fonts.SmallFont.RenderWrapped(screen, x, y, wrappedText, textScale, font.FontOptions{Justify: font.FontJustifyCenter})
+        x, y := options.GeoM.Apply(float64(pageBackground.Bounds().Dx()) / 2, float64(middleY) - wrappedText.TotalHeight / 2 - float64(fonts.BigFont.Height()) / 2 + 5)
+        fonts.BigFont.PrintCenter(screen, x, y, scale.ScaleAmount, textScale, title)
+        y += float64(fonts.BigFont.Height()) + 1
+
+        var textOptions ebiten.DrawImageOptions
+        textOptions.ColorScale = textScale
+        fonts.SmallFont.RenderWrapped(screen, x, y, wrappedText, textScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &textOptions})
 
         scrollOptions := options
-        scrollOptions.GeoM.Translate(float64(-63 * data.ScreenScale), float64(-20 * data.ScreenScale))
-        screen.DrawImage(scrollAnimation.Frame(), &scrollOptions)
+        scrollOptions.GeoM.Translate(float64(-63), float64(-20))
+        scale.DrawScaled(screen, scrollAnimation.Frame(), &scrollOptions)
     }
 
     quit := false
@@ -1354,7 +1357,7 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
 
         if game.Counter % animationSpeed == 0 {
             if scrollAnimation.Next() {
-                scrollLength += 10 * data.ScreenScale
+                scrollLength += 10
             }
         }
 
@@ -1369,7 +1372,7 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
 
         if game.Counter % animationSpeed == 0 {
             if scrollAnimation.Next() {
-                scrollLength -= 10 * data.ScreenScale
+                scrollLength -= 10
             } else {
                 quit = true
             }
@@ -1379,7 +1382,7 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
     }
 
     // offset because the scroll shrunk too much
-    scrollLength += 10 * data.ScreenScale
+    scrollLength += 10
 
     // fade out
     getAlpha = util.MakeFadeOut(7, &game.Counter)
@@ -1403,14 +1406,14 @@ func (game *Game) showOutpost(yield coroutine.YieldFunc, city *citylib.City, sta
         background, _ := game.ImageCache.GetImage("backgrnd.lbx", 32, 0)
 
         var options ebiten.DrawImageOptions
-        options.GeoM.Translate(float64(30 * data.ScreenScale), float64(50 * data.ScreenScale))
-        screen.DrawImage(background, &options)
+        options.GeoM.Translate(float64(30), float64(50))
+        scale.DrawScaled(screen, background, &options)
 
         numHouses := city.GetOutpostHouses()
         maxHouses := 10
 
         houseOptions := options
-        houseOptions.GeoM.Translate(float64(7 * data.ScreenScale), float64(31 * data.ScreenScale))
+        houseOptions.GeoM.Translate(float64(7), float64(31))
 
         fullHouseIndex := 34
         emptyHouseIndex := 37
@@ -1427,44 +1430,44 @@ func (game *Game) showOutpost(yield coroutine.YieldFunc, city *citylib.City, sta
         house, _ := game.ImageCache.GetImage("backgrnd.lbx", fullHouseIndex, 0)
 
         for i := 0; i < numHouses; i++ {
-            screen.DrawImage(house, &houseOptions)
+            scale.DrawScaled(screen, house, &houseOptions)
             houseOptions.GeoM.Translate(float64(house.Bounds().Dx()) + 1, 0)
         }
 
         emptyHouse, _ := game.ImageCache.GetImage("backgrnd.lbx", emptyHouseIndex, 0)
         for i := numHouses; i < maxHouses; i++ {
-            screen.DrawImage(emptyHouse, &houseOptions)
-            houseOptions.GeoM.Translate(float64(emptyHouse.Bounds().Dx() + 1 * data.ScreenScale), 0)
+            scale.DrawScaled(screen, emptyHouse, &houseOptions)
+            houseOptions.GeoM.Translate(float64(emptyHouse.Bounds().Dx() + 1), 0)
         }
 
         if stack != nil {
             stackOptions := options
-            stackOptions.GeoM.Translate(float64(7 * data.ScreenScale), float64(55 * data.ScreenScale))
+            stackOptions.GeoM.Translate(float64(7), float64(55))
 
             for _, unit := range stack.Units() {
                 pic, _ := GetUnitImage(unit, &game.ImageCache, city.GetBanner())
-                screen.DrawImage(pic, &stackOptions)
-                stackOptions.GeoM.Translate(float64(pic.Bounds().Dx() + 1 * data.ScreenScale), 0)
+                scale.DrawScaled(screen, pic, &stackOptions)
+                stackOptions.GeoM.Translate(float64(pic.Bounds().Dx() + 1), 0)
             }
         }
 
-        x, y := options.GeoM.Apply(float64(6 * data.ScreenScale), float64(22 * data.ScreenScale))
-        game.Fonts.InfoFontYellow.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, city.Race.String())
+        x, y := options.GeoM.Apply(float64(6), float64(22))
+        game.Fonts.InfoFontYellow.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, city.Race.String())
 
-        x, y = options.GeoM.Apply(float64(20 * data.ScreenScale), float64(5 * data.ScreenScale))
+        x, y = options.GeoM.Apply(float64(20), float64(5))
         if rename {
-            fonts.BigFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, "New Outpost Founded")
+            fonts.BigFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, "New Outpost Founded")
         } else {
-            fonts.BigFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("Outpost Of %v", city.Name))
+            fonts.BigFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, fmt.Sprintf("Outpost Of %v", city.Name))
         }
 
         cityScapeOptions := options
-        cityScapeOptions.GeoM.Translate(float64(185 * data.ScreenScale), float64(30 * data.ScreenScale))
+        cityScapeOptions.GeoM.Translate(float64(185), float64(30))
         x, y = cityScapeOptions.GeoM.Apply(0, 0)
-        cityScape := screen.SubImage(image.Rect(int(x), int(y), int(x) + 72 * data.ScreenScale, int(y) + 66 * data.ScreenScale)).(*ebiten.Image)
+        cityScape := screen.SubImage(scale.ScaleRect(image.Rect(int(x), int(y), int(x) + 72, int(y) + 66))).(*ebiten.Image)
 
         cityScapeBackground, _ := game.ImageCache.GetImage("cityscap.lbx", 0, 0)
-        cityScape.DrawImage(cityScapeBackground, &cityScapeOptions)
+        scale.DrawScaled(cityScape, cityScapeBackground, &cityScapeOptions)
 
         // regular house
         houseIndex := 25
@@ -1476,8 +1479,8 @@ func (game *Game) showOutpost(yield coroutine.YieldFunc, city *citylib.City, sta
 
         cityHouse, _ := game.ImageCache.GetImage("cityscap.lbx", houseIndex, 0)
         options2 := cityScapeOptions
-        options2.GeoM.Translate(float64(30 * data.ScreenScale), float64(20 * data.ScreenScale))
-        cityScape.DrawImage(cityHouse, &options2)
+        options2.GeoM.Translate(float64(30), float64(20))
+        scale.DrawScaled(cityScape, cityHouse, &options2)
 
         /*
         x, y = options2.GeoM.Apply(0, 0)
@@ -2051,21 +2054,21 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
         elements = nil
 
         elements = append(elements, &uilib.UIElement{
-            Rect: util.ImageRect(266 * data.ScreenScale, 176 * data.ScreenScale, ok),
+            Rect: util.ImageRect(266, 176, ok),
             LeftClick: func(element *uilib.UIElement){
                 onOk()
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(element.Rect.Min.X), float64(element.Rect.Min.Y))
-                screen.DrawImage(ok, &options)
+                scale.DrawScaled(screen, ok, &options)
             },
         })
 
         resolutionBackground, _ := imageCache.GetImage("load.lbx", 5, 0)
 
         elements = append(elements, &uilib.UIElement{
-            Rect: util.ImageRect(20 * data.ScreenScale, 40 * data.ScreenScale, resolutionBackground),
+            Rect: util.ImageRect(20, 40, resolutionBackground),
             LeftClick: func(element *uilib.UIElement){
                 selected := func(name string, scale int, algorithm data.ScaleAlgorithm) string {
                     if data.ScreenScale == scale && data.ScreenScaleAlgorithm == algorithm {
@@ -2075,6 +2078,7 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
                 }
 
                 update := func(scale int, algorithm data.ScaleAlgorithm){
+                    /*
                     data.ScreenScale = scale
                     data.ScreenScaleAlgorithm = algorithm
                     data.ScreenWidth = data.ScreenWidthOriginal * scale
@@ -2082,7 +2086,7 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
                     game.UpdateImages()
                     *imageCache = util.MakeImageCache(game.Cache)
                     makeElements()
-
+                    */
                 }
 
                 makeChoices := func (name string, scales []int, algorithm data.ScaleAlgorithm) []uilib.Selection {
@@ -2109,10 +2113,10 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
             Draw: func (element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(element.Rect.Min.X), float64(element.Rect.Min.Y))
-                screen.DrawImage(resolutionBackground, &options)
+                scale.DrawScaled(screen, resolutionBackground, &options)
 
-                x, y := options.GeoM.Apply(float64(3 * data.ScreenScale), float64(3 * data.ScreenScale))
-                fonts.OptionFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, "Screen")
+                x, y := options.GeoM.Apply(float64(3), float64(3))
+                fonts.OptionFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, "Screen")
             },
         })
 
@@ -2137,7 +2141,7 @@ func (game *Game) doGameMenu(yield coroutine.YieldFunc) {
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -2152,7 +2156,7 @@ func (game *Game) doGameMenu(yield coroutine.YieldFunc) {
     makeButton := func (index int, x int, y int, action func()) *uilib.UIElement {
         useImage, _ := imageCache.GetImage("load.lbx", index, 0)
         return &uilib.UIElement{
-            Rect: util.ImageRect(x * data.ScreenScale, y * data.ScreenScale, useImage),
+            Rect: util.ImageRect(x, y, useImage),
             PlaySoundLeftClick: true,
             LeftClick: func(element *uilib.UIElement){
                 action()
@@ -2160,7 +2164,7 @@ func (game *Game) doGameMenu(yield coroutine.YieldFunc) {
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(element.Rect.Min.X), float64(element.Rect.Min.Y))
-                screen.DrawImage(useImage, &options)
+                scale.DrawScaled(screen, useImage, &options)
             },
         }
     }
@@ -2708,7 +2712,7 @@ func (game *Game) doRandomEvent(yield coroutine.YieldFunc, event *RandomEvent, s
     if !start {
         message = event.MessageStop
     }
-    wrappedText := fonts.BigFont.CreateWrappedText(float64(175 * data.ScreenScale), float64(1 * data.ScreenScale), message)
+    wrappedText := fonts.BigFont.CreateWrappedText(float64(175), 1, message)
 
     rightSide, _ := game.ImageCache.GetImage("resource.lbx", 41, 0)
 
@@ -2734,24 +2738,24 @@ func (game *Game) doRandomEvent(yield coroutine.YieldFunc, event *RandomEvent, s
 
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(getAlpha())
-        options.GeoM.Translate(float64(8 * data.ScreenScale), float64(60 * data.ScreenScale))
-        screen.DrawImage(background, &options)
+        options.GeoM.Translate(float64(8), float64(60))
+        scale.DrawScaled(screen, background, &options)
         iconOptions := options
-        iconOptions.GeoM.Translate(float64(34 * data.ScreenScale), float64(28 * data.ScreenScale))
+        iconOptions.GeoM.Translate(float64(34), float64(28))
         iconOptions.GeoM.Translate(float64(-animal.Bounds().Dx() / 2), float64(-animal.Bounds().Dy() / 2))
-        screen.DrawImage(animal, &iconOptions)
+        scale.DrawScaled(screen, animal, &iconOptions)
 
-        x, y := options.GeoM.Apply(float64(75 * data.ScreenScale), float64(9 * data.ScreenScale))
-        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, options.ColorScale, font.FontOptions{})
+        x, y := options.GeoM.Apply(float64(75), float64(9))
+        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
         options.GeoM.Translate(float64(background.Bounds().Dx()), 0)
 
-        shiftX := float64(6 * data.ScreenScale)
-        shiftY := float64(8 * data.ScreenScale)
+        shiftX := float64(6)
+        shiftY := float64(8)
         options.GeoM.Translate(shiftX, shiftY)
-        screen.DrawImage(eventPic, &options)
+        scale.DrawScaled(screen, eventPic, &options)
         options.GeoM.Translate(-shiftX, -shiftY)
-        screen.DrawImage(rightSide, &options)
+        scale.DrawScaled(screen, rightSide, &options)
 
         /*
         x, y = options.GeoM.Apply(float64(4 * data.ScreenScale), float64(6 * data.ScreenScale))
@@ -5475,9 +5479,8 @@ func (game *Game) MakeHudUI() *uilib.UI {
         Cache: game.Cache,
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
-            options.GeoM.Concat(scale.ScaledGeom)
             mainHud, _ := game.ImageCache.GetImage("main.lbx", 0, 0)
-            screen.DrawImage(mainHud, &options)
+            scale.DrawScaled(screen, mainHud, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -5547,9 +5550,8 @@ func (game *Game) MakeHudUI() *uilib.UI {
 
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
-                options.GeoM.Concat(scale.ScaledGeom)
                 options.ColorScale.ScaleWithColorScale(colorScale)
-                screen.DrawImage(buttons[index], &options)
+                scale.DrawScaled(screen, buttons[index], &options)
             },
         }
     }
@@ -5557,7 +5559,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
     var elements []*uilib.UIElement
 
     // game button
-    elements = append(elements, makeButton(1, 7 * data.ScreenScale, 4 * data.ScreenScale, false, func(){
+    elements = append(elements, makeButton(1, 7, 4, false, func(){
         select {
             case game.Events <- &GameEventGameMenu{}:
             default:
@@ -5565,7 +5567,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
     }))
 
     // spell button
-    elements = append(elements, makeButton(2, 47 * data.ScreenScale, 4 * data.ScreenScale, false, func(){
+    elements = append(elements, makeButton(2, 47, 4, false, func(){
         select {
             case game.Events <- &GameEventCastSpellBook{}:
             default:
@@ -5573,7 +5575,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
     }))
 
     // army button
-    elements = append(elements, makeButton(3, 89 * data.ScreenScale, 4 * data.ScreenScale, false, func(){
+    elements = append(elements, makeButton(3, 89, 4, false, func(){
         select {
             case game.Events<- &GameEventArmyView{}:
             default:
@@ -5581,7 +5583,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
     }))
 
     // cities button
-    elements = append(elements, makeButton(4, 140 * data.ScreenScale, 4 * data.ScreenScale, false, func(){
+    elements = append(elements, makeButton(4, 140, 4, false, func(){
         select {
             case game.Events<- &GameEventCityListView{}:
             default:
@@ -5589,7 +5591,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
     }))
 
     // magic button
-    elements = append(elements, makeButton(5, 184 * data.ScreenScale, 4 * data.ScreenScale, false, func(){
+    elements = append(elements, makeButton(5, 184, 4, false, func(){
         select {
             case game.Events<- &GameEventMagicView{}:
             default:
@@ -5597,12 +5599,12 @@ func (game *Game) MakeHudUI() *uilib.UI {
     }))
 
     // info button
-    elements = append(elements, makeButton(6, 226 * data.ScreenScale, 4 * data.ScreenScale, true, func(){
+    elements = append(elements, makeButton(6, 226, 4, true, func(){
         ui.AddElements(game.MakeInfoUI(60, 25))
     }))
 
     // plane button
-    elements = append(elements, makeButton(7, 270 * data.ScreenScale, 4 * data.ScreenScale, false, func(){
+    elements = append(elements, makeButton(7, 270, 4, false, func(){
         game.SwitchPlane()
 
         game.RefreshUI()
@@ -5612,8 +5614,8 @@ func (game *Game) MakeHudUI() *uilib.UI {
         player := game.Players[0]
         // stack := player.SelectedStack
 
-        unitX1 := 246 * data.ScreenScale
-        unitY1 := 79 * data.ScreenScale
+        unitX1 := 246
+        unitY1 := 79
 
         unitX := unitX1
         unitY := unitY1
@@ -5727,7 +5729,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                             }
 
                             x, y := options.GeoM.Apply(float64(4), float64(19))
-                            vector.StrokeLine(screen, float32(x), float32(y), float32(x + healthLength), float32(y), float32(data.ScreenScale), useColor, false)
+                            vector.StrokeLine(screen, scale.Scale(float32(x)), scale.Scale(float32(y)), scale.Scale(float32(x + healthLength)), scale.Scale(float32(y)), float32(scale.ScaleAmount), useColor, false)
                         }
 
                         silverBadge := 51
@@ -5822,13 +5824,13 @@ func (game *Game) MakeHudUI() *uilib.UI {
                         // draw a G on the unit if they are moving, P if purify, and B if building road
                         if unit.GetBusy() == units.BusyStatusBuildRoad {
                             x, y := useGeom.Apply(float64(1), float64(1))
-                            game.Fonts.WhiteFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, "B")
+                            game.Fonts.WhiteFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, "B")
                         } else if unit.GetBusy() == units.BusyStatusPurify {
                             x, y := useGeom.Apply(float64(1), float64(1))
-                            game.Fonts.WhiteFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, "P")
+                            game.Fonts.WhiteFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, "P")
                         } else if len(stack.CurrentPath) != 0 {
                             x, y := useGeom.Apply(float64(1), float64(1))
-                            game.Fonts.WhiteFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, "G")
+                            game.Fonts.WhiteFont.Print(screen, x, y, scale.ScaleAmount, options.ColorScale, "G")
                         }
                     },
                 })
@@ -5968,7 +5970,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
             purifyImages, _ := game.ImageCache.GetImages("main.lbx", 42)
             inactivePurify, _ := game.ImageCache.GetImage("main.lbx", 43, 0)
             buildIndex := 0
-            buildRect := util.ImageRect(280 * data.ScreenScale, 186 * data.ScreenScale, buildImages[0])
+            buildRect := util.ImageRect(280, 186, buildImages[0])
             buildCounter := uint64(0)
 
             hasRoad := game.GetMap(player.SelectedStack.Plane()).ContainsRoad(player.SelectedStack.X(), player.SelectedStack.Y())
@@ -7479,7 +7481,7 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
 
     drawFogTile := func(tileX int, tileY int) {
         if overworld.FogBlack != nil {
-            screen.DrawImage(overworld.FogBlack, &options)
+            scale.DrawScaled(screen, overworld.FogBlack, &options)
         }
     }
 
@@ -7494,35 +7496,35 @@ func (overworld *Overworld) DrawFog(screen *ebiten.Image, geom ebiten.GeoM){
         sw := fogSW(tileX, tileY, fogType)
 
         if n && e {
-            screen.DrawImage(FogEdge_N_E, &options)
+            scale.DrawScaled(screen, FogEdge_N_E, &options)
         } else if n {
-            screen.DrawImage(FogEdge_N, &options)
+            scale.DrawScaled(screen, FogEdge_N, &options)
         } else if e {
-            screen.DrawImage(FogEdge_E, &options)
+            scale.DrawScaled(screen, FogEdge_E, &options)
         } else if ne {
-            screen.DrawImage(FogCorner_NE, &options)
+            scale.DrawScaled(screen, FogCorner_NE, &options)
         }
 
         if s && e {
-            screen.DrawImage(FogEdge_S_E, &options)
+            scale.DrawScaled(screen, FogEdge_S_E, &options)
         } else if s {
-            screen.DrawImage(FogEdge_S, &options)
+            scale.DrawScaled(screen, FogEdge_S, &options)
         } else if se {
-            screen.DrawImage(FogCorner_SE, &options)
+            scale.DrawScaled(screen, FogCorner_SE, &options)
         }
 
         if n && w {
-            screen.DrawImage(FogEdge_N_W, &options)
+            scale.DrawScaled(screen, FogEdge_N_W, &options)
         } else if w {
-            screen.DrawImage(FogEdge_W, &options)
+            scale.DrawScaled(screen, FogEdge_W, &options)
         } else if nw {
-            screen.DrawImage(FogCorner_NW, &options)
+            scale.DrawScaled(screen, FogCorner_NW, &options)
         }
 
         if s && w {
-            screen.DrawImage(FogEdge_S_W, &options)
+            scale.DrawScaled(screen, FogEdge_S_W, &options)
         } else if sw {
-            screen.DrawImage(FogCorner_SW, &options)
+            scale.DrawScaled(screen, FogCorner_SW, &options)
         }
     }
 
@@ -7728,7 +7730,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
     overworld.Map.DrawLayer2(overworld.Camera, overworld.Counter / 8, overworld.ImageCache, screen, scale.ScaleGeom(geom))
 
     if overworld.Fog != nil {
-        overworld.DrawFog(screen, scale.ScaleGeom(geom))
+        overworld.DrawFog(screen, geom)
     }
 
     // draw current path on top of fog
@@ -7810,9 +7812,11 @@ func (game *Game) DrawGame(screen *ebiten.Image){
     }
 
     useCounter := game.Counter
+    /*
     if data.ScreenScale == 1 && game.Camera.GetZoom() < 0.9 {
         useCounter = 1
     }
+    */
 
     overworld := Overworld{
         Camera: game.Camera,

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4154,7 +4154,7 @@ func (game *Game) confirmLairEncounter(yield coroutine.YieldFunc, encounter *map
     if animated {
         rotateIndexLow := 247
         rotateIndexHigh := 254
-        animation = util.MakePaletteRotateAnimation(reloadLbx, &game.ImageCache, lairIndex, rotateIndexLow, rotateIndexHigh)
+        animation = util.MakePaletteRotateAnimation(reloadLbx, lairIndex, rotateIndexLow, rotateIndexHigh)
     }
 
     game.Music.PushSong(music.SongSiteDiscovery)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4310,7 +4310,7 @@ func (game *Game) doTreasurePopup(yield coroutine.YieldFunc, player *playerlib.P
             options.GeoM = rightGeom
             scale.DrawScaled(screen, right, &options)
 
-            fonts.TreasureFont.PrintWrap(screen, fontX, fontY, float64(left.Bounds().Dx() - 5), 1, options.ColorScale, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, treasure.String())
+            fonts.TreasureFont.PrintWrap(screen, fontX, fontY, float64(left.Bounds().Dx() - 5), font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, treasure.String())
         },
     }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2071,9 +2071,11 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
             Rect: util.ImageRect(20, 40, resolutionBackground),
             LeftClick: func(element *uilib.UIElement){
                 selected := func(name string, scale int, algorithm data.ScaleAlgorithm) string {
+                    /*
                     if data.ScreenScale == scale && data.ScreenScaleAlgorithm == algorithm {
                         return name + "*"
                     }
+                    */
                     return name
                 }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5822,7 +5822,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
                             scale.DrawScaled(screen, weapon, &weaponOptions)
                         }
 
-                        useGeom := scale.ScaleGeom(options.GeoM)
+                        useGeom := options.GeoM
 
                         // draw a G on the unit if they are moving, P if purify, and B if building road
                         if unit.GetBusy() == units.BusyStatusBuildRoad {
@@ -7618,7 +7618,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
     geom.Scale(overworld.Camera.GetAnimatedZoom(), overworld.Camera.GetAnimatedZoom())
     // geom.Concat(scale.ScaledGeom)
 
-    overworld.Map.DrawLayer1(overworld.Camera, overworld.Counter / 8, overworld.ImageCache, screen, scale.ScaleGeom(geom))
+    overworld.Map.DrawLayer1(overworld.Camera, overworld.Counter / 8, overworld.ImageCache, screen, geom)
 
     convertTileCoordinates := func(x int, y int) (int, int) {
         outX := x * tileWidth
@@ -7730,7 +7730,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
         }
     }
 
-    overworld.Map.DrawLayer2(overworld.Camera, overworld.Counter / 8, overworld.ImageCache, screen, scale.ScaleGeom(geom))
+    overworld.Map.DrawLayer2(overworld.Camera, overworld.Counter / 8, overworld.ImageCache, screen, geom)
 
     if overworld.Fog != nil {
         overworld.DrawFog(screen, geom)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6922,8 +6922,6 @@ func ChangeCityOwner(city *citylib.City, owner *playerlib.Player, newOwner *play
     city.Buildings.Remove(buildinglib.BuildingFortress)
     city.Buildings.Remove(buildinglib.BuildingSummoningCircle)
 
-    city.UpdateUnrest()
-
     switch enchantmentChange {
         case ChangeCityKeepEnchantments:
         case ChangeCityRemoveOwnerEnchantments:
@@ -6931,6 +6929,8 @@ func ChangeCityOwner(city *citylib.City, owner *playerlib.Player, newOwner *play
         case ChangeCityRemoveAllEnchantments:
             city.Enchantments.Clear()
     }
+
+    city.UpdateUnrest()
 }
 
 func (game *Game) ManaShortActive() bool {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6123,7 +6123,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
         // next turn
         nextTurnImage, _ := game.ImageCache.GetImage("main.lbx", 35, 0)
         nextTurnImageClicked, _ := game.ImageCache.GetImage("main.lbx", 58, 0)
-        nextTurnRect := image.Rect(240 * data.ScreenScale, 174 * data.ScreenScale, 240 * data.ScreenScale + nextTurnImage.Bounds().Dx(), 174 * data.ScreenScale + nextTurnImage.Bounds().Dy())
+        nextTurnRect := image.Rect(240, 174, 240 + nextTurnImage.Bounds().Dx(), 174 + nextTurnImage.Bounds().Dy())
         nextTurnClicked := false
         elements = append(elements, &uilib.UIElement{
             Rect: nextTurnRect,
@@ -6146,11 +6146,11 @@ func (game *Game) MakeHudUI() *uilib.UI {
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
-                options.GeoM.Translate(float64(240 * data.ScreenScale), float64(174 * data.ScreenScale))
-                screen.DrawImage(nextTurnImage, &options)
+                options.GeoM.Translate(240, 174)
+                screen.DrawImage(nextTurnImage, scale.ScaleOptions(options))
                 if nextTurnClicked {
-                    options.GeoM.Translate(float64(6 * data.ScreenScale), float64(5 * data.ScreenScale))
-                    screen.DrawImage(nextTurnImageClicked, &options)
+                    options.GeoM.Translate(6, 5)
+                    screen.DrawImage(nextTurnImageClicked, scale.ScaleOptions(options))
                 }
             },
         })
@@ -6168,8 +6168,8 @@ func (game *Game) MakeHudUI() *uilib.UI {
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                     goldFood, _ := game.ImageCache.GetImage("main.lbx", 34, 0)
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(240 * data.ScreenScale), float64(77 * data.ScreenScale))
-                    screen.DrawImage(goldFood, &options)
+                    options.GeoM.Translate(240, 77)
+                    screen.DrawImage(goldFood, scale.ScaleOptions(options))
 
                     negativeScale := ebiten.ColorScale{}
 
@@ -6177,28 +6177,34 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     v := (math.Cos(float64(game.Counter) / 7) + 1) / 4 + 0.5
                     negativeScale.SetR(float32(v))
 
+                    negative := options
+                    negative.ColorScale = negativeScale
+
+                    negativeOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &negative, Scale: scale.ScaleAmount}
+                    normalOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
+
                     if goldPerTurn < 0 {
-                        game.Fonts.InfoFontRed.PrintCenter(screen, float64(278 * data.ScreenScale), float64(103 * data.ScreenScale), float64(data.ScreenScale), negativeScale, fmt.Sprintf("%v Gold", goldPerTurn))
+                        game.Fonts.InfoFontRed.PrintOptions2(screen, 278, 103, negativeOptions, fmt.Sprintf("%v Gold", goldPerTurn))
                     } else {
-                        game.Fonts.InfoFontYellow.PrintCenter(screen, float64(278 * data.ScreenScale), float64(103 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v Gold", goldPerTurn))
+                        game.Fonts.InfoFontYellow.PrintOptions2(screen, 278, 103, normalOptions, fmt.Sprintf("%v Gold", goldPerTurn))
                     }
 
                     if foodPerTurn < 0 {
-                        game.Fonts.InfoFontRed.PrintCenter(screen, float64(278 * data.ScreenScale), float64(135 * data.ScreenScale), float64(data.ScreenScale), negativeScale, fmt.Sprintf("%v Food", foodPerTurn))
+                        game.Fonts.InfoFontRed.PrintOptions2(screen, 278, 135, negativeOptions, fmt.Sprintf("%v Food", foodPerTurn))
                     } else {
-                        game.Fonts.InfoFontYellow.PrintCenter(screen, float64(278 * data.ScreenScale), float64(135 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v Food", foodPerTurn))
+                        game.Fonts.InfoFontYellow.PrintOptions2(screen, 278, 135, normalOptions, fmt.Sprintf("%v Food", foodPerTurn))
                     }
 
                     if manaPerTurn < 0 {
-                        game.Fonts.InfoFontRed.PrintCenter(screen, float64(278 * data.ScreenScale), float64(167 * data.ScreenScale), float64(data.ScreenScale), negativeScale, fmt.Sprintf("%v Mana", manaPerTurn))
+                        game.Fonts.InfoFontRed.PrintOptions2(screen, 278, 167, negativeOptions, fmt.Sprintf("%v Mana", manaPerTurn))
                     } else {
-                        game.Fonts.InfoFontYellow.PrintCenter(screen, float64(278 * data.ScreenScale), float64(167 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v Mana", manaPerTurn))
+                        game.Fonts.InfoFontYellow.PrintOptions2(screen, 278, 167, normalOptions, fmt.Sprintf("%v Mana", manaPerTurn))
                     }
 
                     if conjunction != "" {
-                        var scale ebiten.ColorScale
-                        scale.ScaleWithColor(conjunctionColor)
-                        game.Fonts.WhiteFont.PrintCenter(screen, float64(278 * data.ScreenScale), float64(155 * data.ScreenScale), float64(data.ScreenScale), scale, conjunction)
+                        conjunctionOptions := options
+                        conjunctionOptions.ColorScale.ScaleWithColor(conjunctionColor)
+                        game.Fonts.WhiteFont.PrintOptions2(screen, 278, 155, font.FontOptions{Justify: font.FontJustifyCenter, Options: &conjunctionOptions, Scale: scale.ScaleAmount}, conjunction)
                     }
                 },
             })

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6087,7 +6087,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
         elements = append(elements, &uilib.UIElement{
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 if !minMoves.IsZero() {
-                    game.Fonts.WhiteFont.PrintOptions2(screen, 246, 167, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("Moves:%v", minMoves.ToFloat()))
+                    game.Fonts.WhiteFont.PrintOptions(screen, 246, 167, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("Moves:%v", minMoves.ToFloat()))
 
                     sailingIcon, _ := game.ImageCache.GetImage("main.lbx", 18, 0)
                     swimmingIcon, _ := game.ImageCache.GetImage("main.lbx", 19, 0)
@@ -6193,27 +6193,27 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     normalOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
 
                     if goldPerTurn < 0 {
-                        game.Fonts.InfoFontRed.PrintOptions2(screen, 278, 103, negativeOptions, fmt.Sprintf("%v Gold", goldPerTurn))
+                        game.Fonts.InfoFontRed.PrintOptions(screen, 278, 103, negativeOptions, fmt.Sprintf("%v Gold", goldPerTurn))
                     } else {
-                        game.Fonts.InfoFontYellow.PrintOptions2(screen, 278, 103, normalOptions, fmt.Sprintf("%v Gold", goldPerTurn))
+                        game.Fonts.InfoFontYellow.PrintOptions(screen, 278, 103, normalOptions, fmt.Sprintf("%v Gold", goldPerTurn))
                     }
 
                     if foodPerTurn < 0 {
-                        game.Fonts.InfoFontRed.PrintOptions2(screen, 278, 135, negativeOptions, fmt.Sprintf("%v Food", foodPerTurn))
+                        game.Fonts.InfoFontRed.PrintOptions(screen, 278, 135, negativeOptions, fmt.Sprintf("%v Food", foodPerTurn))
                     } else {
-                        game.Fonts.InfoFontYellow.PrintOptions2(screen, 278, 135, normalOptions, fmt.Sprintf("%v Food", foodPerTurn))
+                        game.Fonts.InfoFontYellow.PrintOptions(screen, 278, 135, normalOptions, fmt.Sprintf("%v Food", foodPerTurn))
                     }
 
                     if manaPerTurn < 0 {
-                        game.Fonts.InfoFontRed.PrintOptions2(screen, 278, 167, negativeOptions, fmt.Sprintf("%v Mana", manaPerTurn))
+                        game.Fonts.InfoFontRed.PrintOptions(screen, 278, 167, negativeOptions, fmt.Sprintf("%v Mana", manaPerTurn))
                     } else {
-                        game.Fonts.InfoFontYellow.PrintOptions2(screen, 278, 167, normalOptions, fmt.Sprintf("%v Mana", manaPerTurn))
+                        game.Fonts.InfoFontYellow.PrintOptions(screen, 278, 167, normalOptions, fmt.Sprintf("%v Mana", manaPerTurn))
                     }
 
                     if conjunction != "" {
                         conjunctionOptions := options
                         conjunctionOptions.ColorScale.ScaleWithColor(conjunctionColor)
-                        game.Fonts.WhiteFont.PrintOptions2(screen, 278, 155, font.FontOptions{Justify: font.FontJustifyCenter, Options: &conjunctionOptions, Scale: scale.ScaleAmount}, conjunction)
+                        game.Fonts.WhiteFont.PrintOptions(screen, 278, 155, font.FontOptions{Justify: font.FontJustifyCenter, Options: &conjunctionOptions, Scale: scale.ScaleAmount}, conjunction)
                     }
                 },
             })
@@ -6222,13 +6222,13 @@ func (game *Game) MakeHudUI() *uilib.UI {
 
     elements = append(elements, &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            game.Fonts.WhiteFont.PrintOptions2(screen, 276, 68, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v GP", game.Players[0].Gold))
+            game.Fonts.WhiteFont.PrintOptions(screen, 276, 68, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v GP", game.Players[0].Gold))
         },
     })
 
     elements = append(elements, &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            game.Fonts.WhiteFont.PrintOptions2(screen, 313, 68, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", game.Players[0].Mana))
+            game.Fonts.WhiteFont.PrintOptions(screen, 313, 68, font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", game.Players[0].Mana))
         },
     })
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2070,7 +2070,7 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
         elements = append(elements, &uilib.UIElement{
             Rect: util.ImageRect(20, 40, resolutionBackground),
             LeftClick: func(element *uilib.UIElement){
-                selected := func(name string, scale int, algorithm data.ScaleAlgorithm) string {
+                selected := func(name string, scale int, algorithm scale.ScaleAlgorithm) string {
                     /*
                     if data.ScreenScale == scale && data.ScreenScaleAlgorithm == algorithm {
                         return name + "*"
@@ -2079,7 +2079,7 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
                     return name
                 }
 
-                update := func(scale int, algorithm data.ScaleAlgorithm){
+                update := func(scale int, algorithm scale.ScaleAlgorithm){
                     /*
                     data.ScreenScale = scale
                     data.ScreenScaleAlgorithm = algorithm
@@ -2091,7 +2091,7 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
                     */
                 }
 
-                makeChoices := func (name string, scales []int, algorithm data.ScaleAlgorithm) []uilib.Selection {
+                makeChoices := func (name string, scales []int, algorithm scale.ScaleAlgorithm) []uilib.Selection {
                     var out []uilib.Selection
                     for _, value := range scales {
                         out = append(out, uilib.Selection{
@@ -2104,9 +2104,9 @@ func (game *Game) MakeSettingsUI(imageCache *util.ImageCache, ui *uilib.UI, back
                     return out
                 }
 
-                normalChoices := makeChoices("Normal", []int{1, 2, 3, 4}, data.ScaleAlgorithmNormal)
-                scaleChoices := makeChoices("Scale", []int{2, 3, 4}, data.ScaleAlgorithmScale)
-                xbrChoices := makeChoices("XBR", []int{2, 3, 4}, data.ScaleAlgorithmXbr)
+                normalChoices := makeChoices("Normal", []int{1, 2, 3, 4}, scale.ScaleAlgorithmNormal)
+                scaleChoices := makeChoices("Scale", []int{2, 3, 4}, scale.ScaleAlgorithmScale)
+                xbrChoices := makeChoices("XBR", []int{2, 3, 4}, scale.ScaleAlgorithmXbr)
 
                 choices := append(append(normalChoices, scaleChoices...), xbrChoices...)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1223,7 +1223,7 @@ func (game *Game) showNewBuilding(yield coroutine.YieldFunc, city *citylib.City,
         scale.DrawScaled(screen, animal, &iconOptions)
 
         x, y := options.GeoM.Apply(float64(8 + animal.Bounds().Dx()), float64(9))
-        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
+        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
         options.GeoM.Translate(float64(background.Bounds().Dx()), 0)
         scale.DrawScaled(screen, rightSide, &options)
@@ -1333,7 +1333,7 @@ func (game *Game) showScroll(yield coroutine.YieldFunc, title string, text strin
 
         var textOptions ebiten.DrawImageOptions
         textOptions.ColorScale = textScale
-        fonts.SmallFont.RenderWrapped(screen, x, y, wrappedText, textScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &textOptions})
+        fonts.SmallFont.RenderWrapped(screen, x, y, wrappedText, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &textOptions})
 
         scrollOptions := options
         scrollOptions.GeoM.Translate(float64(-63), float64(-20))
@@ -2751,7 +2751,7 @@ func (game *Game) doRandomEvent(yield coroutine.YieldFunc, event *RandomEvent, s
         scale.DrawScaled(screen, animal, &iconOptions)
 
         x, y := options.GeoM.Apply(float64(75), float64(9))
-        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
+        fonts.BigFont.RenderWrapped(screen, x, y, wrappedText, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
         options.GeoM.Translate(float64(background.Bounds().Dx()), 0)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2187,6 +2187,8 @@ func (game *Game) doGameMenu(yield coroutine.YieldFunc) {
 
     // settings
     elements = append(elements, makeButton(12, 172, 171, func(){
+        // disable for now
+        /*
         ui.RemoveElements(elements)
 
         game.MakeSettingsUI(&imageCache, ui, &background, func(){
@@ -2194,6 +2196,7 @@ func (game *Game) doGameMenu(yield coroutine.YieldFunc) {
             // re-enter the game menu
             game.Events <- &GameEventGameMenu{}
         })
+        */
     }))
 
     // ok

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -140,7 +140,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 
             x := float64(hireRect.Min.X + hireRect.Max.X) / 2
             y := float64(hireRect.Min.Y + hireRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, hireText)
+            fonts.OkDismissFont.PrintOptions(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, hireText)
         },
     })
 
@@ -169,7 +169,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 
             x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
             y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Reject")
+            fonts.OkDismissFont.PrintOptions(screen, x, y - float64(5), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Reject")
         },
     })
 
@@ -182,7 +182,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             options.ColorScale.ScaleAlpha(getAlpha())
             scale.DrawScaled(screen, banner, &options)
 
-            fonts.OkDismissFont.PrintOptions2(screen, float64(135), float64(6), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, titleText)
+            fonts.OkDismissFont.PrintOptions(screen, float64(135), float64(6), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, titleText)
         },
     })
 
@@ -266,7 +266,7 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
         scale.DrawScaled(screen, portrait, &options)
 
         // text
-        fonts.TitleFont.PrintOptions2(screen, left + float64(48), top + float64(10), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v has made a level.", hero.Name))
+        fonts.TitleFont.PrintOptions(screen, left + float64(48), top + float64(10), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v has made a level.", hero.Name))
 
         // stats progression
         for index, progression := range hero.GetBaseProgression() {
@@ -277,7 +277,7 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
             options.GeoM.Translate(left + (48 + xOffset), top + (25 + yOffset))
             scale.DrawScaled(screen, dot, &options)
 
-            fonts.SmallFont.PrintOptions2(screen, left + (55 + xOffset), top + (24 + yOffset), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, progression)
+            fonts.SmallFont.PrintOptions(screen, left + (55 + xOffset), top + (24 + yOffset), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, progression)
         }
 
         row := 0
@@ -304,9 +304,9 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
 
                 abilityBonus := hero.GetAbilityBonus(ability.Ability)
                 if abilityBonus > 0 {
-                    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v +%v", ability.Name(), abilityBonus))
+                    fonts.SmallFont.PrintOptions(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v +%v", ability.Name(), abilityBonus))
                 } else {
-                    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, ability.Name())
+                    fonts.SmallFont.PrintOptions(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, ability.Name())
                 }
             }
 

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -8,12 +8,14 @@ import (
     "cmp"
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/lib/set"
     "github.com/kazzmir/master-of-magic/lib/coroutine"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     fontslib "github.com/kazzmir/master-of-magic/game/magic/fonts"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -25,7 +27,7 @@ import (
 func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero, goldToHire int, action func(bool), onFadeOut func()) *uilib.UIElementGroup {
     imageCache := util.MakeImageCache(cache)
 
-    yTop := float64(10 * data.ScreenScale)
+    yTop := float64(10)
 
     fonts := fontslib.MakeHireHeroFonts(cache)
 
@@ -48,30 +50,30 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
-            options.GeoM.Translate(float64(9 * data.ScreenScale), float64(7 * data.ScreenScale))
+            options.GeoM.Translate(float64(9), float64(7))
             portraitLbx, portraitIndex := hero.GetPortraitLbxInfo()
             portrait, err := imageCache.GetImage(portraitLbx, portraitIndex, 0)
             if err == nil {
-                screen.DrawImage(portrait, &options)
+                scale.DrawScaled(screen, portrait, &options)
             }
 
             // unitview.RenderCombatImage(screen, &imageCache, &hero.Unit.Unit, options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
-            options.GeoM.Translate(float64(51 * data.ScreenScale), float64(7 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(51), float64(7))
 
             unitview.RenderUnitInfoNormal(screen, &imageCache, hero, hero.GetTitle(), "", fonts.DescriptionFont, fonts.SmallFont, options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
-            options.GeoM.Translate(float64(10 * data.ScreenScale), float64(50 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(10), float64(50))
             unitview.RenderUnitInfoStats(screen, &imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, options)
 
             /*
@@ -81,7 +83,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
         },
     })
 
-    uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, hero, fonts.MediumFont, 40 * data.ScreenScale, 124 * data.ScreenScale, &ui.Counter, 1, &getAlpha, true, 0, false))
+    uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, hero, fonts.MediumFont, 40, 124, &ui.Counter, 1, &getAlpha, true, 0, false))
 
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
@@ -89,15 +91,15 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             box, _ := imageCache.GetImage("unitview.lbx", 2, 0)
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(248 * data.ScreenScale), float64(139 * data.ScreenScale))
+            options.GeoM.Translate(float64(248), float64(139))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(box, &options)
+            scale.DrawScaled(screen, box, &options)
         },
     })
 
     buttonBackgrounds, _ := imageCache.GetImages("backgrnd.lbx", 24)
     // hire button
-    hireRect := util.ImageRect(257 * data.ScreenScale, 149 * data.ScreenScale + int(yTop), buttonBackgrounds[0])
+    hireRect := util.ImageRect(257, 149 + int(yTop), buttonBackgrounds[0])
     hireIndex := 0
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
@@ -134,15 +136,15 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(hireRect.Min.X), float64(hireRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(buttonBackgrounds[hireIndex], &options)
+            scale.DrawScaled(screen, buttonBackgrounds[hireIndex], &options)
 
             x := float64(hireRect.Min.X + hireRect.Max.X) / 2
             y := float64(hireRect.Min.Y + hireRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, hireText)
+            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, hireText)
         },
     })
 
-    rejectRect := util.ImageRect(257 * data.ScreenScale, 169 * data.ScreenScale + int(yTop), buttonBackgrounds[0])
+    rejectRect := util.ImageRect(257, 169 + int(yTop), buttonBackgrounds[0])
     rejectIndex := 0
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
@@ -163,11 +165,11 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(rejectRect.Min.X), float64(rejectRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(buttonBackgrounds[rejectIndex], &options)
+            scale.DrawScaled(screen, buttonBackgrounds[rejectIndex], &options)
 
             x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
             y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Reject")
+            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Reject")
         },
     })
 
@@ -178,9 +180,9 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(0, 0)
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(banner, &options)
+            scale.DrawScaled(screen, banner, &options)
 
-            fonts.OkDismissFont.PrintCenter(screen, float64(135 * data.ScreenScale), float64(6 * data.ScreenScale), float64(1 * data.ScreenScale), options.ColorScale, titleText)
+            fonts.OkDismissFont.PrintOptions2(screen, float64(135), float64(6), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, titleText)
         },
     })
 
@@ -190,8 +192,8 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.Hero) {
     fonts := fontslib.MakeHeroLevelUpFonts(game.Cache)
 
-    top := float64(40 * data.ScreenScale)
-    left := float64(30 * data.ScreenScale)
+    top := float64(40)
+    left := float64(30)
 
     // the set of abilities that can possibly show an improvement
     progressAbilities := set.MakeSet[data.AbilityType]()
@@ -225,7 +227,7 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
 
     abilityRows := int(math.Ceil(float64(1 + len(haveAbilities)) / float64(maxAbilitiesPerRow)))
 
-    height := (50 + abilityRows * 20) * data.ScreenScale
+    height := (50 + abilityRows * 20)
 
     backgroundTop, _ := game.ImageCache.GetImage("reload.lbx", 23, 0)
     backgroundTop = backgroundTop.SubImage(image.Rect(0, 0, backgroundTop.Bounds().Dx(), height)).(*ebiten.Image)
@@ -252,19 +254,19 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
         // background
         options.GeoM.Translate(left, top)
         options.ColorScale.ScaleAlpha(getAlpha())
-        screen.DrawImage(backgroundTop, &options)
+        scale.DrawScaled(screen, backgroundTop, &options)
 
         options.GeoM.Reset()
         options.GeoM.Translate(left, top + float64(height))
-        screen.DrawImage(backgroundBottom, &options)
+        scale.DrawScaled(screen, backgroundBottom, &options)
 
         // portrait
         options.GeoM.Reset()
-        options.GeoM.Translate(left + float64(10 * data.ScreenScale), top + float64(10 * data.ScreenScale))
-        screen.DrawImage(portrait, &options)
+        options.GeoM.Translate(left + float64(10), top + float64(10))
+        scale.DrawScaled(screen, portrait, &options)
 
         // text
-        fonts.TitleFont.Print(screen, left + float64(48 * data.ScreenScale), top + float64(10 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v has made a level.", hero.Name))
+        fonts.TitleFont.PrintOptions2(screen, left + float64(48), top + float64(10), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v has made a level.", hero.Name))
 
         // stats progression
         for index, progression := range hero.GetBaseProgression() {
@@ -272,10 +274,10 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
             yOffset := 10 * float64(index % 2)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(left + (48 + xOffset) * float64(data.ScreenScale), top + (25 + yOffset) * float64(data.ScreenScale))
-            screen.DrawImage(dot, &options)
+            options.GeoM.Translate(left + (48 + xOffset), top + (25 + yOffset))
+            scale.DrawScaled(screen, dot, &options)
 
-            fonts.SmallFont.Print(screen, left + (55 + xOffset) * float64(data.ScreenScale), top + (24 + yOffset) * float64(data.ScreenScale), float64(data.ScreenScale), options.ColorScale, progression)
+            fonts.SmallFont.PrintOptions2(screen, left + (55 + xOffset), top + (24 + yOffset), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, progression)
         }
 
         row := 0
@@ -284,7 +286,7 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
 
         // level
         options.GeoM.Reset()
-        options.GeoM.Translate(left + float64((10 + abilityWidth * column) * data.ScreenScale), top + float64((50 + row * 20) * data.ScreenScale))
+        options.GeoM.Translate(left + float64((10 + abilityWidth * column)), top + float64((50 + row * 20)))
         unitview.RenderExperienceBadge(screen, &game.ImageCache, hero, fonts.SmallFont, options, false)
 
         // start in second column because the badge is in the first
@@ -295,16 +297,16 @@ func (game *Game) showHeroLevelUpPopup(yield coroutine.YieldFunc, hero *herolib.
             pic, err := game.ImageCache.GetImage(ability.LbxFile(), ability.LbxIndex(), 0)
             if err == nil {
                 options.GeoM.Reset()
-                options.GeoM.Translate(left + float64((10 + abilityWidth * column) * data.ScreenScale), top + float64((50 + row * 20) * data.ScreenScale))
-                screen.DrawImage(pic, &options)
+                options.GeoM.Translate(left + float64((10 + abilityWidth * column)), top + float64((50 + row * 20)))
+                scale.DrawScaled(screen, pic, &options)
 
-                x, y := options.GeoM.Apply(float64(pic.Bounds().Dx() + 2 * data.ScreenScale), float64(5 * data.ScreenScale))
+                x, y := options.GeoM.Apply(float64(pic.Bounds().Dx() + 2), float64(5))
 
                 abilityBonus := hero.GetAbilityBonus(ability.Ability)
                 if abilityBonus > 0 {
-                    fonts.SmallFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v +%v", ability.Name(), abilityBonus))
+                    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v +%v", ability.Name(), abilityBonus))
                 } else {
-                    fonts.SmallFont.Print(screen, x, y, float64(data.ScreenScale), options.ColorScale, ability.Name())
+                    fonts.SmallFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, ability.Name())
                 }
             }
 

--- a/game/magic/game/learn-spell.go
+++ b/game/magic/game/learn-spell.go
@@ -1,8 +1,9 @@
 package game
 
 import (
-    "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/lib/coroutine"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
@@ -63,25 +64,25 @@ func (game *Game) wizlabAnimation(yield coroutine.YieldFunc, wizard setup.Wizard
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(fade())
 
-        screen.DrawImage(background, &options)
+        scale.DrawScaled(screen, background, &options)
 
         wizardPic, _ := game.ImageCache.GetImage("wizlab.lbx", wizardIndex, 0)
-        options.GeoM.Translate(float64(70 * data.ScreenScale), float64(74 * data.ScreenScale))
-        screen.DrawImage(wizardPic, &options)
+        options.GeoM.Translate(float64(70), float64(74))
+        scale.DrawScaled(screen, wizardPic, &options)
 
         options.GeoM.Reset()
-        options.GeoM.Translate(float64(132 * data.ScreenScale), float64(-5 * data.ScreenScale))
-        screen.DrawImage(sparkles.Frame(), &options)
+        options.GeoM.Translate(float64(132), float64(-5))
+        scale.DrawScaled(screen, sparkles.Frame(), &options)
 
         pulpit, _ := game.ImageCache.GetImage("wizlab.lbx", 20, 0)
         options.GeoM.Reset()
-        options.GeoM.Translate(float64(150 * data.ScreenScale), float64(130 * data.ScreenScale))
-        screen.DrawImage(pulpit, &options)
+        options.GeoM.Translate(float64(150), float64(130))
+        scale.DrawScaled(screen, pulpit, &options)
 
         options.GeoM.Reset()
-        options.GeoM.Translate(float64(190 * data.ScreenScale), float64(157 * data.ScreenScale))
+        options.GeoM.Translate(float64(190), float64(157))
         animalPic, _ := game.ImageCache.GetImage("wizlab.lbx", animalIndex, 0)
-        screen.DrawImage(animalPic, &options)
+        scale.DrawScaled(screen, animalPic, &options)
     }
 
     counter := uint64(0)

--- a/game/magic/game/mercenaries.go
+++ b/game/magic/game/mercenaries.go
@@ -8,8 +8,9 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/unitview"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/font"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
@@ -17,7 +18,7 @@ import (
 func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.OverworldUnit, count int, goldToHire int, action func(bool)) *uilib.UIElementGroup {
     imageCache := util.MakeImageCache(cache)
 
-    yTop := float64(10 * data.ScreenScale)
+    yTop := float64(10)
 
     fonts := fontslib.MakeMercenariesFonts(cache)
 
@@ -35,28 +36,28 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
-            options.GeoM.Translate(float64(24 * data.ScreenScale), float64(28 * data.ScreenScale))
+            options.GeoM.Translate(float64(24), float64(28))
             unitview.RenderUnitViewImage(screen, &imageCache, unit, options, false, 0)
 
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
-            options.GeoM.Translate(float64(51 * data.ScreenScale), float64(7 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(51), float64(7))
             unitview.RenderUnitInfoNormal(screen, &imageCache, unit, "", unit.Unit.Race.String(), fonts.DescriptionFont, fonts.SmallFont, options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(31 * data.ScreenScale), float64(6 * data.ScreenScale))
-            options.GeoM.Translate(float64(10 * data.ScreenScale), float64(50 * data.ScreenScale))
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(10), float64(50))
             unitview.RenderUnitInfoStats(screen, &imageCache, unit, 15, fonts.DescriptionFont, fonts.SmallFont, options)
         },
     })
 
-    uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, unit, fonts.MediumFont, 40 * data.ScreenScale, 124 * data.ScreenScale, &ui.Counter, 1, &getAlpha, false, 0, false))
+    uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, unit, fonts.MediumFont, 40, 124, &ui.Counter, 1, &getAlpha, false, 0, false))
 
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
@@ -64,15 +65,15 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             box, _ := imageCache.GetImage("unitview.lbx", 2, 0)
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(0, yTop)
-            options.GeoM.Translate(float64(248 * data.ScreenScale), float64(139 * data.ScreenScale))
+            options.GeoM.Translate(float64(248), float64(139))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(box, &options)
+            scale.DrawScaled(screen, box, &options)
         },
     })
 
     buttonBackgrounds, _ := imageCache.GetImages("backgrnd.lbx", 24)
 
-    hireRect := util.ImageRect(257 * data.ScreenScale, 149 * data.ScreenScale + int(yTop), buttonBackgrounds[0])
+    hireRect := util.ImageRect(257, 149 + int(yTop), buttonBackgrounds[0])
     hireIndex := 0
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
@@ -93,15 +94,15 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(hireRect.Min.X), float64(hireRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(buttonBackgrounds[hireIndex], &options)
+            scale.DrawScaled(screen, buttonBackgrounds[hireIndex], &options)
 
             x := float64(hireRect.Min.X + hireRect.Max.X) / 2
             y := float64(hireRect.Min.Y + hireRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Hire")
+            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Hire")
         },
     })
 
-    rejectRect := util.ImageRect(257 * data.ScreenScale, 169 * data.ScreenScale + int(yTop), buttonBackgrounds[0])
+    rejectRect := util.ImageRect(257, 169 + int(yTop), buttonBackgrounds[0])
     rejectIndex := 0
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
@@ -122,11 +123,11 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(rejectRect.Min.X), float64(rejectRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(buttonBackgrounds[rejectIndex], &options)
+            scale.DrawScaled(screen, buttonBackgrounds[rejectIndex], &options)
 
             x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
             y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Reject")
+            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Reject")
         },
     })
 
@@ -137,13 +138,13 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(0, 0)
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(banner, &options)
+            scale.DrawScaled(screen, banner, &options)
 
             message := fmt.Sprintf("Mercenaries for Hire: %v gold", goldToHire)
             if count > 1 {
                 message = fmt.Sprintf("%v Mercenaries for Hire: %v gold", count, goldToHire)
             }
-            fonts.OkDismissFont.PrintCenter(screen, float64(135 * data.ScreenScale), float64(6 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, message)
+            fonts.OkDismissFont.PrintOptions2(screen, float64(135), float64(6), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, message)
         },
     })
 

--- a/game/magic/game/mercenaries.go
+++ b/game/magic/game/mercenaries.go
@@ -98,7 +98,7 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
 
             x := float64(hireRect.Min.X + hireRect.Max.X) / 2
             y := float64(hireRect.Min.Y + hireRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Hire")
+            fonts.OkDismissFont.PrintOptions(screen, x, y - float64(5), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Hire")
         },
     })
 
@@ -127,7 +127,7 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
 
             x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
             y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
-            fonts.OkDismissFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Reject")
+            fonts.OkDismissFont.PrintOptions(screen, x, y - float64(5), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Reject")
         },
     })
 
@@ -144,7 +144,7 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             if count > 1 {
                 message = fmt.Sprintf("%v Mercenaries for Hire: %v gold", count, goldToHire)
             }
-            fonts.OkDismissFont.PrintOptions2(screen, float64(135), float64(6), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, message)
+            fonts.OkDismissFont.PrintOptions(screen, float64(135), float64(6), font.FontOptions{Options: &options, Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, message)
         },
     })
 

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -82,7 +82,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
 
             x := float64(buyRect.Min.X + buyRect.Max.X) / 2
             y := float64(buyRect.Min.Y + buyRect.Max.Y) / 2
-            fonts.LightFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Buy")
+            fonts.LightFont.PrintOptions(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Buy")
         },
     })
 
@@ -110,7 +110,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
 
             x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
             y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
-            fonts.LightFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Reject")
+            fonts.LightFont.PrintOptions(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Reject")
         },
     })
 

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -7,7 +7,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     fontslib "github.com/kazzmir/master-of-magic/game/magic/fonts"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
@@ -32,18 +32,8 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
             background, _ := imageCache.GetImage("hire.lbx", 2, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(4 * data.ScreenScale), float64(15 * data.ScreenScale))
-            screen.DrawImage(background, &options)
-        },
-    })
-
-    elements = append(elements, &uilib.UIElement{
-        Layer: 1,
-        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            colorScale := ebiten.ColorScale{}
-            colorScale.ScaleAlpha(getAlpha())
-            text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifactToBuy.Name, goldToBuy)
-            fonts.LightFont.PrintWrap(screen, float64(60 * data.ScreenScale), float64(23 * data.ScreenScale), float64(180 * data.ScreenScale), float64(data.ScreenScale), colorScale, font.FontOptions{}, text)
+            options.GeoM.Translate(float64(4), float64(15))
+            scale.DrawScaled(screen, background, &options)
         },
     })
 
@@ -52,13 +42,23 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(18 * data.ScreenScale), float64(80 * data.ScreenScale))
+            text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifactToBuy.Name, goldToBuy)
+            fonts.LightFont.PrintWrap(screen, float64(60), float64(23), float64(180), 1, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, text)
+        },
+    })
+
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(getAlpha())
+            options.GeoM.Translate(float64(18), float64(80))
             artifact.RenderArtifactBox(screen, &imageCache, *artifactToBuy, ui.Counter / 8, vaultFonts.ItemName, vaultFonts.PowerFont, options)
         },
     })
 
     buttonBackgrounds, _ := imageCache.GetImages("backgrnd.lbx", 24)
-    buyRect := util.ImageRect(256 * data.ScreenScale, 136 * data.ScreenScale, buttonBackgrounds[0])
+    buyRect := util.ImageRect(256, 136, buttonBackgrounds[0])
     buyIndex := 0
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
@@ -78,15 +78,15 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(buyRect.Min.X), float64(buyRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(buttonBackgrounds[buyIndex], &options)
+            scale.DrawScaled(screen, buttonBackgrounds[buyIndex], &options)
 
             x := float64(buyRect.Min.X + buyRect.Max.X) / 2
             y := float64(buyRect.Min.Y + buyRect.Max.Y) / 2
-            fonts.LightFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Buy")
+            fonts.LightFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Buy")
         },
     })
 
-    rejectRect := util.ImageRect(256 * data.ScreenScale, 155 * data.ScreenScale, buttonBackgrounds[0])
+    rejectRect := util.ImageRect(256, 155, buttonBackgrounds[0])
     rejectIndex := 0
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
@@ -106,11 +106,11 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(rejectRect.Min.X), float64(rejectRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(buttonBackgrounds[rejectIndex], &options)
+            scale.DrawScaled(screen, buttonBackgrounds[rejectIndex], &options)
 
             x := float64(rejectRect.Min.X + rejectRect.Max.X) / 2
             y := float64(rejectRect.Min.Y + rejectRect.Max.Y) / 2
-            fonts.LightFont.PrintCenter(screen, x, y - float64(5 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Reject")
+            fonts.LightFont.PrintOptions2(screen, x, y - float64(5), font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Reject")
         },
     })
 

--- a/game/magic/game/merchant.go
+++ b/game/magic/game/merchant.go
@@ -43,7 +43,7 @@ func MakeMerchantScreenUI(cache *lbx.LbxCache, ui *uilib.UI, artifactToBuy *arti
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
             text := fmt.Sprintf("A merchant arrives and offers a magic %v for sale. The price is only %v gold pieces.", artifactToBuy.Name, goldToBuy)
-            fonts.LightFont.PrintWrap(screen, float64(60), float64(23), float64(180), 1, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, text)
+            fonts.LightFont.PrintWrap(screen, float64(60), float64(23), float64(180), font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, text)
         },
     })
 

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -240,7 +240,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                         y = float64(170) - float64(fonts.WhiteFont.Height()) * 3 - cityInfoText.TotalHeight
                     }
 
-                    fonts.YellowFont.RenderWrapped(screen, float64(245), y, cityInfoText, ebiten.ColorScale{}, font.FontOptions{})
+                    fonts.YellowFont.RenderWrapped(screen, float64(245), y, cityInfoText, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
                     y += cityInfoText.TotalHeight
 
                     if resources.Enabled {

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -9,6 +9,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     fontslib "github.com/kazzmir/master-of-magic/game/magic/fonts"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -90,15 +91,15 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             mainHud, _ := game.ImageCache.GetImage("main.lbx", 0, 0)
-            screen.DrawImage(mainHud, &options)
+            scale.DrawScaled(screen, mainHud, &options)
 
             landImage, _ := game.ImageCache.GetImage("main.lbx", 57, 0)
-            options.GeoM.Translate(float64(240 * data.ScreenScale), float64(77 * data.ScreenScale))
-            screen.DrawImage(landImage, &options)
+            options.GeoM.Translate(float64(240), float64(77))
+            scale.DrawScaled(screen, landImage, &options)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(240 * data.ScreenScale), float64(174 * data.ScreenScale))
-            screen.DrawImage(cancelBackground, &options)
+            options.GeoM.Translate(float64(240), float64(174))
+            scale.DrawScaled(screen, cancelBackground, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -108,10 +109,10 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
 
             player := game.Players[0]
 
-            game.Fonts.WhiteFont.PrintRight(screen, float64(276 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v GP", player.Gold))
-            game.Fonts.WhiteFont.PrintRight(screen, float64(313 * data.ScreenScale), float64(68 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v MP", player.Mana))
+            game.Fonts.WhiteFont.PrintRight(screen, float64(276), float64(68), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v GP", player.Gold))
+            game.Fonts.WhiteFont.PrintRight(screen, float64(313), float64(68), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v MP", player.Mana))
 
-            fonts.SurveyorFont.PrintCenter(screen, float64(280 * data.ScreenScale), float64(81 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Surveyor")
+            fonts.SurveyorFont.PrintCenter(screen, float64(280), float64(81), scale.ScaleAmount, ebiten.ColorScale{}, "Surveyor")
 
             if selectedPoint.X >= 0 && selectedPoint.X < game.CurrentMap().Width() && selectedPoint.Y >= 0 && selectedPoint.Y < game.CurrentMap().Height() {
                 if overworld.Fog[selectedPoint.X][selectedPoint.Y] != data.FogTypeUnexplored {
@@ -119,7 +120,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                     tile := mapObject.GetTile(selectedPoint.X, selectedPoint.Y)
                     node := mapObject.GetMagicNode(selectedPoint.X, selectedPoint.Y)
 
-                    y := float64(93 * data.ScreenScale)
+                    y := float64(93)
 
                     // Terrain
                     name := tile.Name(mapObject)
@@ -130,88 +131,88 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                             case maplib.MagicNodeChaos: name = "Mountain"
                         }
                     }
-                    fonts.YellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, name)
-                    y += float64(fonts.YellowFont.Height() * data.ScreenScale)
+                    fonts.YellowFont.PrintCenter(screen, 280, y, scale.ScaleAmount, ebiten.ColorScale{}, name)
+                    y += float64(fonts.YellowFont.Height())
 
                     // Terrain bonuses
                     if tile.Corrupted() {
-                        fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Corruption")
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                        fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, "Corruption")
+                        y += float64(fonts.WhiteFont.Height())
                     }
 
                     foodBonus := tile.FoodBonus()
                     if !foodBonus.IsZero() {
-                        fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v food", foodBonus.NormalString()))
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                        fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v food", foodBonus.NormalString()))
+                        y += float64(fonts.WhiteFont.Height())
                     }
 
                     productionBonus := tile.ProductionBonus(false)
                     if productionBonus != 0 {
-                        fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v%% production", productionBonus))
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                        fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v%% production", productionBonus))
+                        y += float64(fonts.WhiteFont.Height())
                     }
 
                     goldBonus := tile.GoldBonus(mapObject)
                     if goldBonus != 0 {
-                        fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v%% gold", goldBonus))
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                        fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v%% gold", goldBonus))
+                        y += float64(fonts.WhiteFont.Height())
                     }
 
-                    y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                    y += float64(fonts.WhiteFont.Height())
 
                     // Bonuses
                     bonus := tile.GetBonus()
                     if bonus != data.BonusNone {
-                        fonts.YellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, bonus.String())
-                        y += float64(fonts.YellowFont.Height() * data.ScreenScale)
+                        fonts.YellowFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, bonus.String())
+                        y += float64(fonts.YellowFont.Height())
 
                         food := bonus.FoodBonus()
                         if food != 0 {
-                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v food", food))
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280), y, float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v food", food))
+                            y += float64(fonts.WhiteFont.Height())
                         }
 
                         gold := bonus.GoldBonus()
                         if gold != 0 {
-                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v gold", gold))
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280), y, float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v gold", gold))
+                            y += float64(fonts.WhiteFont.Height())
                         }
 
                         power := bonus.PowerBonus()
                         if power != 0 {
-                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v power", power))
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280), y, float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v power", power))
+                            y += float64(fonts.WhiteFont.Height())
                         }
 
                         reduction := bonus.UnitReductionBonus()
                         if reduction != 0 {
-                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("Reduces normal unit cost by %v%%", reduction))
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintWrapCenter(screen, float64(280), y, float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("Reduces normal unit cost by %v%%", reduction))
+                            y += float64(fonts.WhiteFont.Height())
                         }
                     }
 
                     // Nodes
                     if node != nil {
-                        fonts.YellowFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, node.Kind.Name())
-                        y += float64(fonts.YellowFont.Height() * data.ScreenScale)
+                        fonts.YellowFont.PrintWrapCenter(screen, float64(280), y, float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, node.Kind.Name())
+                        y += float64(fonts.YellowFont.Height())
 
                         if node.Warped {
-                            fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Warped")
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, "Warped")
+                            y += float64(fonts.WhiteFont.Height())
                         } else if node.MeldingWizard != nil && node.GuardianSpiritMeld {
-                            fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Guardian Spirit")
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, "Guardian Spirit")
+                            y += float64(fonts.WhiteFont.Height())
                         } else if node.MeldingWizard != nil {
-                            fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Magic Spirit")
-                            y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                            fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, "Magic Spirit")
+                            y += float64(fonts.WhiteFont.Height())
                         }
                     }
 
                     // Lairs
                     encounter := mapObject.GetEncounter(selectedPoint.X, selectedPoint.Y)
                     if encounter != nil && encounter.Type != maplib.EncounterTypeChaosNode && encounter.Type != maplib.EncounterTypeNatureNode && encounter.Type != maplib.EncounterTypeSorceryNode {
-                        fonts.YellowFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, encounter.Type.Name())
-                        y += float64(fonts.YellowFont.Height() * data.ScreenScale)
+                        fonts.YellowFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, encounter.Type.Name())
+                        y += float64(fonts.YellowFont.Height())
                     }
 
                     // Enemies
@@ -223,34 +224,34 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                                 text = encounter.Units[0].Name
                             }
                         }
-                        fonts.WhiteFont.PrintCenter(screen, float64(280 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, text)
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
+                        fonts.WhiteFont.PrintCenter(screen, float64(280), y, scale.ScaleAmount, ebiten.ColorScale{}, text)
+                        y += float64(fonts.WhiteFont.Height())
                     }
 
                     // FIXME: how should this behave for different fog types?
                     if cityMap[selectedPoint] != nil {
                         city := cityMap[selectedPoint]
-                        fonts.YellowFont.PrintWrapCenter(screen, float64(280 * data.ScreenScale), y, float64(cancelBackground.Bounds().Dx() - 5 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, city.String())
+                        fonts.YellowFont.PrintWrapCenter(screen, float64(280), y, float64(cancelBackground.Bounds().Dx() - 5), scale.ScaleAmount, ebiten.ColorScale{}, city.String())
                     }
 
-                    y = float64(170 * data.ScreenScale) - cityInfoText.TotalHeight
+                    y = float64(170) - cityInfoText.TotalHeight
 
                     if resources.Enabled {
-                        y = float64(170 * data.ScreenScale) - float64(fonts.WhiteFont.Height() * data.ScreenScale) * 3 - cityInfoText.TotalHeight
+                        y = float64(170) - float64(fonts.WhiteFont.Height()) * 3 - cityInfoText.TotalHeight
                     }
 
-                    fonts.YellowFont.RenderWrapped(screen, float64(245 * data.ScreenScale), y, cityInfoText, ebiten.ColorScale{}, font.FontOptions{})
+                    fonts.YellowFont.RenderWrapped(screen, float64(245), y, cityInfoText, ebiten.ColorScale{}, font.FontOptions{})
                     y += cityInfoText.TotalHeight
 
                     if resources.Enabled {
-                        fonts.WhiteFont.Print(screen, float64(245 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Maximum Pop")
-                        fonts.WhiteFont.PrintRight(screen, float64(308 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("%v", resources.MaximumPopulation))
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
-                        fonts.WhiteFont.Print(screen, float64(245 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Prod Bonus")
-                        fonts.WhiteFont.PrintRight(screen, float64(314 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v%%", resources.ProductionBonus))
-                        y += float64(fonts.WhiteFont.Height() * data.ScreenScale)
-                        fonts.WhiteFont.Print(screen, float64(245 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, "Gold Bonus")
-                        fonts.WhiteFont.PrintRight(screen, float64(314 * data.ScreenScale), y, float64(data.ScreenScale), ebiten.ColorScale{}, fmt.Sprintf("+%v%%", resources.GoldBonus))
+                        fonts.WhiteFont.Print(screen, float64(245), y, scale.ScaleAmount, ebiten.ColorScale{}, "Maximum Pop")
+                        fonts.WhiteFont.PrintRight(screen, float64(308), y, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v", resources.MaximumPopulation))
+                        y += float64(fonts.WhiteFont.Height())
+                        fonts.WhiteFont.Print(screen, float64(245), y, scale.ScaleAmount, ebiten.ColorScale{}, "Prod Bonus")
+                        fonts.WhiteFont.PrintRight(screen, float64(314), y, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v%%", resources.ProductionBonus))
+                        y += float64(fonts.WhiteFont.Height())
+                        fonts.WhiteFont.Print(screen, float64(245), y, scale.ScaleAmount, ebiten.ColorScale{}, "Gold Bonus")
+                        fonts.WhiteFont.PrintRight(screen, float64(314), y, scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("+%v%%", resources.GoldBonus))
                     }
                 }
             }
@@ -262,10 +263,10 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     makeButton := func(lbxIndex int, x int, y int) *uilib.UIElement {
         button, _ := game.ImageCache.GetImage("main.lbx", lbxIndex, 0)
         var options ebiten.DrawImageOptions
-        options.GeoM.Translate(float64(x * data.ScreenScale), float64(y * data.ScreenScale))
+        options.GeoM.Translate(float64(x), float64(y))
         return &uilib.UIElement{
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                screen.DrawImage(button, &options)
+                scale.DrawScaled(screen, button, &options)
             },
         }
     }
@@ -291,8 +292,8 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     // plane button
     ui.AddElement((func () *uilib.UIElement {
         buttons, _ := game.ImageCache.GetImages("main.lbx", 7)
-        x := 270 * data.ScreenScale
-        y := 4 * data.ScreenScale
+        x := 270
+        y := 4
 
         clicked := false
 
@@ -312,9 +313,9 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 if clicked {
-                    screen.DrawImage(buttons[1], &options)
+                    scale.DrawScaled(screen, buttons[1], &options)
                 } else {
-                    screen.DrawImage(buttons[0], &options)
+                    scale.DrawScaled(screen, buttons[0], &options)
                 }
             },
         }
@@ -325,7 +326,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
     // cancel button at bottom
     cancel, _ := game.ImageCache.GetImages("main.lbx", 41)
     cancelIndex := 0
-    cancelRect := util.ImageRect(263 * data.ScreenScale, 182 * data.ScreenScale, cancel[0])
+    cancelRect := util.ImageRect(263, 182, cancel[0])
     ui.AddElement(&uilib.UIElement{
         Rect: cancelRect,
         LeftClick: func(element *uilib.UIElement){
@@ -338,7 +339,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancel[cancelIndex], &options)
+            scale.DrawScaled(screen, cancel[cancelIndex], &options)
         },
     })
 
@@ -348,11 +349,11 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
         overworld.DrawOverworld(screen, ebiten.GeoM{})
 
         var miniGeom ebiten.GeoM
-        miniGeom.Translate(float64(250 * data.ScreenScale), float64(20 * data.ScreenScale))
+        miniGeom.Translate(float64(250), float64(20))
         mx, my := miniGeom.Apply(0, 0)
-        miniWidth := 60 * data.ScreenScale
-        miniHeight := 31 * data.ScreenScale
-        mini := screen.SubImage(image.Rect(int(mx), int(my), int(mx) + miniWidth, int(my) + miniHeight)).(*ebiten.Image)
+        miniWidth := 60
+        miniHeight := 31
+        mini := screen.SubImage(scale.ScaleRect(image.Rect(int(mx), int(my), int(mx) + miniWidth, int(my) + miniHeight))).(*ebiten.Image)
         overworld.DrawMinimap(mini)
 
         ui.Draw(ui, screen)
@@ -401,7 +402,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                     resources.GoldBonus = game.CityGoldBonus(newX, newY, game.Plane)
                 }
 
-                cityInfoText = fonts.YellowFont.CreateWrappedText(float64(cancelBackground.Bounds().Dx() - 9 * data.ScreenScale), float64(data.ScreenScale), text)
+                cityInfoText = fonts.YellowFont.CreateWrappedText(float64(cancelBackground.Bounds().Dx() - 9), 1, text)
             }
         } else {
             cityInfoText.Clear()

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -240,7 +240,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
                         y = float64(170) - float64(fonts.WhiteFont.Height()) * 3 - cityInfoText.TotalHeight
                     }
 
-                    fonts.YellowFont.RenderWrapped(screen, float64(245), y, cityInfoText, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount})
+                    fonts.YellowFont.RenderWrapped(screen, float64(245), y, cityInfoText, font.FontOptions{Scale: scale.ScaleAmount})
                     y += cityInfoText.TotalHeight
 
                     if resources.Enabled {

--- a/game/magic/game/vault.go
+++ b/game/magic/game/vault.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/magicview"
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
     "github.com/kazzmir/master-of-magic/game/magic/fonts"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     helplib "github.com/kazzmir/master-of-magic/game/magic/help"
@@ -36,7 +37,7 @@ func (game *Game) showItemPopup(item *artifact.Artifact, cache *lbx.LbxCache, im
     drawer := func (screen *ebiten.Image){
         var options ebiten.DrawImageOptions
         options.ColorScale.ScaleAlpha(getAlpha())
-        options.GeoM.Translate(float64(48 * data.ScreenScale), float64(48 * data.ScreenScale))
+        options.GeoM.Translate(float64(48), float64(48))
         artifact.RenderArtifactBox(screen, imageCache, *item, counter / 8, vaultFonts.ItemName, vaultFonts.PowerFont, options)
     }
 
@@ -107,11 +108,11 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
             background, _ := imageCache.GetImage("armylist.lbx", 5, 0)
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(data.ScreenWidth / 2 - background.Bounds().Dx() / 2), 2)
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
-            fontOptions := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}
-            fonts.ResourceFont.PrintOptions(screen, float64(190 * data.ScreenScale), float64(166 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fontOptions, fmt.Sprintf("%v GP", player.Gold))
-            fonts.ResourceFont.PrintOptions(screen, float64(233 * data.ScreenScale), float64(166 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fontOptions, fmt.Sprintf("%v MP", player.Mana))
+            fontOptions := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Options: &options, Scale: scale.ScaleAmount}
+            fonts.ResourceFont.PrintOptions2(screen, 190, 166, fontOptions, fmt.Sprintf("%v GP", player.Gold))
+            fonts.ResourceFont.PrintOptions2(screen, 233, 166, fontOptions, fmt.Sprintf("%v MP", player.Mana))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -132,10 +133,10 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
 
     // the 4 equipment slots
     makeEquipmentSlot := func(index int) *uilib.UIElement{
-        width := 20 * data.ScreenScale
-        height := 17 * data.ScreenScale
-        x1 := 72 * data.ScreenScale + index * width
-        y1 := 173 * data.ScreenScale
+        width := 20
+        height := 17
+        x1 := 72 + index * width
+        y1 := 173
         rect := image.Rect(x1, y1, x1 + width, y1 + height)
 
         return &uilib.UIElement{
@@ -158,7 +159,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
                     // util.DrawRect(screen, rect, color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff})
 
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(73 + index * 20) * float64(data.ScreenScale), float64(173 * data.ScreenScale))
+                    options.GeoM.Translate(float64(73 + index * 20), float64(173))
                     /*
                     equipmentImage, _ := imageCache.GetImage("items.lbx", player.VaultEquipment[index].Image, 0)
                     screen.DrawImage(equipmentImage, &options)
@@ -175,7 +176,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
 
     // blacksmith anvil
     ui.AddElement(func () *uilib.UIElement {
-        rect := image.Rect(26 * data.ScreenScale, 158 * data.ScreenScale, 65 * data.ScreenScale, 190 * data.ScreenScale)
+        rect := image.Rect(26, 158, 65, 190)
         return &uilib.UIElement{
             Rect: rect,
             PlaySoundLeftClick: true,
@@ -214,8 +215,8 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
     makeHero := func(index int, hero *herolib.Hero) []*uilib.UIElement {
         // 3 on left, 3 on right
 
-        x1 := (34 + (index % 2) * 135) * data.ScreenScale
-        y1 := (16 + (index / 2) * 46) * data.ScreenScale
+        x1 := (34 + (index % 2) * 135)
+        y1 := (16 + (index / 2) * 46)
 
         portraitLbx, portraitIndex := hero.GetPortraitLbxInfo()
         profile, _ := imageCache.GetImage(portraitLbx, portraitIndex, 0)
@@ -242,17 +243,17 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
                 ui.AddGroup(unitview.MakeUnitContextMenu(game.Cache, ui, hero, disband))
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                screen.DrawImage(profile, &options)
-                screen.DrawImage(frame, &options)
+                scale.DrawScaled(screen, profile, &options)
+                scale.DrawScaled(screen, frame, &options)
             },
         })
 
         for slotIndex, slot := range hero.GetArtifactSlots() {
             slotOptions := options
             slotOptions.GeoM = baseGeom
-            slotOptions.GeoM.Translate(float64(profile.Bounds().Dx() + 8 * data.ScreenScale), float64(14 * data.ScreenScale))
+            slotOptions.GeoM.Translate(float64(profile.Bounds().Dx() + 8), float64(14))
             pic, _ := imageCache.GetImage("itemisc.lbx", slot.ImageIndex(), 0)
-            slotOptions.GeoM.Translate(float64((pic.Bounds().Dx() + 11 * data.ScreenScale) * slotIndex), 0)
+            slotOptions.GeoM.Translate(float64((pic.Bounds().Dx() + 11) * slotIndex), 0)
 
             x, y := slotOptions.GeoM.Apply(0, 0)
             rect := util.ImageRect(int(x), int(y), pic)
@@ -283,7 +284,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
                         */
                         artifact.RenderArtifactImage(screen, &imageCache, *hero.Equipment[slotIndex], ui.Counter / 8, slotOptions)
                     } else {
-                        screen.DrawImage(pic, &slotOptions)
+                        scale.DrawScaled(screen, pic, &slotOptions)
                     }
                 },
             })
@@ -303,7 +304,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
     ui.AddElement(func () *uilib.UIElement {
         okImages, _ := imageCache.GetImages("armylist.lbx", 8)
         index := 0
-        rect := util.ImageRect(237 * data.ScreenScale, 177 * data.ScreenScale, okImages[index])
+        rect := util.ImageRect(237, 177, okImages[index])
         return &uilib.UIElement{
             Rect: rect,
             PlaySoundLeftClick: true,
@@ -325,7 +326,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
                 if selectedItem != nil {
                     options.ColorScale.SetR(2)
                 }
-                screen.DrawImage(okImages[index], &options)
+                scale.DrawScaled(screen, okImages[index], &options)
             },
         }
     }())
@@ -333,7 +334,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
     ui.AddElement(func () *uilib.UIElement {
         images, _ := imageCache.GetImages("armylist.lbx", 7)
         index := 0
-        rect := util.ImageRect(237 * data.ScreenScale, 157 * data.ScreenScale, images[index])
+        rect := util.ImageRect(237, 157, images[index])
         return &uilib.UIElement{
             Rect: rect,
             PlaySoundLeftClick: true,
@@ -348,7 +349,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
-                screen.DrawImage(images[index], &options)
+                scale.DrawScaled(screen, images[index], &options)
             },
         }
     }())

--- a/game/magic/game/vault.go
+++ b/game/magic/game/vault.go
@@ -111,8 +111,8 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
             scale.DrawScaled(screen, background, &options)
 
             fontOptions := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Options: &options, Scale: scale.ScaleAmount}
-            fonts.ResourceFont.PrintOptions2(screen, 190, 166, fontOptions, fmt.Sprintf("%v GP", player.Gold))
-            fonts.ResourceFont.PrintOptions2(screen, 233, 166, fontOptions, fmt.Sprintf("%v MP", player.Mana))
+            fonts.ResourceFont.PrintOptions(screen, 190, 166, fontOptions, fmt.Sprintf("%v GP", player.Gold))
+            fonts.ResourceFont.PrintOptions(screen, 233, 166, fontOptions, fmt.Sprintf("%v MP", player.Mana))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {

--- a/game/magic/intro/intro.go
+++ b/game/magic/intro/intro.go
@@ -6,6 +6,7 @@ import (
 
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/audio"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/lib/lbx"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -164,6 +165,6 @@ func (intro *Intro) Draw(screen *ebiten.Image){
 
     if intro.Scene.Frame() != nil {
         var options ebiten.DrawImageOptions
-        screen.DrawImage(intro.Scene.Frame(), &options)
+        scale.DrawScaled(screen, intro.Scene.Frame(), &options)
     }
 }

--- a/game/magic/magicview/view.go
+++ b/game/magic/magicview/view.go
@@ -171,11 +171,11 @@ func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib
             leftSide := float64(122)
             rightSide := float64(224)
             if isRight {
-                smallFont.PrintOptions2(screen, leftSide, float64(86), fontOptions, fmt.Sprintf("%v GP", int(float64(totalMana) * changePercent * alchemyConversion)))
-                smallFont.PrintOptions2(screen, rightSide, float64(86), fontOptions, fmt.Sprintf("%v PP", int(float64(totalMana) * changePercent)))
+                smallFont.PrintOptions(screen, leftSide, float64(86), fontOptions, fmt.Sprintf("%v GP", int(float64(totalMana) * changePercent * alchemyConversion)))
+                smallFont.PrintOptions(screen, rightSide, float64(86), fontOptions, fmt.Sprintf("%v PP", int(float64(totalMana) * changePercent)))
             } else {
-                smallFont.PrintOptions2(screen, leftSide, float64(86), fontOptions, fmt.Sprintf("%v GP", int(float64(totalGold) * changePercent)))
-                smallFont.PrintOptions2(screen, rightSide, float64(86), fontOptions, fmt.Sprintf("%v PP", int(float64(totalGold) * changePercent * alchemyConversion)))
+                smallFont.PrintOptions(screen, leftSide, float64(86), fontOptions, fmt.Sprintf("%v GP", int(float64(totalGold) * changePercent)))
+                smallFont.PrintOptions(screen, rightSide, float64(86), fontOptions, fmt.Sprintf("%v PP", int(float64(totalGold) * changePercent * alchemyConversion)))
             }
         },
     })
@@ -343,9 +343,9 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             research := int(math.Round(player.PowerDistribution.Research * float64(magic.Power)))
             skill := magic.Power - (mana + research)
 
-            fonts.NormalFont.PrintOptions2(screen, float64(56), float64(160), rightShadow, fmt.Sprintf("%v MP", mana))
-            fonts.NormalFont.PrintOptions2(screen, float64(103), float64(160), rightShadow, fmt.Sprintf("%v RP", research))
-            fonts.NormalFont.PrintOptions2(screen, float64(151), float64(160), rightShadow, fmt.Sprintf("%v SP", skill))
+            fonts.NormalFont.PrintOptions(screen, float64(56), float64(160), rightShadow, fmt.Sprintf("%v MP", mana))
+            fonts.NormalFont.PrintOptions(screen, float64(103), float64(160), rightShadow, fmt.Sprintf("%v RP", research))
+            fonts.NormalFont.PrintOptions(screen, float64(151), float64(160), rightShadow, fmt.Sprintf("%v SP", skill))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -434,7 +434,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                             if text == "" {
                                 text = "None"
                             }
-                            fonts.SpellFont.PrintOptions2(screen, float64((position.X + 21)), float64(position.Y), centerShadow, text)
+                            fonts.SpellFont.PrintOptions(screen, float64((position.X + 21)), float64(position.Y), centerShadow, text)
                         }
                     }
                 } else {
@@ -772,9 +772,9 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             // vector.StrokeRect(screen, float32(spellCastUIRect.Min.X), float32(spellCastUIRect.Min.Y), float32(spellCastUIRect.Dx()), float32(spellCastUIRect.Dy()), 1, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff}, false)
 
-            fonts.SmallerFont.PrintOptions2(screen, float64(5), float64(176), leftShadow, fmt.Sprintf("Casting Skill: %v(%v)", overworldCastingSkill, castingSkill))
-            fonts.SmallerFont.PrintOptions2(screen, float64(5), float64(183), leftShadow, fmt.Sprintf("Magic Reserve: %v", player.Mana))
-            fonts.SmallerFont.PrintOptions2(screen, float64(5), float64(190), leftShadow, fmt.Sprintf("Power Base: %v", magic.Power))
+            fonts.SmallerFont.PrintOptions(screen, float64(5), float64(176), leftShadow, fmt.Sprintf("Casting Skill: %v(%v)", overworldCastingSkill, castingSkill))
+            fonts.SmallerFont.PrintOptions(screen, float64(5), float64(183), leftShadow, fmt.Sprintf("Magic Reserve: %v", player.Mana))
+            fonts.SmallerFont.PrintOptions(screen, float64(5), float64(190), leftShadow, fmt.Sprintf("Power Base: %v", magic.Power))
         },
     })
 
@@ -789,8 +789,8 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         },
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             // util.DrawRect(screen, castingRect, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff})
-            fonts.SmallerFont.PrintOptions2(screen, float64(100), float64(176), leftShadow, fmt.Sprintf("Casting: %v", player.CastingSpell.Name))
-            fonts.SmallerFont.PrintOptions2(screen, float64(100), float64(183), leftShadow, fmt.Sprintf("Researching: %v", player.ResearchingSpell.Name))
+            fonts.SmallerFont.PrintOptions(screen, float64(100), float64(176), leftShadow, fmt.Sprintf("Casting: %v", player.CastingSpell.Name))
+            fonts.SmallerFont.PrintOptions(screen, float64(100), float64(183), leftShadow, fmt.Sprintf("Researching: %v", player.ResearchingSpell.Name))
 
             summonCity := player.FindSummoningCity()
             if summonCity == nil {
@@ -799,7 +799,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                 }
             }
 
-            fonts.SmallerFont.PrintOptions2(screen, float64(100), float64(190), leftShadow, fmt.Sprintf("Summon To: %v", summonCity.Name))
+            fonts.SmallerFont.PrintOptions(screen, float64(100), float64(190), leftShadow, fmt.Sprintf("Summon To: %v", summonCity.Name))
         },
     })
 
@@ -855,7 +855,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             globalEnchantments = append(globalEnchantments, &uilib.UIElement{
                 Rect: rect,
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                    useFont.PrintOptions2(screen, float64(rect.Min.X), float64(rect.Min.Y), leftShadow, name)
+                    useFont.PrintOptions(screen, float64(rect.Min.X), float64(rect.Min.Y), leftShadow, name)
                 },
                 LeftClick: func(element *uilib.UIElement){
                     // can only cancel the player's enchantments

--- a/game/magic/magicview/view.go
+++ b/game/magic/magicview/view.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/mirror"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -64,10 +65,10 @@ func MakeMagicScreen(cache *lbx.LbxCache, player *playerlib.Player, enemies []*p
 func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib.Player, help *helplib.Help, cache *lbx.LbxCache, imageCache *util.ImageCache) *uilib.UIElementGroup {
     group := uilib.MakeGroup()
 
-    fontOptions := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}
+    fontOptions := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}
 
     ok, _ := imageCache.GetImages("magic.lbx", 54)
-    okRect := util.ImageRect(176 * data.ScreenScale, 99 * data.ScreenScale, ok[0])
+    okRect := util.ImageRect(176, 99, ok[0])
     okIndex := 0
 
     arrowRight, _ := imageCache.GetImage("magic.lbx", 55, 0)
@@ -76,10 +77,10 @@ func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib
     // if true, then convert power to gold, otherwise convert gold to power
     isRight := true
 
-    arrowRect := util.ImageRect(146 * data.ScreenScale, 99 * data.ScreenScale, arrowRight)
+    arrowRect := util.ImageRect(146, 99, arrowRight)
 
     cancel, _ := imageCache.GetImages("magic.lbx", 53)
-    cancelRect := util.ImageRect(93 * data.ScreenScale, 99 * data.ScreenScale, cancel[0])
+    cancelRect := util.ImageRect(93, 99, cancel[0])
     cancelIndex := 0
 
     powerToGold, _ := imageCache.GetImage("magic.lbx", 59, 0)
@@ -103,85 +104,85 @@ func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := imageCache.GetImage("magic.lbx", 52, 0)
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(75 * data.ScreenScale), float64(60 * data.ScreenScale))
-            screen.DrawImage(background, &options)
+            options.GeoM.Translate(75, 60)
+            scale.DrawScaled(screen, background, &options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(okRect.Min.X), float64(okRect.Min.Y))
-            screen.DrawImage(ok[okIndex], &options)
+            scale.DrawScaled(screen, ok[okIndex], &options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(arrowRect.Min.X), float64(arrowRect.Min.Y))
 
             flip := false
             if isRight {
-                screen.DrawImage(arrowRight, &options)
+                scale.DrawScaled(screen, arrowRight, &options)
 
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(87 * data.ScreenScale), float64(70 * data.ScreenScale))
-                screen.DrawImage(powerToGold, &options)
+                options.GeoM.Translate(87, 70)
+                scale.DrawScaled(screen, powerToGold, &options)
 
                 flip = true
             } else {
-                screen.DrawImage(arrowLeft, &options)
+                scale.DrawScaled(screen, arrowLeft, &options)
             }
 
             // the conveyor belt should only be drawn until the position of the cursor
-            conveyorArea := screen.SubImage(image.Rect(131 * data.ScreenScale, 85 * data.ScreenScale, 131 * data.ScreenScale + cursorPosition, (85 + 7) * data.ScreenScale)).(*ebiten.Image)
+            conveyorArea := screen.SubImage(scale.ScaleRect(image.Rect(131, 85, 131 + cursorPosition, (85 + 7)))).(*ebiten.Image)
 
             // draw an animated conveyor belt by drawing the same image twice with a slight offset
             movement := int((ui.Counter / 6) % 8)
             if flip {
                 options.GeoM.Reset()
                 options.GeoM.Scale(-1, 1)
-                options.GeoM.Translate(float64(131 * data.ScreenScale), float64(85 * data.ScreenScale))
+                options.GeoM.Translate(float64(131), float64(85))
                 options.GeoM.Translate(float64(cursorPosition + conveyor.Bounds().Dx()), 0)
-                options.GeoM.Translate(float64(-movement * data.ScreenScale), 0)
-                conveyorArea.DrawImage(conveyor, &options)
+                options.GeoM.Translate(float64(-movement), 0)
+                scale.DrawScaled(conveyorArea, conveyor, &options)
 
                 options.GeoM.Reset()
                 options.GeoM.Scale(-1, 1)
-                options.GeoM.Translate(float64(131 * data.ScreenScale), float64(85 * data.ScreenScale))
+                options.GeoM.Translate(float64(131), float64(85))
                 options.GeoM.Translate(float64(cursorPosition), 0)
-                options.GeoM.Translate(float64(-movement * data.ScreenScale), 0)
-                conveyorArea.DrawImage(conveyor, &options)
+                options.GeoM.Translate(float64(-movement), 0)
+                scale.DrawScaled(conveyorArea, conveyor, &options)
             } else {
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(131 * data.ScreenScale), float64(85 * data.ScreenScale))
+                options.GeoM.Translate(float64(131), float64(85))
                 options.GeoM.Translate(float64(-conveyor.Bounds().Dx()), 0)
-                options.GeoM.Translate(float64(movement * data.ScreenScale), 0)
-                conveyorArea.DrawImage(conveyor, &options)
+                options.GeoM.Translate(float64(movement), 0)
+                scale.DrawScaled(conveyorArea, conveyor, &options)
 
                 options.GeoM.Reset()
-                options.GeoM.Translate(float64(131 * data.ScreenScale), float64(85 * data.ScreenScale))
-                options.GeoM.Translate(float64(movement * data.ScreenScale), 0)
-                conveyorArea.DrawImage(conveyor, &options)
+                options.GeoM.Translate(float64(131), float64(85))
+                options.GeoM.Translate(float64(movement), 0)
+                scale.DrawScaled(conveyorArea, conveyor, &options)
             }
 
             // draw the cursor itself
             options.GeoM.Reset()
-            options.GeoM.Translate(float64((131 - 3) * data.ScreenScale) + float64(cursorPosition), float64(85 * data.ScreenScale))
-            screen.DrawImage(cursor, &options)
+            options.GeoM.Translate(float64((131 - 3)) + float64(cursorPosition), float64(85))
+            scale.DrawScaled(screen, cursor, &options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(cancelRect.Min.X), float64(cancelRect.Min.Y))
-            screen.DrawImage(cancel[cancelIndex], &options)
+            scale.DrawScaled(screen, cancel[cancelIndex], &options)
 
-            leftSide := float64(122 * data.ScreenScale)
-            rightSide := float64(224 * data.ScreenScale)
+            leftSide := float64(122)
+            rightSide := float64(224)
             if isRight {
-                smallFont.PrintOptions(screen, leftSide, float64(86 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fontOptions, fmt.Sprintf("%v GP", int(float64(totalMana) * changePercent * alchemyConversion)))
-                smallFont.PrintOptions(screen, rightSide, float64(86 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fontOptions, fmt.Sprintf("%v PP", int(float64(totalMana) * changePercent)))
+                smallFont.PrintOptions2(screen, leftSide, float64(86), fontOptions, fmt.Sprintf("%v GP", int(float64(totalMana) * changePercent * alchemyConversion)))
+                smallFont.PrintOptions2(screen, rightSide, float64(86), fontOptions, fmt.Sprintf("%v PP", int(float64(totalMana) * changePercent)))
             } else {
-                smallFont.PrintOptions(screen, leftSide, float64(86 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fontOptions, fmt.Sprintf("%v GP", int(float64(totalGold) * changePercent)))
-                smallFont.PrintOptions(screen, rightSide, float64(86 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, fontOptions, fmt.Sprintf("%v PP", int(float64(totalGold) * changePercent * alchemyConversion)))
+                smallFont.PrintOptions2(screen, leftSide, float64(86), fontOptions, fmt.Sprintf("%v GP", int(float64(totalGold) * changePercent)))
+                smallFont.PrintOptions2(screen, rightSide, float64(86), fontOptions, fmt.Sprintf("%v PP", int(float64(totalGold) * changePercent * alchemyConversion)))
             }
         },
     })
 
     {
         posX := 0
-        conveyorRect := image.Rect(131 * data.ScreenScale, 85 * data.ScreenScale, (131 + 56) * data.ScreenScale, (85 + 7) * data.ScreenScale)
+        conveyorRect := image.Rect(131, 85, (131 + 56), (85 + 7))
         group.AddElement(&uilib.UIElement{
             Rect: conveyorRect,
             Layer: 1,
@@ -206,7 +207,7 @@ func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib
     }
 
     group.AddElement(&uilib.UIElement{
-        Rect: image.Rect(94 * data.ScreenScale, 85 * data.ScreenScale, 123 * data.ScreenScale, 92 * data.ScreenScale),
+        Rect: image.Rect(94, 85, 123, 92),
         Layer: 1,
         RightClick: func(element *uilib.UIElement){
             helpEntries := help.GetEntriesByName("Alchemy Gold")
@@ -217,7 +218,7 @@ func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib
     })
 
     group.AddElement(&uilib.UIElement{
-        Rect: image.Rect(195 * data.ScreenScale, 85 * data.ScreenScale, 225 * data.ScreenScale, 92 * data.ScreenScale),
+        Rect: image.Rect(195, 85, 225, 92),
         Layer: 1,
         RightClick: func(element *uilib.UIElement){
             helpEntries := help.GetEntriesByName("Alchemy Power")
@@ -315,9 +316,9 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
     knownPlayers := player.GetKnownPlayers()
 
     fonts := fontslib.MakeMagicViewFonts(magic.Cache)
-    leftShadow := font.FontOptions{Justify: font.FontJustifyLeft, DropShadow: true}
-    centerShadow := font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true}
-    rightShadow := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true}
+    leftShadow := font.FontOptions{Justify: font.FontJustifyLeft, DropShadow: true, Scale: scale.ScaleAmount}
+    centerShadow := font.FontOptions{Justify: font.FontJustifyCenter, DropShadow: true, Scale: scale.ScaleAmount}
+    rightShadow := font.FontOptions{Justify: font.FontJustifyRight, DropShadow: true, Scale: scale.ScaleAmount}
 
     helpLbx, err := magic.Cache.GetLbxFile("help.lbx")
     if err != nil {
@@ -335,16 +336,16 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             background, err := magic.ImageCache.GetImage("magic.lbx", 0, 0)
             if err == nil {
                 var options ebiten.DrawImageOptions
-                screen.DrawImage(background, &options)
+                scale.DrawScaled(screen, background, &options)
             }
 
             mana := int(math.Round(player.PowerDistribution.Mana * float64(magic.Power)))
             research := int(math.Round(player.PowerDistribution.Research * float64(magic.Power)))
             skill := magic.Power - (mana + research)
 
-            fonts.NormalFont.PrintOptions(screen, float64(56 * data.ScreenScale), float64(160 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, rightShadow, fmt.Sprintf("%v MP", mana))
-            fonts.NormalFont.PrintOptions(screen, float64(103 * data.ScreenScale), float64(160 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, rightShadow, fmt.Sprintf("%v RP", research))
-            fonts.NormalFont.PrintOptions(screen, float64(151 * data.ScreenScale), float64(160 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, rightShadow, fmt.Sprintf("%v SP", skill))
+            fonts.NormalFont.PrintOptions2(screen, float64(56), float64(160), rightShadow, fmt.Sprintf("%v MP", mana))
+            fonts.NormalFont.PrintOptions2(screen, float64(103), float64(160), rightShadow, fmt.Sprintf("%v RP", research))
+            fonts.NormalFont.PrintOptions2(screen, float64(151), float64(160), rightShadow, fmt.Sprintf("%v SP", skill))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -398,7 +399,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         gemDefeated, _ := magic.ImageCache.GetImage("magic.lbx", 51, 0)
         gemUnknown, _ := magic.ImageCache.GetImage("magic.lbx", 6, 0)
         position := gemPositions[i]
-        rect := util.ImageRect(position.X * data.ScreenScale, position.Y * data.ScreenScale, gemUnknown)
+        rect := util.ImageRect(position.X, position.Y, gemUnknown)
         group.AddElement(&uilib.UIElement{
             Rect: rect,
             LeftClick: func(element *uilib.UIElement){
@@ -421,23 +422,23 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                     enemy := knownPlayers[i]
 
                     if enemy.Defeated {
-                        screen.DrawImage(gemDefeated, &options)
+                        scale.DrawScaled(screen, gemDefeated, &options)
                     } else {
                         portraitIndex := mirror.GetWizardPortraitIndex(enemy.Wizard.Base, enemy.Wizard.Banner)
                         portrait, _ := magic.ImageCache.GetImage("lilwiz.lbx", portraitIndex, 0)
                         if portrait != nil {
-                            screen.DrawImage(portrait, &options)
+                            scale.DrawScaled(screen, portrait, &options)
                         }
                         if player.GlobalEnchantments.Contains(data.EnchantmentDetectMagic) {
                             text := enemy.CastingSpell.Name
                             if text == "" {
                                 text = "None"
                             }
-                            fonts.SpellFont.PrintOptions(screen, float64((position.X + 21) * data.ScreenScale), float64(position.Y * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, centerShadow, text)
+                            fonts.SpellFont.PrintOptions2(screen, float64((position.X + 21)), float64(position.Y), centerShadow, text)
                         }
                     }
                 } else {
-                    screen.DrawImage(gemUnknown, &options)
+                    scale.DrawScaled(screen, gemUnknown, &options)
                 }
             },
         })
@@ -445,9 +446,9 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         if i < len(knownPlayers) {
             enemy := knownPlayers[i]
             if !enemy.Defeated {
-                positionStart := gemPositions[i].Mul(data.ScreenScale)
-                positionStart.X += gemUnknown.Bounds().Dx() + 2 * data.ScreenScale
-                positionStart.Y -= 2 * data.ScreenScale
+                positionStart := gemPositions[i]
+                positionStart.X += gemUnknown.Bounds().Dx() + 2
+                positionStart.Y -= 2
                 for otherPlayer, relationship := range enemy.PlayerRelations {
                     treatyIcon := getTreatyIcon(otherPlayer, relationship.Treaty)
                     if treatyIcon != nil {
@@ -464,11 +465,11 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                                 var options ebiten.DrawImageOptions
                                 options.GeoM.Translate(float64(element.Rect.Min.X), float64(element.Rect.Min.Y))
-                                screen.DrawImage(treatyIcon, &options)
+                                scale.DrawScaled(screen, treatyIcon, &options)
                             },
                         })
 
-                        positionStart.Y += treatyIcon.Bounds().Dy() + 1 * data.ScreenScale
+                        positionStart.Y += treatyIcon.Bounds().Dy() + 1
                     }
                 }
             }
@@ -529,7 +530,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
     manaLocked, err := magic.ImageCache.GetImage("magic.lbx", 15, 0)
     if err == nil {
         group.AddElement(&uilib.UIElement{
-            Rect: image.Rect(27 * data.ScreenScale, 81 * data.ScreenScale, 27 * data.ScreenScale + manaLocked.Bounds().Dx(), 81 * data.ScreenScale + manaLocked.Bounds().Dy() - 2 * data.ScreenScale),
+            Rect: image.Rect(27, 81, 27 + manaLocked.Bounds().Dx(), 81 + manaLocked.Bounds().Dy() - 2),
             RightClick: func(element *uilib.UIElement){
                 helpEntries := help.GetEntriesByName("Mana Points Ratio")
                 if helpEntries != nil {
@@ -546,7 +547,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
 
         posY := 0
         manaPowerStaff, _ := magic.ImageCache.GetImage("magic.lbx", 8, 0)
-        staffRect := image.Rect(33 * data.ScreenScale, 102 * data.ScreenScale, 38 * data.ScreenScale, 102 * data.ScreenScale + manaPowerStaff.Bounds().Dy())
+        staffRect := image.Rect(33, 102, 38, 102 + manaPowerStaff.Bounds().Dy())
 
         group.AddElement(&uilib.UIElement{
             Rect: staffRect,
@@ -569,28 +570,28 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
-                options.GeoM.Translate(float64(29 * data.ScreenScale), float64(83 * data.ScreenScale))
-                screen.DrawImage(manaStaff, &options)
+                options.GeoM.Translate(float64(29), float64(83))
+                scale.DrawScaled(screen, manaStaff, &options)
 
                 if player.PowerDistribution.Mana > 0 {
                     length := manaPowerStaff.Bounds().Dy() - int(float64(manaPowerStaff.Bounds().Dy()) * player.PowerDistribution.Mana)
                     part := manaPowerStaff.SubImage(image.Rect(0, length, manaPowerStaff.Bounds().Dx(), manaPowerStaff.Bounds().Dy())).(*ebiten.Image)
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(32 * data.ScreenScale), float64(staffRect.Min.Y + length))
-                    screen.DrawImage(part, &options)
+                    options.GeoM.Translate(float64(32), float64(staffRect.Min.Y + length))
+                    scale.DrawScaled(screen, part, &options)
                 }
 
                 if magic.ManaLocked {
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(27 * data.ScreenScale), float64(81 * data.ScreenScale))
-                    screen.DrawImage(manaLocked, &options)
+                    options.GeoM.Translate(float64(27), float64(81))
+                    scale.DrawScaled(screen, manaLocked, &options)
                 }
             },
         })
     }
 
     // transmute button
-    transmuteRect := image.Rect(235 * data.ScreenScale, 185 * data.ScreenScale, 290 * data.ScreenScale, 195 * data.ScreenScale)
+    transmuteRect := image.Rect(235, 185, 290, 195)
     group.AddElement(&uilib.UIElement{
         Rect: transmuteRect,
         PlaySoundLeftClick: true,
@@ -610,7 +611,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
     })
 
     // ok button
-    okRect := image.Rect(296 * data.ScreenScale, 185 * data.ScreenScale, 316 * data.ScreenScale, 195 * data.ScreenScale)
+    okRect := image.Rect(296, 185, 316, 195)
     group.AddElement(&uilib.UIElement{
         Rect: okRect,
         PlaySoundLeftClick: true,
@@ -633,7 +634,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         researchStaff, _ := magic.ImageCache.GetImage("magic.lbx", 9, 0)
 
         group.AddElement(&uilib.UIElement{
-            Rect: image.Rect(74 * data.ScreenScale, 81 * data.ScreenScale, 74 * data.ScreenScale + researchLocked.Bounds().Dx(), 81 * data.ScreenScale + researchLocked.Bounds().Dy() - 2 * data.ScreenScale),
+            Rect: image.Rect(74, 81, 74 + researchLocked.Bounds().Dx(), 81 + researchLocked.Bounds().Dy() - 2),
             PlaySoundLeftClick: true,
             LeftClick: func(element *uilib.UIElement){
                 magic.ResearchLocked = !magic.ResearchLocked
@@ -648,7 +649,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
 
         researchPowerStaff, _ := magic.ImageCache.GetImage("magic.lbx", 10, 0)
         posY := 0
-        staffRect := image.Rect(79 * data.ScreenScale, 102 * data.ScreenScale, 86 * data.ScreenScale, 102 * data.ScreenScale + researchPowerStaff.Bounds().Dy())
+        staffRect := image.Rect(79, 102, 86, 102 + researchPowerStaff.Bounds().Dy())
 
         group.AddElement(&uilib.UIElement{
             Rect: staffRect,
@@ -671,21 +672,21 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
-                options.GeoM.Translate(float64(75 * data.ScreenScale), float64(85 * data.ScreenScale))
-                screen.DrawImage(researchStaff, &options)
+                options.GeoM.Translate(float64(75), float64(85))
+                scale.DrawScaled(screen, researchStaff, &options)
 
                 if player.PowerDistribution.Research > 0 {
                     length := researchPowerStaff.Bounds().Dy() - int(float64(researchPowerStaff.Bounds().Dy()) * player.PowerDistribution.Research)
                     part := researchPowerStaff.SubImage(image.Rect(0, length, researchPowerStaff.Bounds().Dx(), researchPowerStaff.Bounds().Dy())).(*ebiten.Image)
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(staffRect.Min.X), float64(staffRect.Min.Y + length))
-                    screen.DrawImage(part, &options)
+                    scale.DrawScaled(screen, part, &options)
                 }
 
                 if magic.ResearchLocked {
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(74 * data.ScreenScale), float64(81 * data.ScreenScale))
-                    screen.DrawImage(researchLocked, &options)
+                    options.GeoM.Translate(float64(74), float64(81))
+                    scale.DrawScaled(screen, researchLocked, &options)
                 }
 
             },
@@ -695,7 +696,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
     skillLocked, err := magic.ImageCache.GetImage("magic.lbx", 17, 0)
     if err == nil {
         group.AddElement(&uilib.UIElement{
-            Rect: image.Rect(121 * data.ScreenScale, 81 * data.ScreenScale, 121 * data.ScreenScale + skillLocked.Bounds().Dx(), 81 * data.ScreenScale + skillLocked.Bounds().Dy() - 3 * data.ScreenScale),
+            Rect: image.Rect(121, 81, 121 + skillLocked.Bounds().Dx(), 81 + skillLocked.Bounds().Dy() - 3),
             PlaySoundLeftClick: true,
             LeftClick: func(element *uilib.UIElement){
                 magic.SkillLocked = !magic.SkillLocked
@@ -710,7 +711,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
 
         skillPowerStaff, _ := magic.ImageCache.GetImage("magic.lbx", 10, 0)
         posY := 0
-        staffRect := image.Rect(126 * data.ScreenScale, 102 * data.ScreenScale, 132 * data.ScreenScale, 102 * data.ScreenScale + skillPowerStaff.Bounds().Dy())
+        staffRect := image.Rect(126, 102, 132, 102 + skillPowerStaff.Bounds().Dy())
 
         group.AddElement(&uilib.UIElement{
             Rect: staffRect,
@@ -735,8 +736,8 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                 skillStaff, err := magic.ImageCache.GetImage("magic.lbx", 11, 0)
                 if err == nil {
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(122 * data.ScreenScale), float64(83 * data.ScreenScale))
-                    screen.DrawImage(skillStaff, &options)
+                    options.GeoM.Translate(float64(122), float64(83))
+                    scale.DrawScaled(screen, skillStaff, &options)
                 }
 
                 if player.PowerDistribution.Skill > 0 {
@@ -744,23 +745,22 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                     part := skillPowerStaff.SubImage(image.Rect(0, length, skillPowerStaff.Bounds().Dx(), skillPowerStaff.Bounds().Dy())).(*ebiten.Image)
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(staffRect.Min.X), float64(staffRect.Min.Y + length))
-                    screen.DrawImage(part, &options)
+                    scale.DrawScaled(screen, part, &options)
                 }
 
                 if magic.SkillLocked {
                     var options ebiten.DrawImageOptions
-                    options.GeoM.Translate(float64(121 * data.ScreenScale), float64(81 * data.ScreenScale))
-                    screen.DrawImage(skillLocked, &options)
+                    options.GeoM.Translate(float64(121), float64(81))
+                    scale.DrawScaled(screen, skillLocked, &options)
                 }
             },
         })
     }
 
-
     overworldCastingSkill := player.ComputeOverworldCastingSkill()
     castingSkill := player.ComputeCastingSkill()
 
-    spellCastUIRect := image.Rect(5 * data.ScreenScale, 175 * data.ScreenScale, 99 * data.ScreenScale, 196 * data.ScreenScale)
+    spellCastUIRect := image.Rect(5, 175, 99, 196)
     group.AddElement(&uilib.UIElement{
         Rect: spellCastUIRect,
         RightClick: func(element *uilib.UIElement){
@@ -772,13 +772,13 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             // vector.StrokeRect(screen, float32(spellCastUIRect.Min.X), float32(spellCastUIRect.Min.Y), float32(spellCastUIRect.Dx()), float32(spellCastUIRect.Dy()), 1, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff}, false)
 
-            fonts.SmallerFont.PrintOptions(screen, float64(5 * data.ScreenScale), float64(176 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, fmt.Sprintf("Casting Skill: %v(%v)", overworldCastingSkill, castingSkill))
-            fonts.SmallerFont.PrintOptions(screen, float64(5 * data.ScreenScale), float64(183 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, fmt.Sprintf("Magic Reserve: %v", player.Mana))
-            fonts.SmallerFont.PrintOptions(screen, float64(5 * data.ScreenScale), float64(190 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, fmt.Sprintf("Power Base: %v", magic.Power))
+            fonts.SmallerFont.PrintOptions2(screen, float64(5), float64(176), leftShadow, fmt.Sprintf("Casting Skill: %v(%v)", overworldCastingSkill, castingSkill))
+            fonts.SmallerFont.PrintOptions2(screen, float64(5), float64(183), leftShadow, fmt.Sprintf("Magic Reserve: %v", player.Mana))
+            fonts.SmallerFont.PrintOptions2(screen, float64(5), float64(190), leftShadow, fmt.Sprintf("Power Base: %v", magic.Power))
         },
     })
 
-    castingRect := image.Rect(100 * data.ScreenScale, 175 * data.ScreenScale, 220 * data.ScreenScale, 196 * data.ScreenScale)
+    castingRect := image.Rect(100, 175, 220, 196)
     group.AddElement(&uilib.UIElement{
         Rect: castingRect,
         RightClick: func(element *uilib.UIElement){
@@ -789,8 +789,8 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         },
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             // util.DrawRect(screen, castingRect, color.RGBA{R: 0xff, G: 0x0, B: 0x0, A: 0xff})
-            fonts.SmallerFont.PrintOptions(screen, float64(100 * data.ScreenScale), float64(176 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, fmt.Sprintf("Casting: %v", player.CastingSpell.Name))
-            fonts.SmallerFont.PrintOptions(screen, float64(100 * data.ScreenScale), float64(183 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, fmt.Sprintf("Researching: %v", player.ResearchingSpell.Name))
+            fonts.SmallerFont.PrintOptions2(screen, float64(100), float64(176), leftShadow, fmt.Sprintf("Casting: %v", player.CastingSpell.Name))
+            fonts.SmallerFont.PrintOptions2(screen, float64(100), float64(183), leftShadow, fmt.Sprintf("Researching: %v", player.ResearchingSpell.Name))
 
             summonCity := player.FindSummoningCity()
             if summonCity == nil {
@@ -799,7 +799,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
                 }
             }
 
-            fonts.SmallerFont.PrintOptions(screen, float64(100 * data.ScreenScale), float64(190 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, fmt.Sprintf("Summon To: %v", summonCity.Name))
+            fonts.SmallerFont.PrintOptions2(screen, float64(100), float64(190), leftShadow, fmt.Sprintf("Summon To: %v", summonCity.Name))
         },
     })
 
@@ -851,11 +851,11 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             }
 
             yStart := 80
-            rect := image.Rect(170 * data.ScreenScale, (yStart + i * useFont.Height()) * data.ScreenScale, 310 * data.ScreenScale, (yStart + (i + 1) * useFont.Height()) * data.ScreenScale)
+            rect := image.Rect(170, (yStart + i * useFont.Height()), 310, (yStart + (i + 1) * useFont.Height()))
             globalEnchantments = append(globalEnchantments, &uilib.UIElement{
                 Rect: rect,
                 Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-                    useFont.PrintOptions(screen, float64(rect.Min.X), float64(rect.Min.Y), float64(data.ScreenScale), ebiten.ColorScale{}, leftShadow, name)
+                    useFont.PrintOptions2(screen, float64(rect.Min.X), float64(rect.Min.Y), leftShadow, name)
                 },
                 LeftClick: func(element *uilib.UIElement){
                     // can only cancel the player's enchantments
@@ -888,7 +888,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
         }
 
         if len(globalEnchantments) == 0 {
-            enchantmentsRect := image.Rect(168 * data.ScreenScale, 67 * data.ScreenScale, 310 * data.ScreenScale, 172 * data.ScreenScale)
+            enchantmentsRect := image.Rect(168, 67, 310, 172)
             globalEnchantments = append(globalEnchantments, &uilib.UIElement{
                 Rect: enchantmentsRect,
                 RightClick: func(element *uilib.UIElement){

--- a/game/magic/magicview/view.go
+++ b/game/magic/magicview/view.go
@@ -131,7 +131,7 @@ func MakeTransmuteElements(ui *uilib.UI, smallFont *font.Font, player *playerlib
             conveyorArea := screen.SubImage(scale.ScaleRect(image.Rect(131, 85, 131 + cursorPosition, (85 + 7)))).(*ebiten.Image)
 
             // draw an animated conveyor belt by drawing the same image twice with a slight offset
-            movement := int((ui.Counter / 6) % 8)
+            movement := int((ui.Counter / 4) % 8)
             if flip {
                 options.GeoM.Reset()
                 options.GeoM.Scale(-1, 1)

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -18,6 +18,7 @@ import (
     musiclib "github.com/kazzmir/master-of-magic/game/magic/music"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/units"
@@ -33,12 +34,6 @@ import (
     "github.com/hajimehoshi/ebiten/v2/ebitenutil"
     "github.com/hajimehoshi/ebiten/v2/inpututil"
 )
-
-func stretchImage(screen *ebiten.Image, sprite *ebiten.Image){
-    var options ebiten.DrawImageOptions
-    options.GeoM.Scale(float64(data.ScreenWidth) / float64(sprite.Bounds().Dx()), float64(data.ScreenHeight) / float64(sprite.Bounds().Dy()))
-    screen.DrawImage(sprite, &options)
-}
 
 type DrawFunc func(*ebiten.Image)
 
@@ -451,7 +446,7 @@ func (game *MagicGame) Update() error {
 }
 
 func (game *MagicGame) Layout(outsideWidth int, outsideHeight int) (int, int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func (game *MagicGame) Draw(screen *ebiten.Image) {
@@ -473,7 +468,7 @@ func main() {
     flag.BoolVar(&startGame, "start", false, "start the game immediately with a random wizard")
     flag.Parse()
 
-    ebiten.SetWindowSize(data.ScreenWidth * 2, data.ScreenHeight * 2)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("magic")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
     ebiten.SetWindowClosingHandled(true)

--- a/game/magic/mainview/view.go
+++ b/game/magic/mainview/view.go
@@ -5,7 +5,7 @@ import (
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -51,13 +51,13 @@ func (main *MainScreen) MakeUI() *uilib.UI {
             top, err := main.ImageCache.GetImages("mainscrn.lbx", 0)
             if err == nil {
                 use := top[(main.Counter / 4) % uint64(len(top))]
-                screen.DrawImage(use, &options)
+                scale.DrawScaled(screen, use, &options)
                 options.GeoM.Translate(0, float64(use.Bounds().Dy()))
             }
 
             background, err := main.ImageCache.GetImage("mainscrn.lbx", 5, 0)
             if err == nil {
-                screen.DrawImage(background, &options)
+                scale.DrawScaled(screen, background, &options)
             }
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
@@ -74,7 +74,7 @@ func (main *MainScreen) MakeUI() *uilib.UI {
 
     makeButton := func(index int, x, y int, action func()) *uilib.UIElement {
         images, _ := main.ImageCache.GetImages("mainscrn.lbx", index)
-        rect := util.ImageRect(x * data.ScreenScale, y * data.ScreenScale, images[0])
+        rect := util.ImageRect(x, y, images[0])
         imageIndex := 1
         return &uilib.UIElement{
             Rect: rect,
@@ -91,7 +91,7 @@ func (main *MainScreen) MakeUI() *uilib.UI {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
                 options.ColorScale.ScaleAlpha(getAlpha())
-                screen.DrawImage(images[imageIndex], &options)
+                scale.DrawScaled(screen, images[imageIndex], &options)
             },
         }
     }

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -1316,7 +1316,7 @@ func (mapObject *Map) ResetCache() {
     mapObject.TileCache = make(map[int]*ebiten.Image)
 }
 
-func (mapObject *Map) GetTileImage(tileX int, tileY int, animationCounter uint64, scaler util.Scaler) (*ebiten.Image, error) {
+func (mapObject *Map) GetTileImage(tileX int, tileY int, animationCounter uint64) (*ebiten.Image, error) {
     tile := mapObject.Map.Terrain[tileX][tileY]
     tileInfo := mapObject.Data.Tiles[tile]
 
@@ -1326,7 +1326,7 @@ func (mapObject *Map) GetTileImage(tileX int, tileY int, animationCounter uint64
         return image, nil
     }
 
-    gpuImage := ebiten.NewImageFromImage(scaler.ApplyScale(tileInfo.Images[animationCounter % uint64(len(tileInfo.Images))]))
+    gpuImage := ebiten.NewImageFromImage(tileInfo.Images[animationCounter % uint64(len(tileInfo.Images))])
 
     mapObject.TileCache[tile * 0x1000 + int(animationIndex)] = gpuImage
     return gpuImage, nil
@@ -1813,7 +1813,7 @@ func (mapObject *Map) DrawLayer1(camera cameralib.Camera, animationCounter uint6
                 continue
             }
 
-            tileImage, err := mapObject.GetTileImage(tileX, tileY, animationCounter, imageCache)
+            tileImage, err := mapObject.GetTileImage(tileX, tileY, animationCounter)
             if err == nil {
                 options.GeoM.Reset()
                 // options.GeoM = geom

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -126,7 +126,7 @@ func (road *ExtraRoad) DrawLayer1(screen *ebiten.Image, imageCache *util.ImageCa
             pics, err := imageCache.GetImages("mapback.lbx", baseIndex + index)
             if err == nil {
                 pic := pics[counter % uint64(len(pics))]
-                screen.DrawImage(pic, options)
+                scale.DrawScaled(screen, pic, options)
             }
 
             connected = true
@@ -137,7 +137,7 @@ func (road *ExtraRoad) DrawLayer1(screen *ebiten.Image, imageCache *util.ImageCa
         pics, err := imageCache.GetImages("mapback.lbx", baseIndex)
         if err == nil {
             pic := pics[counter % uint64(len(pics))]
-            screen.DrawImage(pic, options)
+            scale.DrawScaled(screen, pic, options)
         }
     }
 }
@@ -159,7 +159,7 @@ func (bonus *ExtraBonus) DrawLayer1(screen *ebiten.Image, imageCache *util.Image
 
     pic, err := imageCache.GetImage("mapback.lbx", index, 0)
     if err == nil {
-        screen.DrawImage(pic, options)
+        scale.DrawScaled(screen, pic, options)
     }
 }
 
@@ -355,7 +355,7 @@ func (extra *ExtraEncounter) DrawLayer1(screen *ebiten.Image, imageCache *util.I
 
     pic, err := imageCache.GetImage("mapback.lbx", index, 0)
     if err == nil {
-        screen.DrawImage(pic, options)
+        scale.DrawScaled(screen, pic, options)
     }
 }
 
@@ -371,7 +371,7 @@ func (extra *ExtraOpenTower) DrawLayer1(screen *ebiten.Image, imageCache *util.I
 
     pic, err := imageCache.GetImage("mapback.lbx", index, 0)
     if err == nil {
-        screen.DrawImage(pic, options)
+        scale.DrawScaled(screen, pic, options)
     }
 }
 
@@ -422,7 +422,7 @@ func (node *ExtraMagicNode) DrawLayer2(screen *ebiten.Image, imageCache *util.Im
             options2.GeoM.Reset()
             options2.GeoM.Translate(float64(point.X * tileWidth), float64(point.Y * tileHeight))
             options2.GeoM.Concat(options.GeoM)
-            screen.DrawImage(use, &options2)
+            scale.DrawScaled(screen, use, &options2)
         }
     }
 
@@ -450,7 +450,7 @@ func (node *ExtraMagicNode) DrawLayer2(screen *ebiten.Image, imageCache *util.Im
             return
         }
         rect := image.Rect(int(x1), int(y1), int(x2), int(y2))
-        image := screen.SubImage(rect)
+        image := screen.SubImage(scale.ScaleRect(rect))
         if image.Bounds().Dx() == 0 || image.Bounds().Dy() == 0 {
             return
         }
@@ -466,6 +466,7 @@ func (node *ExtraMagicNode) DrawLayer2(screen *ebiten.Image, imageCache *util.Im
         // log.Printf("warp at %v, %v bounds image=%v source=%v", point.X, point.Y, image.Bounds(), sourceImage.Bounds())
 
         var options2 ebiten.DrawRectShaderOptions
+        options2.GeoM.Concat(scale.ScaledGeom)
         options2.GeoM.Translate(x1, y1)
 
         options2.Images[0] = sourceImage
@@ -539,7 +540,7 @@ type ExtraCorruption struct {
 func (node *ExtraCorruption) DrawLayer1(screen *ebiten.Image, imageCache *util.ImageCache, options *ebiten.DrawImageOptions, counter uint64, tileWidth int, tileHeight int){
     pic, err := imageCache.GetImage("mapback.lbx", 77, 0)
     if err == nil {
-        screen.DrawImage(pic, options)
+        scale.DrawScaled(screen, pic, options)
     }
 }
 
@@ -1822,7 +1823,7 @@ func (mapObject *Map) DrawLayer1(camera cameralib.Camera, animationCounter uint6
                 options.GeoM.Translate(float64(x * tileWidth), float64(y * tileHeight))
                 options.GeoM.Concat(geom)
 
-                screen.DrawImage(tileImage, &options)
+                scale.DrawScaled(screen, tileImage, &options)
 
                 for _, extraKind := range ExtraDrawOrder {
                     extra, ok := mapObject.ExtraMap[image.Pt(tileX, tileY)][extraKind]

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -466,8 +466,7 @@ func (node *ExtraMagicNode) DrawLayer2(screen *ebiten.Image, imageCache *util.Im
         // log.Printf("warp at %v, %v bounds image=%v source=%v", point.X, point.Y, image.Bounds(), sourceImage.Bounds())
 
         var options2 ebiten.DrawRectShaderOptions
-        options2.GeoM.Concat(scale.ScaledGeom)
-        options2.GeoM.Translate(x1, y1)
+        options2.GeoM.Translate(scale.Scale(x1), scale.Scale(y1))
 
         options2.Images[0] = sourceImage
         // options2.Images[1] = mask

--- a/game/magic/mirror/mirror.go
+++ b/game/magic/mirror/mirror.go
@@ -9,8 +9,9 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/draw"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
@@ -51,8 +52,8 @@ func GetWizardPortraitIndex(base data.WizardBase, banner data.BannerType) int {
 }
 
 func MakeMirrorUI(cache *lbx.LbxCache, player *playerlib.Player, ui *uilib.UI) *uilib.UIElement {
-    cornerX := 50 * data.ScreenScale
-    cornerY := 1 * data.ScreenScale
+    cornerX := 50
+    cornerY := 1
 
     fontLbx, err := cache.GetLbxFile("fonts.lbx")
     if err != nil {
@@ -97,7 +98,7 @@ func MakeMirrorUI(cache *lbx.LbxCache, player *playerlib.Player, ui *uilib.UI) *
         })
     }
 
-    wrappedAbilities := smallFont.CreateWrappedText(float64(160 * data.ScreenScale), float64(data.ScreenScale), setup.JoinAbilities(player.Wizard.Retorts))
+    wrappedAbilities := smallFont.CreateWrappedText(float64(160), 1, setup.JoinAbilities(player.Wizard.Retorts))
 
     element = &uilib.UIElement{
         Layer: 1,
@@ -113,35 +114,37 @@ func MakeMirrorUI(cache *lbx.LbxCache, player *playerlib.Player, ui *uilib.UI) *
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(cornerX), float64(cornerY))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             if portrait != nil {
-                options.GeoM.Translate(float64(11 * data.ScreenScale), float64(11 * data.ScreenScale))
-                screen.DrawImage(portrait, &options)
+                options.GeoM.Translate(float64(11), float64(11))
+                scale.DrawScaled(screen, portrait, &options)
             }
 
-            nameFont.PrintCenter(screen, float64(cornerX + 110 * data.ScreenScale), float64(cornerY + 10 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, player.Wizard.Name)
+            centerOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
 
-            smallFont.PrintCenter(screen, float64(cornerX + 30 * data.ScreenScale), float64(cornerY + 75 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v GP", player.Gold))
-            smallFont.PrintRight(screen, float64(cornerX + 170 * data.ScreenScale), float64(cornerY + 75 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v MP", player.Mana))
+            nameFont.PrintOptions2(screen, float64(cornerX + 110), float64(cornerY + 10), centerOptions, player.Wizard.Name)
 
-            options.GeoM.Translate(float64(34 * data.ScreenScale), float64(55 * data.ScreenScale))
+            smallFont.PrintOptions2(screen, float64(cornerX + 30), float64(cornerY + 75), centerOptions, fmt.Sprintf("%v GP", player.Gold))
+            smallFont.PrintOptions2(screen, float64(cornerX + 170), float64(cornerY + 75), font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", player.Mana))
+
+            options.GeoM.Translate(float64(34), float64(55))
             newRand := rand.New(rand.NewPCG(player.BookOrderSeed1, player.BookOrderSeed2))
             draw.DrawBooks(screen, options, &imageCache, player.Wizard.Books, newRand)
 
             if player.GetFame() > 0 {
-                heroFont.PrintCenter(screen, float64(cornerX + 90 * data.ScreenScale), float64(cornerY + 95 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("%v Fame", player.GetFame()))
+                heroFont.PrintOptions2(screen, float64(cornerX + 90), float64(cornerY + 95), centerOptions, fmt.Sprintf("%v Fame", player.GetFame()))
             }
 
-            smallFont.RenderWrapped(screen, float64(cornerX + 13 * data.ScreenScale), float64(cornerY + 112 * data.ScreenScale), wrappedAbilities, options.ColorScale, font.FontOptions{})
+            smallFont.RenderWrapped(screen, float64(cornerX + 13), float64(cornerY + 112), wrappedAbilities, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
-            heroFont.PrintCenter(screen, float64(cornerX + 90 * data.ScreenScale), float64(cornerY + 131 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Heroes")
+            heroFont.PrintOptions2(screen, float64(cornerX + 90), float64(cornerY + 131), centerOptions, "Heroes")
 
-            heroX := cornerX + 13 * data.ScreenScale
-            heroY := cornerY + 142 * data.ScreenScale
+            heroX := cornerX + 13
+            heroY := cornerY + 142
             for _, hero := range player.AliveHeroes() {
-                smallFont.Print(screen, float64(heroX), float64(heroY), float64(data.ScreenScale), options.ColorScale, hero.GetFullName())
-                heroY += smallFont.Height() * data.ScreenScale
+                smallFont.PrintOptions2(screen, float64(heroX), float64(heroY), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, hero.GetFullName())
+                heroY += smallFont.Height()
             }
         },
     }

--- a/game/magic/mirror/mirror.go
+++ b/game/magic/mirror/mirror.go
@@ -136,7 +136,7 @@ func MakeMirrorUI(cache *lbx.LbxCache, player *playerlib.Player, ui *uilib.UI) *
                 heroFont.PrintOptions2(screen, float64(cornerX + 90), float64(cornerY + 95), centerOptions, fmt.Sprintf("%v Fame", player.GetFame()))
             }
 
-            smallFont.RenderWrapped(screen, float64(cornerX + 13), float64(cornerY + 112), wrappedAbilities, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
+            smallFont.RenderWrapped(screen, float64(cornerX + 13), float64(cornerY + 112), wrappedAbilities, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
             heroFont.PrintOptions2(screen, float64(cornerX + 90), float64(cornerY + 131), centerOptions, "Heroes")
 

--- a/game/magic/mirror/mirror.go
+++ b/game/magic/mirror/mirror.go
@@ -123,27 +123,27 @@ func MakeMirrorUI(cache *lbx.LbxCache, player *playerlib.Player, ui *uilib.UI) *
 
             centerOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
 
-            nameFont.PrintOptions2(screen, float64(cornerX + 110), float64(cornerY + 10), centerOptions, player.Wizard.Name)
+            nameFont.PrintOptions(screen, float64(cornerX + 110), float64(cornerY + 10), centerOptions, player.Wizard.Name)
 
-            smallFont.PrintOptions2(screen, float64(cornerX + 30), float64(cornerY + 75), centerOptions, fmt.Sprintf("%v GP", player.Gold))
-            smallFont.PrintOptions2(screen, float64(cornerX + 170), float64(cornerY + 75), font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", player.Mana))
+            smallFont.PrintOptions(screen, float64(cornerX + 30), float64(cornerY + 75), centerOptions, fmt.Sprintf("%v GP", player.Gold))
+            smallFont.PrintOptions(screen, float64(cornerX + 170), float64(cornerY + 75), font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", player.Mana))
 
             options.GeoM.Translate(float64(34), float64(55))
             newRand := rand.New(rand.NewPCG(player.BookOrderSeed1, player.BookOrderSeed2))
             draw.DrawBooks(screen, options, &imageCache, player.Wizard.Books, newRand)
 
             if player.GetFame() > 0 {
-                heroFont.PrintOptions2(screen, float64(cornerX + 90), float64(cornerY + 95), centerOptions, fmt.Sprintf("%v Fame", player.GetFame()))
+                heroFont.PrintOptions(screen, float64(cornerX + 90), float64(cornerY + 95), centerOptions, fmt.Sprintf("%v Fame", player.GetFame()))
             }
 
             smallFont.RenderWrapped(screen, float64(cornerX + 13), float64(cornerY + 112), wrappedAbilities, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
 
-            heroFont.PrintOptions2(screen, float64(cornerX + 90), float64(cornerY + 131), centerOptions, "Heroes")
+            heroFont.PrintOptions(screen, float64(cornerX + 90), float64(cornerY + 131), centerOptions, "Heroes")
 
             heroX := cornerX + 13
             heroY := cornerY + 142
             for _, hero := range player.AliveHeroes() {
-                smallFont.PrintOptions2(screen, float64(heroX), float64(heroY), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, hero.GetFullName())
+                smallFont.PrintOptions(screen, float64(heroX), float64(heroY), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, hero.GetFullName())
                 heroY += smallFont.Height()
             }
         },

--- a/game/magic/mouse/mouse.go
+++ b/game/magic/mouse/mouse.go
@@ -2,6 +2,8 @@ package mouse
 
 import (
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
+
     "github.com/hajimehoshi/ebiten/v2"
 )
 
@@ -35,7 +37,7 @@ func (mouse *GlobalMouse) Draw(screen *ebiten.Image) {
     if mouse != nil && mouse.Enabled && mouse.CurrentMouse != nil {
         x, y := inputmanager.MousePosition()
         var options ebiten.DrawImageOptions
-        options.GeoM.Translate(float64(x), float64(y))
-        screen.DrawImage(mouse.CurrentMouse, &options)
+        options.GeoM.Translate(scale.Unscale(float64(x)), scale.Unscale(float64(y)))
+        scale.DrawScaled(screen, mouse.CurrentMouse, &options)
     }
 }

--- a/game/magic/player/stack.go
+++ b/game/magic/player/stack.go
@@ -99,7 +99,7 @@ func (stack *UnitStack) SplitActiveUnits() *UnitStack {
 }
 
 func (stack *UnitStack) ActiveUnits() []units.StackUnit {
-    var out []units.StackUnit
+    out := make([]units.StackUnit, 0, len(stack.active))
     for unit, active := range stack.active {
         if active {
             out = append(out, unit)
@@ -181,8 +181,8 @@ func (stack *UnitStack) HasHero() bool {
 
 // returns true if any of the active units in the stack have the given ability
 func (stack *UnitStack) ActiveUnitsHasAbility(ability data.AbilityType) bool {
-    for _, unit := range stack.ActiveUnits() {
-        if unit.HasAbility(ability) {
+    for unit, active := range stack.active {
+        if active && unit.HasAbility(ability) {
             return true
         }
     }
@@ -191,8 +191,8 @@ func (stack *UnitStack) ActiveUnitsHasAbility(ability data.AbilityType) bool {
 }
 
 func (stack *UnitStack) ActiveUnitsHasEnchantment(ability data.UnitEnchantment) bool {
-    for _, unit := range stack.ActiveUnits() {
-        if unit.HasEnchantment(ability) {
+    for unit, active := range stack.active {
+        if active && unit.HasEnchantment(ability) {
             return true
         }
     }
@@ -203,8 +203,8 @@ func (stack *UnitStack) ActiveUnitsHasEnchantment(ability data.UnitEnchantment) 
 // returns true if none of the active units in the stack have the given ability
 // if a single unit has the ability then return false
 func (stack *UnitStack) ActiveUnitsDoesntHaveAbility(ability data.AbilityType) bool {
-    for _, unit := range stack.ActiveUnits() {
-        if unit.HasAbility(ability) {
+    for unit, active := range stack.active {
+        if active && unit.HasAbility(ability) {
             return false
         }
     }
@@ -218,7 +218,14 @@ func (stack *UnitStack) HasPathfinding() bool {
 }
 
 func (stack *UnitStack) AllActive() bool {
-    return len(stack.ActiveUnits()) == len(stack.units)
+    count := 0
+    for _, active := range stack.active {
+        if active {
+            count += 1
+        }
+    }
+
+    return count == len(stack.units)
 }
 
 func (stack *UnitStack) ToggleActive(unit units.StackUnit){

--- a/game/magic/scale/scale.go
+++ b/game/magic/scale/scale.go
@@ -60,3 +60,11 @@ func UpdateScale(amount float64) {
     ScaledGeom.Reset()
     ScaledGeom.Scale(ScaleAmount, ScaleAmount)
 }
+
+// draw the image using the current scale, but avoid allocating an entire DrawImageOptions
+func DrawScaled(screen *ebiten.Image, img *ebiten.Image, options *ebiten.DrawImageOptions) {
+    oldGeom := options.GeoM
+    options.GeoM.Concat(ScaledGeom)
+    screen.DrawImage(img, options)
+    options.GeoM = oldGeom
+}

--- a/game/magic/scale/scale.go
+++ b/game/magic/scale/scale.go
@@ -2,6 +2,7 @@ package scale
 
 import (
     "golang.org/x/exp/constraints"
+    "image"
 
     "github.com/hajimehoshi/ebiten/v2"
 )
@@ -67,4 +68,11 @@ func DrawScaled(screen *ebiten.Image, img *ebiten.Image, options *ebiten.DrawIma
     options.GeoM.Concat(ScaledGeom)
     screen.DrawImage(img, options)
     options.GeoM = oldGeom
+}
+
+func ScaleRect(rect image.Rectangle) image.Rectangle {
+    return image.Rectangle{
+        Min: rect.Min.Mul(int(ScaleAmount)),
+        Max: rect.Max.Mul(int(ScaleAmount)),
+    }
 }

--- a/game/magic/scale/scale.go
+++ b/game/magic/scale/scale.go
@@ -10,6 +10,28 @@ import (
 var ScaleAmount = 3.0
 var ScaledGeom ebiten.GeoM
 
+var ScreenScaleAlgorithm = ScaleAlgorithmNormal
+
+type ScaleAlgorithm int
+
+const (
+    // the scale2x
+    // https://www.scale2x.it/
+    ScaleAlgorithmScale ScaleAlgorithm = iota
+    ScaleAlgorithmXbr
+    ScaleAlgorithmNormal
+)
+
+func (algorithm ScaleAlgorithm) String() string {
+    switch algorithm {
+        case ScaleAlgorithmScale: return "scale"
+        case ScaleAlgorithmXbr: return "xbr"
+        case ScaleAlgorithmNormal: return "normal"
+    }
+
+    return ""
+}
+
 type UnscaledGeoM ebiten.GeoM
 
 func (unscaled *UnscaledGeoM) Scaled() ebiten.GeoM {

--- a/game/magic/setup/new-game.go
+++ b/game/magic/setup/new-game.go
@@ -192,7 +192,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
 
             x := difficultyX + difficultyBlock.Bounds().Dx() / 2
             y := (difficultyY + 3)
-            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.DifficultyString())
+            buttonFont.PrintOptions(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.DifficultyString())
         },
     })
 
@@ -212,7 +212,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
             scale.DrawScaled(screen, opponentsBlock, &options)
             x := opponentsX + opponentsBlock.Bounds().Dx() / 2
             y := (opponentsY + 4)
-            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.OpponentsString())
+            buttonFont.PrintOptions(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.OpponentsString())
         },
     })
 
@@ -233,7 +233,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
             x := landsizeX + landSizeBlock.Bounds().Dx() / 2
             y := (landsizeY + 4)
 
-            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.LandSizeString())
+            buttonFont.PrintOptions(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.LandSizeString())
         },
     })
 
@@ -252,7 +252,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
             scale.DrawScaled(screen, magicBlock, &options)
             x := magicX + magicBlock.Bounds().Dx() / 2
             y := (magicY + 4)
-            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.MagicString())
+            buttonFont.PrintOptions(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.MagicString())
         },
     })
 

--- a/game/magic/setup/new-game.go
+++ b/game/magic/setup/new-game.go
@@ -8,6 +8,7 @@ import (
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/util"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -138,7 +139,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
 
     okIndex := 0
     elements = append(elements, &uilib.UIElement{
-        Rect: util.ImageRect(okX * data.ScreenScale, okY * data.ScreenScale, okButtons[0]),
+        Rect: util.ImageRect(okX, okY, okButtons[0]),
         LeftClick: func(element *uilib.UIElement) {
             okIndex = 1
         },
@@ -149,7 +150,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
         Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(this.Rect.Min.X), float64(this.Rect.Min.Y))
-            screen.DrawImage(okButtons[okIndex], &options)
+            scale.DrawScaled(screen, okButtons[okIndex], &options)
         },
     })
 
@@ -159,7 +160,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
     cancelButtons, _ := newGameScreen.ImageCache.GetImages("newgame.lbx", 3)
     cancelIndex := 0
     elements = append(elements, &uilib.UIElement{
-        Rect: util.ImageRect(cancelX * data.ScreenScale, cancelY * data.ScreenScale, cancelButtons[0]),
+        Rect: util.ImageRect(cancelX, cancelY, cancelButtons[0]),
         LeftClick: func(element *uilib.UIElement) {
             cancelIndex = 1
         },
@@ -170,7 +171,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
         Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(this.Rect.Min.X), float64(this.Rect.Min.Y))
-            screen.DrawImage(cancelButtons[cancelIndex], &options)
+            scale.DrawScaled(screen, cancelButtons[cancelIndex], &options)
         },
     })
 
@@ -180,18 +181,18 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
     difficultyBlock, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 4, 0)
 
     elements = append(elements, &uilib.UIElement{
-        Rect: util.ImageRect(difficultyX * data.ScreenScale, difficultyY * data.ScreenScale, difficultyBlock),
+        Rect: util.ImageRect(difficultyX, difficultyY, difficultyBlock),
         LeftClick: func(element *uilib.UIElement) {
             newGameScreen.Settings.DifficultyNext()
         },
         Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(this.Rect.Min.X), float64(this.Rect.Min.Y))
-            screen.DrawImage(difficultyBlock, &options)
+            scale.DrawScaled(screen, difficultyBlock, &options)
 
-            x := difficultyX * data.ScreenScale + difficultyBlock.Bounds().Dx() / 2
-            y := (difficultyY + 3) * data.ScreenScale
-            buttonFont.PrintCenter(screen, float64(x), float64(y), float64(data.ScreenScale), ebiten.ColorScale{}, newGameScreen.Settings.DifficultyString())
+            x := difficultyX + difficultyBlock.Bounds().Dx() / 2
+            y := (difficultyY + 3)
+            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.DifficultyString())
         },
     })
 
@@ -201,17 +202,17 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
     opponentsBlock, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 5, 0)
 
     elements = append(elements, &uilib.UIElement{
-        Rect: util.ImageRect(opponentsX * data.ScreenScale, opponentsY * data.ScreenScale, opponentsBlock),
+        Rect: util.ImageRect(opponentsX, opponentsY, opponentsBlock),
         LeftClick: func(element *uilib.UIElement) {
             newGameScreen.Settings.OpponentsNext()
         },
         Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(this.Rect.Min.X), float64(this.Rect.Min.Y))
-            screen.DrawImage(opponentsBlock, &options)
-            x := opponentsX * data.ScreenScale + opponentsBlock.Bounds().Dx() / 2
-            y := (opponentsY + 4) * data.ScreenScale
-            buttonFont.PrintCenter(screen, float64(x), float64(y), float64(data.ScreenScale), ebiten.ColorScale{}, newGameScreen.Settings.OpponentsString())
+            scale.DrawScaled(screen, opponentsBlock, &options)
+            x := opponentsX + opponentsBlock.Bounds().Dx() / 2
+            y := (opponentsY + 4)
+            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.OpponentsString())
         },
     })
 
@@ -220,19 +221,19 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
     landSizeBlock, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 6, 0)
 
     elements = append(elements, &uilib.UIElement{
-        Rect: util.ImageRect(landsizeX * data.ScreenScale, landsizeY * data.ScreenScale, landSizeBlock),
+        Rect: util.ImageRect(landsizeX, landsizeY, landSizeBlock),
         LeftClick: func(element *uilib.UIElement) {
             newGameScreen.Settings.LandSizeNext()
         },
         Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(this.Rect.Min.X), float64(this.Rect.Min.Y))
-            screen.DrawImage(landSizeBlock, &options)
+            scale.DrawScaled(screen, landSizeBlock, &options)
 
-            x := landsizeX * data.ScreenScale + landSizeBlock.Bounds().Dx() / 2
-            y := (landsizeY + 4)* data.ScreenScale
+            x := landsizeX + landSizeBlock.Bounds().Dx() / 2
+            y := (landsizeY + 4)
 
-            buttonFont.PrintCenter(screen, float64(x), float64(y), float64(data.ScreenScale), ebiten.ColorScale{}, newGameScreen.Settings.LandSizeString())
+            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.LandSizeString())
         },
     })
 
@@ -241,17 +242,17 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
     magicBlock, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 7, 0)
 
     elements = append(elements, &uilib.UIElement{
-        Rect: util.ImageRect(magicX * data.ScreenScale, magicY * data.ScreenScale, magicBlock),
+        Rect: util.ImageRect(magicX, magicY, magicBlock),
         LeftClick: func(element *uilib.UIElement) {
             newGameScreen.Settings.MagicNext()
         },
         Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(this.Rect.Min.X), float64(this.Rect.Min.Y))
-            screen.DrawImage(magicBlock, &options)
-            x := magicX * data.ScreenScale + magicBlock.Bounds().Dx() / 2
-            y := (magicY + 4) * data.ScreenScale
-            buttonFont.PrintCenter(screen, float64(x), float64(y), float64(data.ScreenScale), ebiten.ColorScale{}, newGameScreen.Settings.MagicString())
+            scale.DrawScaled(screen, magicBlock, &options)
+            x := magicX + magicBlock.Bounds().Dx() / 2
+            y := (magicY + 4)
+            buttonFont.PrintOptions2(screen, float64(x), float64(y), font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, newGameScreen.Settings.MagicString())
         },
     })
 
@@ -260,13 +261,13 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
             var options ebiten.DrawImageOptions
 
             background, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 0, 0)
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64((160 + 5) * data.ScreenScale), 0)
+            options.GeoM.Translate(float64((160 + 5)), 0)
 
             optionsImage, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 1, 0)
-            screen.DrawImage(optionsImage, &options)
+            scale.DrawScaled(screen, optionsImage, &options)
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 element.Draw(element, screen)

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -2032,7 +2032,7 @@ func (screen *NewWizardScreen) MakeSelectBannerUI() *uilib.UI {
         height := 34
         yPos := 24 + i * height
         elements = append(elements, &uilib.UIElement{
-            Rect: image.Rect(160 * data.ScreenScale, yPos * data.ScreenScale, 320 * data.ScreenScale, (yPos + height) * data.ScreenScale),
+            Rect: image.Rect(160, yPos, 320, (yPos + height)),
             Draw: func(this *uilib.UIElement, window *ebiten.Image){
                 // vector.StrokeRect(window, 160, float32(yPos), 160, float32(height), 1, color.RGBA{R: 0xff, G: uint8(i * 20), B: uint8(i * 20), A: 0xff}, true)
             },
@@ -2062,25 +2062,25 @@ func (screen *NewWizardScreen) MakeSelectBannerUI() *uilib.UI {
 
             var options ebiten.DrawImageOptions
             background, _ := screen.ImageCache.GetImage("newgame.lbx", 0, 0)
-            window.DrawImage(background, &options)
+            window.DrawImage(background, scale.ScaleOptions(options))
 
-            options.GeoM.Translate(float64(portraitX * data.ScreenScale), float64(portraitY * data.ScreenScale))
+            options.GeoM.Translate(float64(portraitX), float64(portraitY))
             portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
-            window.DrawImage(portrait, &options)
-            screen.Font.PrintCenter(window, float64(nameX * data.ScreenScale), float64(nameY * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, screen.CustomWizard.Name)
+            window.DrawImage(portrait, scale.ScaleOptions(options))
+            screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(34 * data.ScreenScale), float64(135 * data.ScreenScale))
+            options.GeoM.Translate(34, 135)
             draw.DrawBooks(window, options, &imageCache, screen.CustomWizard.Books, screen.BooksOrderRandom())
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(158 * data.ScreenScale), 0)
+            options.GeoM.Translate(158, 0)
             bannerBackground, _ := screen.ImageCache.GetImage("newgame.lbx", 46, 0)
-            window.DrawImage(bannerBackground, &options)
+            window.DrawImage(bannerBackground, scale.ScaleOptions(options))
 
-            screen.SelectFont.PrintCenter(window, float64(245 * data.ScreenScale), float64(2 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, "Select Banner")
+            screen.SelectFont.PrintOptions2(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Banner")
 
-            screen.AbilityFontSelected.Print(window, float64(12 * data.ScreenScale), float64(180 * data.ScreenScale), float64(data.ScreenScale), ebiten.ColorScale{}, JoinAbilities(screen.CustomWizard.Retorts))
+            screen.AbilityFontSelected.PrintOptions2(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -466,8 +466,8 @@ func (screen *NewWizardScreen) MakeCustomNameUI() *uilib.UI {
             options.GeoM.Translate(float64(portraitX), float64(portraitY))
             portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
             window.DrawImage(portrait, scale.ScaleOptions(options))
-            screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
-            screen.SelectFont.PrintOptions2(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Wizard's Name")
+            screen.Font.PrintOptions(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
+            screen.SelectFont.PrintOptions(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Wizard's Name")
 
             options.GeoM.Reset()
             options.GeoM.Translate(184, 20)
@@ -481,7 +481,7 @@ func (screen *NewWizardScreen) MakeCustomNameUI() *uilib.UI {
                 name += "_"
             }
 
-            screen.NameFontBright.PrintOptions2(window, 195, 39, font.FontOptions{Scale: scale.ScaleAmount}, name)
+            screen.NameFontBright.PrintOptions(window, 195, 39, font.FontOptions{Scale: scale.ScaleAmount}, name)
 
             return
         },
@@ -591,7 +591,7 @@ func (screen *NewWizardScreen) MakeCustomPictureUI() *uilib.UI {
             background, _ := screen.ImageCache.GetImage("newgame.lbx", 0, 0)
             window.DrawImage(background, scale.ScaleOptions(options))
 
-            screen.SelectFont.PrintOptions2(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Wizard")
+            screen.SelectFont.PrintOptions(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Wizard")
 
             const portraitX = 24
             const portraitY = 10
@@ -664,7 +664,7 @@ func (screen *NewWizardScreen) MakeWizardUIElements(clickFunc func(wizard int), 
                 },
                 Draw: func(this *uilib.UIElement, window *ebiten.Image){
                     window.DrawImage(background, scaledOptions)
-                    screen.Font.PrintOptions2(window, float64(x1) + float64(background.Bounds().Dx()) / 2, float64(y1 + 3), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, name)
+                    screen.Font.PrintOptions(window, float64(x1) + float64(background.Bounds().Dx()) / 2, float64(y1 + 3), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, name)
                 },
             })
         }
@@ -723,7 +723,7 @@ func (screen *NewWizardScreen) MakeSelectWizardUI() *uilib.UI {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(x1), float64(y1))
                 window.DrawImage(background, scale.ScaleOptions(options))
-                screen.Font.PrintOptions2(window, float64(x1) + float64(background.Bounds().Dx()) / 2, float64(y1 + 3), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Custom")
+                screen.Font.PrintOptions(window, float64(x1) + float64(background.Bounds().Dx()) / 2, float64(y1 + 3), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Custom")
             },
         }
     })())
@@ -733,7 +733,7 @@ func (screen *NewWizardScreen) MakeSelectWizardUI() *uilib.UI {
             var options ebiten.DrawImageOptions
             background, _ := screen.ImageCache.GetImage("newgame.lbx", 0, 0)
             window.DrawImage(background, scale.ScaleOptions(options))
-            screen.SelectFont.PrintOptions2(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Wizard")
+            screen.SelectFont.PrintOptions(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Wizard")
 
             this.IterateElementsByLayer(func (element *uilib.UIElement){
                 element.Draw(element, window)
@@ -751,14 +751,14 @@ func (screen *NewWizardScreen) MakeSelectWizardUI() *uilib.UI {
                     var options ebiten.DrawImageOptions
                     options.GeoM.Translate(float64(portraitX), float64(portraitY))
                     window.DrawImage(portrait, scale.ScaleOptions(options))
-                    screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.WizardSlots[screen.CurrentWizard].Name)
+                    screen.Font.PrintOptions(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.WizardSlots[screen.CurrentWizard].Name)
 
                     // screen.DrawBooks(window, 36, 135, screen.WizardSlots[screen.CurrentWizard].Books)
                     options.GeoM.Reset()
                     options.GeoM.Translate(34, 135)
                     draw.DrawBooks(window, options, &screen.ImageCache, screen.WizardSlots[screen.CurrentWizard].Books, screen.BooksOrderRandom())
                     if screen.WizardSlots[screen.CurrentWizard].ExtraRetort != data.RetortNone {
-                        screen.AbilityFontSelected.PrintOptions2(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, screen.WizardSlots[screen.CurrentWizard].ExtraRetort.String())
+                        screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, screen.WizardSlots[screen.CurrentWizard].ExtraRetort.String())
                     }
                 }
             }
@@ -1292,7 +1292,7 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
                     useFont = screen.AbilityFontAvailable
                 }
 
-                useFont.PrintOptions2(window, ability.X, ability.Y, font.FontOptions{Scale: scale.ScaleAmount}, ability.Ability.String())
+                useFont.PrintOptions(window, ability.X, ability.Y, font.FontOptions{Scale: scale.ScaleAmount}, ability.Ability.String())
             },
         })
     }
@@ -1345,7 +1345,7 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
             options.GeoM.Translate(float64(portraitX), float64(portraitY))
             portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
             window.DrawImage(portrait, scale.ScaleOptions(options))
-            screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
+            screen.Font.PrintOptions(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
 
             options.GeoM.Reset()
             options.GeoM.Translate(34, 135)
@@ -1357,8 +1357,8 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
                 }
             })
 
-            screen.AbilityFontSelected.PrintOptions2(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
-            screen.NameFontBright.PrintOptions2(window, 223, 185, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v picks", picksLeft()))
+            screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
+            screen.NameFontBright.PrintOptions(window, 223, 185, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v picks", picksLeft()))
         },
         HandleKeys: func(keys []ebiten.Key){
             for _, key := range keys {
@@ -1603,9 +1603,9 @@ func (screen *NewWizardScreen) MakeSelectSpellsUI() *uilib.UI {
                             var options ebiten.DrawImageOptions
                             options.GeoM.Translate(float64(useX), float64(useY))
                             window.DrawImage(checkMark, scale.ScaleOptions(options))
-                            screen.AbilityFontSelected.PrintOptions2(window, float64(useX + margin), float64(useY), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
+                            screen.AbilityFontSelected.PrintOptions(window, float64(useX + margin), float64(useY), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
                         } else {
-                            screen.AbilityFontAvailable.PrintOptions2(window, float64(useX + margin), float64(useY), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
+                            screen.AbilityFontAvailable.PrintOptions(window, float64(useX + margin), float64(useY), font.FontOptions{Scale: scale.ScaleAmount}, spell.Name)
                         }
                     },
                 })
@@ -1684,7 +1684,7 @@ func (screen *NewWizardScreen) MakeSelectSpellsUI() *uilib.UI {
                 options.GeoM.Translate(float64(portraitX), float64(portraitY))
                 portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
                 window.DrawImage(portrait, scale.ScaleOptions(options))
-                screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
+                screen.Font.PrintOptions(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
 
                 options.GeoM.Reset()
                 options.GeoM.Translate(34, 135)
@@ -1698,22 +1698,22 @@ func (screen *NewWizardScreen) MakeSelectSpellsUI() *uilib.UI {
                 titleX := 240
                 titleY := 5
 
-                blackFont.PrintOptions2(window, float64(titleX + 1), float64(titleY + 1), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("Select %v Spells", magic.String()))
-                titleFont.PrintOptions2(window, float64(titleX), float64(titleY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("Select %v Spells", magic.String()))
+                blackFont.PrintOptions(window, float64(titleX + 1), float64(titleY + 1), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("Select %v Spells", magic.String()))
+                titleFont.PrintOptions(window, float64(titleX), float64(titleY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("Select %v Spells", magic.String()))
 
                 options.GeoM.Reset()
                 options.GeoM.Translate(180, 18)
                 windyBorder, _ := screen.ImageCache.GetImage("newgame.lbx", 47, 0)
                 window.DrawImage(windyBorder, &options)
 
-                screen.AbilityFontSelected.PrintOptions2(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
-                screen.NameFontBright.PrintOptions2(window, 223, 185, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v picks", picksLeft()))
+                screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
+                screen.NameFontBright.PrintOptions(window, 223, 185, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v picks", picksLeft()))
 
                 showDescription := func(y float64, text string, background *ebiten.Image){
                     descriptionX := float64(167)
 
-                    shadowDescriptionFont.PrintOptions2(window, descriptionX + 1, y + 1, font.FontOptions{Scale: scale.ScaleAmount}, text)
-                    descriptionFont.PrintOptions2(window, descriptionX, y, font.FontOptions{Scale: scale.ScaleAmount}, text)
+                    shadowDescriptionFont.PrintOptions(window, descriptionX + 1, y + 1, font.FontOptions{Scale: scale.ScaleAmount}, text)
+                    descriptionFont.PrintOptions(window, descriptionX, y, font.FontOptions{Scale: scale.ScaleAmount}, text)
 
                     boxY := y + float64(descriptionFont.Height()) + 1
 
@@ -1896,9 +1896,9 @@ func (screen *NewWizardScreen) MakeSelectRaceUI() *uilib.UI {
             },
             Draw: func(this *uilib.UIElement, window *ebiten.Image){
                 if highlight {
-                    raceSelect.PrintOptions2(window, float64(this.Rect.Min.X + 5), float64(this.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, race.String())
+                    raceSelect.PrintOptions(window, float64(this.Rect.Min.X + 5), float64(this.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, race.String())
                 } else {
-                    raceAvailable.PrintOptions2(window, float64(this.Rect.Min.X + 5), float64(this.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, race.String())
+                    raceAvailable.PrintOptions(window, float64(this.Rect.Min.X + 5), float64(this.Rect.Min.Y), font.FontOptions{Scale: scale.ScaleAmount}, race.String())
                 }
             },
         })
@@ -1950,7 +1950,7 @@ func (screen *NewWizardScreen) MakeSelectRaceUI() *uilib.UI {
                     }
                 }
 
-                fontDraw.PrintOptions2(window, float64(this.Rect.Min.X + 5), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, race.String())
+                fontDraw.PrintOptions(window, float64(this.Rect.Min.X + 5), float64(yPos), font.FontOptions{Scale: scale.ScaleAmount}, race.String())
             },
         })
     }
@@ -1970,30 +1970,30 @@ func (screen *NewWizardScreen) MakeSelectRaceUI() *uilib.UI {
             options.GeoM.Translate(float64(portraitX), float64(portraitY))
             portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
             window.DrawImage(portrait, scale.ScaleOptions(options))
-            screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
+            screen.Font.PrintOptions(window, float64(nameX), float64(nameY), font.FontOptions{Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
 
             options.GeoM.Reset()
             options.GeoM.Translate(34, 135)
             draw.DrawBooks(window, options, &imageCache, screen.CustomWizard.Books, screen.BooksOrderRandom())
 
-            screen.SelectFont.PrintOptions2(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Race")
+            screen.SelectFont.PrintOptions(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Race")
 
             options.GeoM.Reset()
             options.GeoM.Translate(180, 18)
             windyBorder, _ := screen.ImageCache.GetImage("newgame.lbx", 47, 0)
             window.DrawImage(windyBorder, scale.ScaleOptions(options))
 
-            raceShadowFont.PrintOptions2(window, 243 + 1, 25, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Arcanian Races:")
-            raceFont.PrintOptions2(window, 243, 25, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Arcanian Races:")
+            raceShadowFont.PrintOptions(window, 243 + 1, 25, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Arcanian Races:")
+            raceFont.PrintOptions(window, 243, 25, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Arcanian Races:")
 
             options.GeoM.Reset()
             options.GeoM.Translate(210, 33)
             window.DrawImage(raceBackground, scale.ScaleOptions(options))
 
-            raceShadowFont.PrintOptions2(window, 243 + 1, 132, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Myrran Races:")
-            raceFont.PrintOptions2(window, 243, 132, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Myrran Races:")
+            raceShadowFont.PrintOptions(window, 243 + 1, 132, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Myrran Races:")
+            raceFont.PrintOptions(window, 243, 132, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Myrran Races:")
 
-            screen.AbilityFontSelected.PrintOptions2(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
+            screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {
@@ -2067,7 +2067,7 @@ func (screen *NewWizardScreen) MakeSelectBannerUI() *uilib.UI {
             options.GeoM.Translate(float64(portraitX), float64(portraitY))
             portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
             window.DrawImage(portrait, scale.ScaleOptions(options))
-            screen.Font.PrintOptions2(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
+            screen.Font.PrintOptions(window, float64(nameX), float64(nameY), font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, screen.CustomWizard.Name)
 
             options.GeoM.Reset()
             options.GeoM.Translate(34, 135)
@@ -2078,9 +2078,9 @@ func (screen *NewWizardScreen) MakeSelectBannerUI() *uilib.UI {
             bannerBackground, _ := screen.ImageCache.GetImage("newgame.lbx", 46, 0)
             window.DrawImage(bannerBackground, scale.ScaleOptions(options))
 
-            screen.SelectFont.PrintOptions2(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Banner")
+            screen.SelectFont.PrintOptions(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Banner")
 
-            screen.AbilityFontSelected.PrintOptions2(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
+            screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
 
             ui.IterateElementsByLayer(func (element *uilib.UIElement){
                 if element.Draw != nil {

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -1613,7 +1613,7 @@ func (screen *NewWizardScreen) MakeSelectSpellsUI() *uilib.UI {
                 y += screen.AbilityFontAvailable.Height() + 1
                 if i == 4 {
                     y = yTop
-                    x += width / data.ScreenScale
+                    x += width
                 }
             }
         }

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -526,7 +526,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                     }
 
                     wrapped := getSpellDescriptionNormalText(spell.Index)
-                    spellTextNormalFont.RenderWrapped(pageImage, x, y, wrapped, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions})
+                    spellTextNormalFont.RenderWrapped(pageImage, x, y, wrapped, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions})
 
                     if !flipping && learnedSpell.Name == spell.Name && !learnSpellAnimation.Done() {
                         animationOptions := options
@@ -538,7 +538,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                 } else {
                     spellTitleAlienFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, spell.Name)
                     wrapped := getSpellDescriptionAlienText(spell.Index)
-                    spellTextAlienFont.RenderWrapped(pageImage, x, y + float64(10), wrapped, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
+                    spellTextAlienFont.RenderWrapped(pageImage, x, y + float64(10), wrapped, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
                 }
             }
         }

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -1033,7 +1033,7 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
             showRect.Max.X = showRect.Min.X + int((float64(conveyor.Bounds().Dx()) * float64(amount) / float64(maximum)))
             area := screen.SubImage(scale.ScaleRect(showRect)).(*ebiten.Image)
 
-            motion := (group.Counter) % uint64(conveyor.Bounds().Dx())
+            motion := (group.Counter / 2) % uint64(conveyor.Bounds().Dx())
 
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -11,6 +11,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/lib/coroutine"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     helplib "github.com/kazzmir/master-of-magic/game/magic/help"
@@ -550,7 +551,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             return image
         }
 
-        pageImage := ebiten.NewImage(155 * data.ScreenScale, 170 * data.ScreenScale)
+        pageImage := ebiten.NewImage(155, 170)
         pageImage.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 0})
 
         if halfPage < len(halfPages) {
@@ -730,22 +731,22 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                 if index == 0 {
                     if flipLeftSide >= 0 {
                         leftSide := getHalfPageImage(flipLeftSide)
-                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions1(bookFlip[index]), options)
+                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions1(bookFlip[index]), options.GeoM)
                     }
                 } else if index == 1 {
                     if flipLeftSide >= 0 {
                         leftSide := getHalfPageImage(flipLeftSide)
-                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions2(bookFlip[index]), options)
+                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions2(bookFlip[index]), options.GeoM)
                     }
                 } else if index == 2 {
                     if flipRightSide < len(halfPages) {
                         rightSide := getHalfPageImage(flipRightSide)
-                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions1(bookFlip[index]), options)
+                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions1(bookFlip[index]), options.GeoM)
                     }
                 } else if index == 3 {
                     if flipRightSide < len(halfPages) {
                         rightSide := getHalfPageImage(flipRightSide)
-                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions2(bookFlip[index]), options)
+                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions2(bookFlip[index]), options.GeoM)
                     }
                 }
             }
@@ -849,28 +850,28 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
 func CastLeftSideDistortions1(page *ebiten.Image) util.Distortion {
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 + 25 * data.ScreenScale, 12 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 + 25 * data.ScreenScale, page.Bounds().Dy() - 4 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 + 25, 12),
+        Bottom: image.Pt(page.Bounds().Dx()/2 + 25, page.Bounds().Dy() - 4),
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, -5 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, page.Bounds().Dy() - 25 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 40, -5),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 40, page.Bounds().Dy() - 25),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 60 * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 60 * data.ScreenScale, page.Bounds().Dy() - 33 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 60, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 60, page.Bounds().Dy() - 33),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 80 * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 80 * data.ScreenScale, page.Bounds().Dy() - 30 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 80, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 80, page.Bounds().Dy() - 30),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 100 * data.ScreenScale, -3 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 100 * data.ScreenScale, page.Bounds().Dy() - 22 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 100, -3),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 100, page.Bounds().Dy() - 22),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 135 * data.ScreenScale, 16 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 135 * data.ScreenScale, page.Bounds().Dy() - 3 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 135, 16),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 135, page.Bounds().Dy() - 3),
             },
         },
     }
@@ -878,93 +879,93 @@ func CastLeftSideDistortions1(page *ebiten.Image) util.Distortion {
 
 func CastLeftSideDistortions2(page *ebiten.Image) util.Distortion {
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 + 25 * data.ScreenScale, 9 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 + 25 * data.ScreenScale, page.Bounds().Dy() - 2 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 + 25, 9),
+        Bottom: image.Pt(page.Bounds().Dx()/2 + 25, page.Bounds().Dy() - 2),
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, -12 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, page.Bounds().Dy() - 33 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 40, -12),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 40, page.Bounds().Dy() - 33),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 58 * data.ScreenScale, -13 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 58 * data.ScreenScale, page.Bounds().Dy() - 43 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 58, -13),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 58, page.Bounds().Dy() - 43),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 73 * data.ScreenScale, -20 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 73 * data.ScreenScale, page.Bounds().Dy() - 43 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 73, -20),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 73, page.Bounds().Dy() - 43),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 90 * data.ScreenScale, -3 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 90 * data.ScreenScale, page.Bounds().Dy() - 34 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 90, -3),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 90, page.Bounds().Dy() - 34),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 99 * data.ScreenScale, 1 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 99 * data.ScreenScale, page.Bounds().Dy() - 24 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 99, 1),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 99, page.Bounds().Dy() - 24),
             },
         },
     }
 }
 
 func CastRightSideDistortions1(page *ebiten.Image) util.Distortion {
-    offset := 60 * data.ScreenScale
+    offset := 60
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 - 110 * data.ScreenScale + offset - 3 * data.ScreenScale, 2 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 - 110 * data.ScreenScale + offset, page.Bounds().Dy() - 28 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 - 110 + offset - 3, 2),
+        Bottom: image.Pt(page.Bounds().Dx()/2 - 110 + offset, page.Bounds().Dy() - 28),
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 90 * data.ScreenScale + offset, -0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 90 * data.ScreenScale + offset, page.Bounds().Dy() - 43 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 90 + offset, -0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 90 + offset, page.Bounds().Dy() - 43),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 73 * data.ScreenScale + offset, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 73 * data.ScreenScale + offset, page.Bounds().Dy() - 43 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 73 + offset, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 73 + offset, page.Bounds().Dy() - 43),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 58 * data.ScreenScale + offset, -13 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 58 * data.ScreenScale + offset, page.Bounds().Dy() - 35 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 58 + offset, -13),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 58 + offset, page.Bounds().Dy() - 35),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 40 * data.ScreenScale + offset, 4 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 40 * data.ScreenScale + offset, page.Bounds().Dy() - 21 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 40 + offset, 4),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 40 + offset, page.Bounds().Dy() - 21),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 38 * data.ScreenScale + offset, 18 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 38 * data.ScreenScale + offset, page.Bounds().Dy() - 10 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 38 + offset, 18),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 38 + offset, page.Bounds().Dy() - 10),
             },
         },
     }
 }
 
 func CastRightSideDistortions2(page *ebiten.Image) util.Distortion {
-    offset := 40 * data.ScreenScale
+    offset := 40
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 - 130 * data.ScreenScale + offset + 2 * data.ScreenScale, 15 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 - 130 * data.ScreenScale + offset + 2 * data.ScreenScale, page.Bounds().Dy() - 3 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 - 130 + offset + 2, 15),
+        Bottom: image.Pt(page.Bounds().Dx()/2 - 130 + offset + 2, page.Bounds().Dy() - 3),
 
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 100 * data.ScreenScale + offset, -0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 100 * data.ScreenScale + offset, page.Bounds().Dy() - 18 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 100 + offset, -0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 100 + offset, page.Bounds().Dy() - 18),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 80 * data.ScreenScale + offset, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 80 * data.ScreenScale + offset, page.Bounds().Dy() - 27 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 80 + offset, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 80 + offset, page.Bounds().Dy() - 27),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 60 * data.ScreenScale + offset, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 60 * data.ScreenScale + offset, page.Bounds().Dy() - 31 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 60 + offset, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 60 + offset, page.Bounds().Dy() - 31),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 40 * data.ScreenScale + offset, -3 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 40 * data.ScreenScale + offset, page.Bounds().Dy() - 28 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 40 + offset, -3),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 40 + offset, page.Bounds().Dy() - 28),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 30 * data.ScreenScale + offset, -2 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 30 * data.ScreenScale + offset, page.Bounds().Dy() - 22 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 30 + offset, -2),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 30 + offset, page.Bounds().Dy() - 22),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 - 20 * data.ScreenScale + offset + 3, 15 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 - 20 * data.ScreenScale + offset + 1, page.Bounds().Dy() - 5 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 - 20 + offset + 3, 15),
+                Bottom: image.Pt(page.Bounds().Dx()/2 - 20 + offset + 1, page.Bounds().Dy() - 5),
             },
         },
     }
@@ -1195,14 +1196,14 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
     renderPage := func(screen *ebiten.Image, options ebiten.DrawImageOptions, page Page, highlightedSpell Spell){
         // section := spells.Spells[0].Section
 
-        titleX, titleY := options.GeoM.Apply(float64(60 * data.ScreenScale), float64(1 * data.ScreenScale))
+        titleX, titleY := options.GeoM.Apply(float64(60), float64(1))
 
-        titleFont.PrintCenter(screen, titleX, titleY, float64(data.ScreenScale), options.ColorScale, page.Title)
+        titleFont.PrintOptions2(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, page.Title)
         gibberish, _ := imageCache.GetImage("spells.lbx", 10, 0)
-        gibberishHeight := 18 * data.ScreenScale
+        gibberishHeight := 18
 
         options2 := options
-        options2.GeoM.Translate(0, float64(15 * data.ScreenScale))
+        options2.GeoM.Translate(0, 15)
         for _, spell := range page.Spells.Spells {
 
             // invalid spell?
@@ -1242,25 +1243,28 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 }
             }
 
-            infoFont.Print(screen, spellX, spellY, float64(data.ScreenScale), textColorScale, spell.Name)
-            infoFont.PrintRight(screen, spellX + float64(124 * data.ScreenScale), spellY, float64(data.ScreenScale), textColorScale, fmt.Sprintf("%v MP", costRemaining))
+            var textColorOptions ebiten.DrawImageOptions
+            textColorOptions.ColorScale = textColorScale
+
+            infoFont.PrintOptions2(screen, spellX, spellY, font.FontOptions{Options: &textColorOptions, Scale: scale.ScaleAmount}, spell.Name)
+            infoFont.PrintOptions2(screen, spellX + float64(124), spellY, font.FontOptions{Options: &textColorOptions, Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", costRemaining))
             icon := getMagicIcon(spell)
 
-            nameLength := infoFont.MeasureTextWidth(spell.Name, float64(data.ScreenScale)) + 1
-            mpLength := infoFont.MeasureTextWidth(fmt.Sprintf("%v MP", costRemaining), float64(data.ScreenScale))
+            nameLength := infoFont.MeasureTextWidth(spell.Name, 1) + 1
+            mpLength := infoFont.MeasureTextWidth(fmt.Sprintf("%v MP", costRemaining), 1)
 
             gibberishPart := gibberish.SubImage(image.Rect(0, 0, gibberish.Bounds().Dx(), gibberishHeight)).(*ebiten.Image)
 
             partIndex := 0
-            partHeight := 20 * data.ScreenScale
+            partHeight := 20
 
-            subLines := 6 * data.ScreenScale
+            subLines := 6
 
             part1 := gibberishPart.SubImage(image.Rect(int(nameLength), partIndex * partHeight, int(nameLength) + gibberishPart.Bounds().Dx() - int(nameLength + mpLength), partIndex * partHeight + subLines)).(*ebiten.Image)
 
             part1Options := options2
             part1Options.GeoM.Translate(nameLength, 0)
-            screen.DrawImage(part1, &part1Options)
+            screen.DrawImage(part1, scale.ScaleOptions(part1Options))
 
             iconCount := 0
 
@@ -1278,7 +1282,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             }
 
             iconOptions := spellOptions
-            iconOptions.GeoM.Translate(0, float64(infoFont.Height() * data.ScreenScale)+1)
+            iconOptions.GeoM.Translate(0, float64(infoFont.Height())+1)
             part3Options := iconOptions
 
             icons1 := iconCount
@@ -1296,7 +1300,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             icon1Width := 0
 
             for i := 0; i < icons1; i++ {
-                screen.DrawImage(icon, &iconOptions)
+                screen.DrawImage(icon, scale.ScaleOptions(iconOptions))
                 iconOptions.GeoM.Translate(float64(icon.Bounds().Dx()) + 1, 0)
                 icon1Width += icon.Bounds().Dx() + 1
             }
@@ -1304,27 +1308,27 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             if overland && costRemaining < castingSkill {
                 x, y := iconOptions.GeoM.Apply(0, 0)
                 x += 2
-                infoFont.Print(screen, x, y, float64(data.ScreenScale), spellOptions.ColorScale, "Instant")
-                icon1Width += int(infoFont.MeasureTextWidth("Instant", float64(data.ScreenScale))) + 2
-                iconOptions.GeoM.Translate(infoFont.MeasureTextWidth("Instant", float64(data.ScreenScale)) + 2, 0)
+                infoFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &spellOptions, Scale: scale.ScaleAmount}, "Instant")
+                icon1Width += int(infoFont.MeasureTextWidth("Instant", 1)) + 2
+                iconOptions.GeoM.Translate(infoFont.MeasureTextWidth("Instant", 1) + 2, 0)
             }
 
             part2 := gibberishPart.SubImage(image.Rect(icon1Width + 3, partIndex * partHeight + subLines, gibberish.Bounds().Dx(), partIndex * partHeight + subLines * 2)).(*ebiten.Image)
             part2Options := iconOptions
             part2Options.GeoM.Translate(3, 0)
-            screen.DrawImage(part2, &part2Options)
+            screen.DrawImage(part2, scale.ScaleOptions(part2Options))
 
             part3Options.GeoM.Translate(0, float64(icon.Bounds().Dy()+1))
 
             for i := 0; i < iconCount; i++ {
-                screen.DrawImage(icon, &part3Options)
+                screen.DrawImage(icon, scale.ScaleOptions(part3Options))
                 part3Options.GeoM.Translate(float64(icon.Bounds().Dx()) + 1, 0)
             }
 
             part3 := gibberishPart.SubImage(image.Rect((icon.Bounds().Dx() + 1) * iconCount, partIndex * partHeight + subLines * 2, gibberish.Bounds().Dx(), partIndex * partHeight + subLines * 3)).(*ebiten.Image)
-            screen.DrawImage(part3, &part3Options)
+            screen.DrawImage(part3, scale.ScaleOptions(part3Options))
 
-            options2.GeoM.Translate(0, float64(22 * data.ScreenScale))
+            options2.GeoM.Translate(0, 22)
         }
     }
 
@@ -1335,7 +1339,9 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             return cached
         }
 
-        out := ebiten.NewImage(120 * data.ScreenScale, 154 * data.ScreenScale)
+        width, height := scale.Scale2(120, 154)
+
+        out := ebiten.NewImage(width, height)
         out.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 0})
 
         if page < len(spellPages) {
@@ -1435,7 +1441,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             width := 122
             height := 20
 
-            rect := image.Rect(0, 0, width * data.ScreenScale, height * data.ScreenScale).Add(image.Pt(x1 * data.ScreenScale, y1 * data.ScreenScale))
+            rect := image.Rect(0, 0, width, height).Add(image.Pt(x1, y1))
             spellButtons = append(spellButtons, makeSpell(rect, spell))
         }
 
@@ -1448,7 +1454,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 width := 122
                 height := 20
 
-                rect := image.Rect(0, 0, width * data.ScreenScale, height * data.ScreenScale).Add(image.Pt(x1 * data.ScreenScale, y1 * data.ScreenScale))
+                rect := image.Rect(0, 0, width, height).Add(image.Pt(x1, y1))
                 spellButtons = append(spellButtons, makeSpell(rect, spell))
             }
         }
@@ -1543,17 +1549,17 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             background, _ := imageCache.GetImage("spells.lbx", 0, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(10 * data.ScreenScale), float64(10 * data.ScreenScale))
-            screen.DrawImage(background, &options)
+            options.GeoM.Translate(10, 10)
+            screen.DrawImage(background, scale.ScaleOptions(options))
 
             flipOptions := options
 
             if flipping {
-                options.GeoM.Translate(float64(15 * data.ScreenScale), float64(5 * data.ScreenScale))
+                options.GeoM.Translate(15, 5)
                 renderPage(screen, options, spellPages[showPageLeft], Spell{})
 
                 if showPageRight < len(spellPages) {
-                    options.GeoM.Translate(float64(134 * data.ScreenScale), 0)
+                    options.GeoM.Translate(134, 0)
                     renderPage(screen, options, spellPages[showPageRight], Spell{})
                 }
 
@@ -1565,40 +1571,40 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
 
                     // index = 3
 
-                    flipOptions.GeoM.Translate(float64(-17 * data.ScreenScale), float64(-10 * data.ScreenScale))
-                    screen.DrawImage(bookFlip[index], &flipOptions)
+                    flipOptions.GeoM.Translate(-17, -10)
+                    screen.DrawImage(bookFlip[index], scale.ScaleOptions(flipOptions))
 
                     if index == 0 {
                         if pageSideLeft >= 0 {
                             leftSide := getPageImage(pageSideLeft)
-                            util.DrawDistortion(screen, bookFlip[index], leftSide, CastLeftSideDistortions1(bookFlip[index]), flipOptions)
+                            util.DrawDistortion(screen, bookFlip[index], leftSide, CastLeftSideDistortions1(bookFlip[index]), scale.ScaleGeom(flipOptions.GeoM))
                         }
                     } else if index == 1 {
                         if pageSideLeft >= 0 {
                             leftSide := getPageImage(pageSideLeft)
-                            util.DrawDistortion(screen, bookFlip[index], leftSide, CastLeftSideDistortions2(bookFlip[index]), flipOptions)
+                            util.DrawDistortion(screen, bookFlip[index], leftSide, CastLeftSideDistortions2(bookFlip[index]), scale.ScaleGeom(flipOptions.GeoM))
                         }
                     } else if index == 2 {
                         if pageSideRight < len(spellPages) {
                             rightSide := getPageImage(pageSideRight)
-                            util.DrawDistortion(screen, bookFlip[index], rightSide, CastRightSideDistortions1(bookFlip[index]), flipOptions)
+                            util.DrawDistortion(screen, bookFlip[index], rightSide, CastRightSideDistortions1(bookFlip[index]), scale.ScaleGeom(flipOptions.GeoM))
                         }
                     } else if index == 3 {
                         if pageSideRight < len(spellPages) {
                             rightSide := getPageImage(pageSideRight)
-                            util.DrawDistortion(screen, bookFlip[index], rightSide, CastRightSideDistortions2(bookFlip[index]), flipOptions)
+                            util.DrawDistortion(screen, bookFlip[index], rightSide, CastRightSideDistortions2(bookFlip[index]), scale.ScaleGeom(flipOptions.GeoM))
                         }
                     }
                 }
 
             } else {
-                options.GeoM.Translate(float64(15 * data.ScreenScale), float64(5 * data.ScreenScale))
+                options.GeoM.Translate(15, 5)
                 if currentPage < len(spellPages) {
                     renderPage(screen, options, spellPages[currentPage], highlightedSpell)
                 }
 
                 if currentPage + 1 < len(spellPages) {
-                    options.GeoM.Translate(float64(134 * data.ScreenScale), 0)
+                    options.GeoM.Translate(134, 0)
                     // screen.DrawImage(right, &options)
                     renderPage(screen, options, spellPages[currentPage+1], highlightedSpell)
                 }
@@ -1606,7 +1612,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
         },
     })
 
-    cancelRect := image.Rect(0, 0, 18 * data.ScreenScale, 25 * data.ScreenScale).Add(image.Pt(170 * data.ScreenScale, 170 * data.ScreenScale))
+    cancelRect := image.Rect(0, 0, 18, 25).Add(image.Pt(170, 170))
     elements = append(elements, &uilib.UIElement{
         Rect: cancelRect,
         Layer: 1,
@@ -1624,7 +1630,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
     })
 
     pageTurnRight, _ := imageCache.GetImage("spells.lbx", 2, 0)
-    pageTurnRightRect := image.Rect(0, 0, pageTurnRight.Bounds().Dx(), pageTurnRight.Bounds().Dy()).Add(image.Pt(268 * data.ScreenScale, 14 * data.ScreenScale))
+    pageTurnRightRect := image.Rect(0, 0, pageTurnRight.Bounds().Dx(), pageTurnRight.Bounds().Dy()).Add(image.Pt(268, 14))
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
         Rect: pageTurnRightRect,
@@ -1651,13 +1657,13 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(pageTurnRightRect.Min.X), float64(pageTurnRightRect.Min.Y))
-                screen.DrawImage(pageTurnRight, &options)
+                screen.DrawImage(pageTurnRight, scale.ScaleOptions(options))
             }
         },
     })
 
     pageTurnLeft, _ := imageCache.GetImage("spells.lbx", 1, 0)
-    pageTurnLeftRect := image.Rect(0, 0, pageTurnLeft.Bounds().Dx(), pageTurnLeft.Bounds().Dy()).Add(image.Pt(23 * data.ScreenScale, 14 * data.ScreenScale))
+    pageTurnLeftRect := image.Rect(0, 0, pageTurnLeft.Bounds().Dx(), pageTurnLeft.Bounds().Dy()).Add(image.Pt(23, 14))
     elements = append(elements, &uilib.UIElement{
         Rect: pageTurnLeftRect,
         Layer: 1,
@@ -1684,7 +1690,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(pageTurnLeftRect.Min.X), float64(pageTurnLeftRect.Min.Y))
-                screen.DrawImage(pageTurnLeft, &options)
+                screen.DrawImage(pageTurnLeft, scale.ScaleOptions(options))
             }
 
         },

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -64,28 +64,28 @@ func computeHalfPages(spells Spells, max int) []Page {
 // flipping the page to the left
 func LeftSideDistortions1(page *ebiten.Image) util.Distortion {
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 + 20 * data.ScreenScale, 5 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 + 20 * data.ScreenScale, page.Bounds().Dy() - 12 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 + 20, 5),
+        Bottom: image.Pt(page.Bounds().Dx()/2 + 20, page.Bounds().Dy() - 12),
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, 0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, page.Bounds().Dy() - 25 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 40, 0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 40, page.Bounds().Dy() - 25),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 60 * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 60 * data.ScreenScale, page.Bounds().Dy() - 33 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 60, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 60, page.Bounds().Dy() - 33),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 80 * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 80 * data.ScreenScale, page.Bounds().Dy() - 30 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 80, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 80, page.Bounds().Dy() - 30),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 100 * data.ScreenScale, -0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 100 * data.ScreenScale, page.Bounds().Dy() - 22 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 100, -0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 100, page.Bounds().Dy() - 22),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 130 * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 130 * data.ScreenScale, page.Bounds().Dy() - 12 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 130, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 130, page.Bounds().Dy() - 12),
             },
         },
     }
@@ -93,28 +93,28 @@ func LeftSideDistortions1(page *ebiten.Image) util.Distortion {
 
 func LeftSideDistortions2(page *ebiten.Image) util.Distortion {
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 + 20 * data.ScreenScale, 5 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 + 20 * data.ScreenScale, page.Bounds().Dy() - 15 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 + 20, 5),
+        Bottom: image.Pt(page.Bounds().Dx()/2 + 20, page.Bounds().Dy() - 15),
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, 0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 40 * data.ScreenScale, page.Bounds().Dy() - 28 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 40, 0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 40, page.Bounds().Dy() - 28),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 58 * data.ScreenScale, -13 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 58 * data.ScreenScale, page.Bounds().Dy() - 35 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 58, -13),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 58, page.Bounds().Dy() - 35),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 73 * data.ScreenScale, -20 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 73 * data.ScreenScale, page.Bounds().Dy() - 35 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 73, -20),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 73, page.Bounds().Dy() - 35),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 90 * data.ScreenScale, -0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 90 * data.ScreenScale, page.Bounds().Dy() - 22 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 90, -0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 90, page.Bounds().Dy() - 22),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + 120 * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + 120 * data.ScreenScale, page.Bounds().Dy() - 12 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + 120, -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + 120, page.Bounds().Dy() - 12),
             },
         },
     }
@@ -123,29 +123,29 @@ func LeftSideDistortions2(page *ebiten.Image) util.Distortion {
 func RightSideDistortions2(page *ebiten.Image) util.Distortion {
     offset := 30
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 + (offset - 130) * data.ScreenScale, 5 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 130) * data.ScreenScale, page.Bounds().Dy() - 0),
+        Top: image.Pt(page.Bounds().Dx()/2 + (offset - 130), 5),
+        Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 130), page.Bounds().Dy() - 0),
 
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 100) * data.ScreenScale, -0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 100) * data.ScreenScale, page.Bounds().Dy() - 22 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 100), -0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 100), page.Bounds().Dy() - 22),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 80) * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 80) * data.ScreenScale, page.Bounds().Dy() - 30 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 80), -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 80), page.Bounds().Dy() - 30),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 60) * data.ScreenScale, -10 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 60) * data.ScreenScale, page.Bounds().Dy() - 33 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 60), -10),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 60), page.Bounds().Dy() - 33),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 40) * data.ScreenScale, 0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 40) * data.ScreenScale, page.Bounds().Dy() - 25 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 40), 0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 40), page.Bounds().Dy() - 25),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 20) * data.ScreenScale, 5 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 20) * data.ScreenScale, page.Bounds().Dy() - 12 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 20), 5),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 20), page.Bounds().Dy() - 12),
             },
         },
     }
@@ -154,28 +154,28 @@ func RightSideDistortions2(page *ebiten.Image) util.Distortion {
 func RightSideDistortions1(page *ebiten.Image) util.Distortion {
     offset := 50
     return util.Distortion{
-        Top: image.Pt(page.Bounds().Dx()/2 + (offset - 110) * data.ScreenScale, -10 * data.ScreenScale),
-        Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 110) * data.ScreenScale, page.Bounds().Dy() - 12 * data.ScreenScale),
+        Top: image.Pt(page.Bounds().Dx()/2 + (offset - 110), -10),
+        Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 110), page.Bounds().Dy() - 12),
         Segments: []util.Segment{
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 90) * data.ScreenScale, -0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 90) * data.ScreenScale, page.Bounds().Dy() - 22 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 90), -0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 90), page.Bounds().Dy() - 22),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 73) * data.ScreenScale, -20 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 73) * data.ScreenScale, page.Bounds().Dy() - 35 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 73), -20),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 73), page.Bounds().Dy() - 35),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 58) * data.ScreenScale, -13 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 58) * data.ScreenScale, page.Bounds().Dy() - 35 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 58), -13),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 58), page.Bounds().Dy() - 35),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 40) * data.ScreenScale, 0),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 40) * data.ScreenScale, page.Bounds().Dy() - 28 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 40), 0),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 40), page.Bounds().Dy() - 28),
             },
             util.Segment{
-                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 20) * data.ScreenScale, 5 * data.ScreenScale),
-                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 20) * data.ScreenScale, page.Bounds().Dy() - 15 * data.ScreenScale),
+                Top: image.Pt(page.Bounds().Dx()/2 + (offset - 20), 5),
+                Bottom: image.Pt(page.Bounds().Dx()/2 + (offset - 20), page.Bounds().Dy() - 15),
             },
         },
     }
@@ -348,7 +348,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
     // page 0 would be left: summoning spells 1-4, right: summoning spell 5
     // page 1 would be left: unit spells 1-2, right: empty
 
-    wrapWidth := float64(130 * data.ScreenScale)
+    wrapWidth := float64(130)
 
     spellDescriptionNormalCache := make(map[int]font.WrappedText)
 
@@ -358,7 +358,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             return text
         }
 
-        wrapped := spellTextNormalFont.CreateWrappedText(wrapWidth, float64(data.ScreenScale), spellDescriptions[index])
+        wrapped := spellTextNormalFont.CreateWrappedText(wrapWidth, 1, spellDescriptions[index])
         spellDescriptionNormalCache[index] = wrapped
         return wrapped
     }
@@ -371,7 +371,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             return text
         }
 
-        wrapped := spellTextAlienFont.CreateWrappedText(wrapWidth, float64(data.ScreenScale), spellDescriptions[index])
+        wrapped := spellTextAlienFont.CreateWrappedText(wrapWidth, 1, spellDescriptions[index])
         spellDescriptionAlienCache[index] = wrapped
         return wrapped
     }
@@ -444,36 +444,36 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             // options.GeoM.Translate(0, 0)
 
             // section := pageSpells.Spells[0].Section
-            titleX, titleY := options.GeoM.Apply(float64(90 * data.ScreenScale), float64(11 * data.ScreenScale))
+            titleX, titleY := options.GeoM.Apply(float64(90), float64(11))
 
-            titleFont.PrintCenter(pageImage, titleX, titleY, float64(data.ScreenScale), options.ColorScale, page.Title)
+            titleFont.PrintOptions2(pageImage, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, page.Title)
 
-            x, topY := options.GeoM.Apply(float64(25 * data.ScreenScale), float64(35 * data.ScreenScale))
+            x, topY := options.GeoM.Apply(float64(25), float64(35))
 
             for i, spell := range page.Spells.Spells {
                 if i >= 4 {
                     break
                 }
 
-                y := topY + float64(i * 35 * data.ScreenScale)
+                y := topY + float64(i * 35)
 
                 spellY := y
 
                 if page.IsResearch || knownSpell(spell) || learnedSpell.Name == spell.Name {
-                    scale := options.ColorScale
+                    var scaleOptions ebiten.DrawImageOptions
 
                     if !flipping {
 
                         if researchingSpell.Name == spell.Name {
                             v := 1.5 + (math.Cos(float64(ui.Counter) / 7) * 64 + 64) / float64(64)
-                            scale.SetR(float32(v))
-                            scale.SetG(float32(v))
-                            scale.SetB(float32(v) * 1.8)
+                            scaleOptions.ColorScale.SetR(float32(v))
+                            scaleOptions.ColorScale.SetG(float32(v))
+                            scaleOptions.ColorScale.SetB(float32(v) * 1.8)
                         } else if learnedSpell.Name == spell.Name && !learnSpellAnimation.Done() {
                             v := 1.5 + float64(ui.Counter) / 32
-                            scale.SetR(float32(v))
-                            scale.SetG(float32(v))
-                            scale.SetB(float32(v) * 1.8)
+                            scaleOptions.ColorScale.SetR(float32(v))
+                            scaleOptions.ColorScale.SetG(float32(v))
+                            scaleOptions.ColorScale.SetB(float32(v) * 1.8)
                         } else if pickResearchSpell {
                             hover, ok := hoverTime[spell.Name]
                             if ok {
@@ -483,11 +483,11 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                                     if v > max {
                                         v = max
                                     }
-                                    scale.SetR(v)
+                                    scaleOptions.ColorScale.SetR(v)
                                 } else if hover.Off > 0 {
                                     v := max - float32(ui.Counter - hover.Off) / 3
                                     if v > 0 {
-                                        scale.SetR(v)
+                                        scaleOptions.ColorScale.SetR(v)
                                     }
                                 }
                             }
@@ -495,8 +495,8 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
                     }
 
-                    spellTitleNormalFont.Print(pageImage, x, y, float64(data.ScreenScale), scale, spell.Name)
-                    y += float64(spellTitleNormalFont.Height() * data.ScreenScale)
+                    spellTitleNormalFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, spell.Name)
+                    y += float64(spellTitleNormalFont.Height())
 
                     if page.IsResearch {
                         turns := spell.ResearchCost / researchPoints
@@ -510,8 +510,8 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                         if turns > 1 {
                             turnString = "turns"
                         }
-                        spellTextNormalFont.Print(pageImage, x, y, float64(data.ScreenScale), scale, fmt.Sprintf("Research Cost:%v (%v %v)", spell.ResearchCost, turns, turnString))
-                        y += float64(spellTextNormalFont.Height() * data.ScreenScale)
+                        spellTextNormalFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Research Cost:%v (%v %v)", spell.ResearchCost, turns, turnString))
+                        y += float64(spellTextNormalFont.Height())
                     } else {
                         turns := spell.Cost(true) / castingSkill
                         if turns < 1 {
@@ -521,24 +521,24 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                         if turns > 1 {
                             turnString = "turns"
                         }
-                        spellTextNormalFont.Print(pageImage, x, y, float64(data.ScreenScale), scale, fmt.Sprintf("Casting cost:%v (%v %v)", spell.Cost(true), turns, turnString))
-                        y += float64(spellTextNormalFont.Height() * data.ScreenScale)
+                        spellTextNormalFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Casting cost:%v (%v %v)", spell.Cost(true), turns, turnString))
+                        y += float64(spellTextNormalFont.Height())
                     }
 
                     wrapped := getSpellDescriptionNormalText(spell.Index)
-                    spellTextNormalFont.RenderWrapped(pageImage, x, y, wrapped, scale, font.FontOptions{})
+                    spellTextNormalFont.RenderWrapped(pageImage, x, y, wrapped, ebiten.ColorScale{}, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions})
 
                     if !flipping && learnedSpell.Name == spell.Name && !learnSpellAnimation.Done() {
                         animationOptions := options
                         animationOptions.GeoM.Reset()
                         animationOptions.GeoM.Translate(x, spellY - 2)
-                        pageImage.DrawImage(learnSpellAnimation.Frame(), &animationOptions)
+                        scale.DrawScaled(pageImage, learnSpellAnimation.Frame(), &animationOptions)
                     }
 
                 } else {
-                    spellTitleAlienFont.Print(pageImage, x, y, float64(data.ScreenScale), options.ColorScale, spell.Name)
+                    spellTitleAlienFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, spell.Name)
                     wrapped := getSpellDescriptionAlienText(spell.Index)
-                    spellTextAlienFont.RenderWrapped(pageImage, x, y + float64(10 * data.ScreenScale), wrapped, options.ColorScale, font.FontOptions{})
+                    spellTextAlienFont.RenderWrapped(pageImage, x, y + float64(10), wrapped, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
                 }
             }
         }
@@ -551,7 +551,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             return image
         }
 
-        pageImage := ebiten.NewImage(155, 170)
+        pageImage := ebiten.NewImage(scale.Scale2(155, 170))
         pageImage.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 0})
 
         if halfPage < len(halfPages) {
@@ -621,10 +621,10 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
             newIndex := -1
 
-            if posY >= 35 * data.ScreenScale && posY < (35 + 35 * 4) * data.ScreenScale {
-                newIndex = (posY - 35 * data.ScreenScale) / (35 * data.ScreenScale)
+            if posY >= 35 && posY < (35 + 35 * 4) {
+                newIndex = (posY - 35) / (35)
 
-                if posX >= 160 * data.ScreenScale {
+                if posX >= 160 {
                     newIndex += 4
                 }
             } else {
@@ -706,7 +706,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(background, &options)
+            scale.DrawScaled(screen, background, &options)
 
             if showLeftPage >= 0 {
                 renderPage(halfPages[showLeftPage], false, screen, options)
@@ -714,8 +714,8 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
             if showRightPage < len(halfPages) {
                 rightOptions := options
-                rightOptions.GeoM.Translate(float64(148 * data.ScreenScale), 0)
-                rightPage := screen.SubImage(image.Rect(148 * data.ScreenScale, 0, screen.Bounds().Dx(), screen.Bounds().Dy())).(*ebiten.Image)
+                rightOptions.GeoM.Translate(float64(148), 0)
+                rightPage := screen.SubImage(scale.ScaleRect(image.Rect(148, 0, screen.Bounds().Dx(), screen.Bounds().Dy()))).(*ebiten.Image)
                 renderPage(halfPages[showRightPage], false, rightPage, rightOptions)
             }
 
@@ -726,33 +726,33 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                     index = uint64(len(bookFlip)) - 1 - index
                 }
                 options.GeoM.Translate(0, 0)
-                screen.DrawImage(bookFlip[index], &options)
+                scale.DrawScaled(screen, bookFlip[index], &options)
 
                 if index == 0 {
                     if flipLeftSide >= 0 {
                         leftSide := getHalfPageImage(flipLeftSide)
-                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions1(bookFlip[index]), options.GeoM)
+                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions1(bookFlip[index]), scale.ScaleGeom(options.GeoM))
                     }
                 } else if index == 1 {
                     if flipLeftSide >= 0 {
                         leftSide := getHalfPageImage(flipLeftSide)
-                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions2(bookFlip[index]), options.GeoM)
+                        util.DrawDistortion(screen, bookFlip[index], leftSide, LeftSideDistortions2(bookFlip[index]), scale.ScaleGeom(options.GeoM))
                     }
                 } else if index == 2 {
                     if flipRightSide < len(halfPages) {
                         rightSide := getHalfPageImage(flipRightSide)
-                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions1(bookFlip[index]), options.GeoM)
+                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions1(bookFlip[index]), scale.ScaleGeom(options.GeoM))
                     }
                 } else if index == 3 {
                     if flipRightSide < len(halfPages) {
                         rightSide := getHalfPageImage(flipRightSide)
-                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions2(bookFlip[index]), options.GeoM)
+                        util.DrawDistortion(screen, bookFlip[index], rightSide, RightSideDistortions2(bookFlip[index]), scale.ScaleGeom(options.GeoM))
                     }
                 }
             }
 
             if pickResearchSpell {
-                chooseFont.PrintCenter(screen, float64(160 * data.ScreenScale), float64(180 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, "Choose a new spell to research")
+                chooseFont.PrintOptions2(screen, 160, 180, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Choose a new spell to research")
             }
 
         },
@@ -795,7 +795,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
     // left page turn
     leftTurn, _ := imageCache.GetImage("scroll.lbx", 7, 0)
-    leftRect := util.ImageRect(15 * data.ScreenScale, 9 * data.ScreenScale, leftTurn)
+    leftRect := util.ImageRect(15, 9, leftTurn)
     elements = append(elements, &uilib.UIElement{
         Rect: leftRect,
         LeftClick: func(this *uilib.UIElement){
@@ -806,14 +806,14 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(leftRect.Min.X), float64(leftRect.Min.Y))
                 options.ColorScale.ScaleAlpha(getAlpha())
-                screen.DrawImage(leftTurn, &options)
+                scale.DrawScaled(screen, leftTurn, &options)
             }
         },
     })
 
     // right page turn
     rightTurn, _ := imageCache.GetImage("scroll.lbx", 8, 0)
-    rightRect := util.ImageRect(289 * data.ScreenScale, 9 * data.ScreenScale, rightTurn)
+    rightRect := util.ImageRect(289, 9, rightTurn)
     elements = append(elements, &uilib.UIElement{
         Rect: rightRect,
         LeftClick: func(this *uilib.UIElement){
@@ -824,7 +824,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(rightRect.Min.X), float64(rightRect.Min.Y))
                 options.ColorScale.ScaleAlpha(getAlpha())
-                screen.DrawImage(rightTurn, &options)
+                scale.DrawScaled(screen, rightTurn, &options)
             }
         },
     })
@@ -994,13 +994,13 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
             background, _ := imageCache.GetImage("spellscr.lbx", 5, 0)
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(x * data.ScreenScale), float64(y * data.ScreenScale))
-            screen.DrawImage(background, &options)
+            options.GeoM.Translate(float64(x), float64(y))
+            scale.DrawScaled(screen, background, &options)
 
-            mx, my := options.GeoM.Apply(float64(8 * data.ScreenScale), float64(6 * data.ScreenScale))
-            fonts.BigOrange.Print(screen, mx, my, float64(data.ScreenScale), options.ColorScale, "Additional Power:")
-            mx, _ = options.GeoM.Apply(float64(background.Bounds().Dx() - 6 * data.ScreenScale), 0)
-            fonts.BigOrange.PrintRight(screen, mx, my, float64(data.ScreenScale), options.ColorScale, fmt.Sprintf("+%v", math.Round(amount)))
+            mx, my := options.GeoM.Apply(float64(8), float64(6))
+            fonts.BigOrange.PrintOptions2(screen, mx, my, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, "Additional Power:")
+            mx, _ = options.GeoM.Apply(float64(background.Bounds().Dx() - 6), 0)
+            fonts.BigOrange.PrintOptions2(screen, mx, my, font.FontOptions{Scale: scale.ScaleAmount, Options: &options, Justify: font.FontJustifyRight}, fmt.Sprintf("+%v", math.Round(amount)))
         },
         Order: 0,
     })
@@ -1009,7 +1009,7 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
     conveyor, _ := imageCache.GetImageTransform("spellscr.lbx", 4, 0, "conveyor", func (img *image.Paletted) image.Image {
         return img.SubImage(image.Rect(0, 0, img.Bounds().Dx() - 6, img.Bounds().Dy()))
     })
-    conveyorRect := util.ImageRect((x + 12) * data.ScreenScale, (y + 22) * data.ScreenScale, conveyor)
+    conveyorRect := util.ImageRect((x + 12), (y + 22), conveyor)
     conveyorX := 0
     doUpdate := false
     group.AddElement(&uilib.UIElement{
@@ -1031,22 +1031,22 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             showRect := conveyorRect
             showRect.Max.X = showRect.Min.X + int((float64(conveyor.Bounds().Dx()) * float64(amount) / float64(maximum)))
-            area := screen.SubImage(showRect).(*ebiten.Image)
+            area := screen.SubImage(scale.ScaleRect(showRect)).(*ebiten.Image)
 
             motion := (group.Counter) % uint64(conveyor.Bounds().Dx())
 
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
             options.GeoM.Translate(float64(conveyorRect.Min.X - conveyor.Bounds().Dx() + int(motion)), float64(conveyorRect.Min.Y))
-            area.DrawImage(conveyor, &options)
+            scale.DrawScaled(area, conveyor, &options)
             options.GeoM.Reset()
             options.GeoM.Translate(float64(conveyorRect.Min.X + int(motion)), float64(conveyorRect.Min.Y))
-            area.DrawImage(conveyor, &options)
+            scale.DrawScaled(area, conveyor, &options)
 
             star, _ := imageCache.GetImage("spellscr.lbx", 3, 0)
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(conveyorRect.Min.X) + float64(conveyor.Bounds().Dx()) * amount / float64(maximum) - float64(3 * data.ScreenScale), float64(conveyorRect.Min.Y - 1 * data.ScreenScale))
-            screen.DrawImage(star, &options)
+            options.GeoM.Translate(float64(conveyorRect.Min.X) + float64(conveyor.Bounds().Dx()) * amount / float64(maximum) - float64(3), float64(conveyorRect.Min.Y - 1))
+            scale.DrawScaled(screen, star, &options)
 
             // vector.StrokeRect(area, float32(conveyorRect.Min.X), float32(conveyorRect.Min.Y), float32(conveyorRect.Bounds().Dx()), float32(conveyorRect.Bounds().Dy()), 2, color.RGBA{R: 255, G: 255, B: 255, A: 255}, false)
         },
@@ -1055,7 +1055,7 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
     // ok button
     okIndex := 0
     okImages, _ := imageCache.GetImages("spellscr.lbx", 42)
-    okRect := util.ImageRect((x + 127) * data.ScreenScale, (y + 17) * data.ScreenScale, okImages[0])
+    okRect := util.ImageRect((x + 127), (y + 17), okImages[0])
     group.AddElement(&uilib.UIElement{
         Layer: layer,
         Rect: okRect,
@@ -1063,7 +1063,7 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(okRect.Min.X), float64(okRect.Min.Y))
             options.ColorScale.ScaleAlpha(getAlpha())
-            screen.DrawImage(okImages[okIndex], &options)
+            scale.DrawScaled(screen, okImages[okIndex], &options)
         },
         LeftClick: func(element *uilib.UIElement){
             okIndex = 1
@@ -1264,7 +1264,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
 
             part1Options := options2
             part1Options.GeoM.Translate(nameLength, 0)
-            screen.DrawImage(part1, scale.ScaleOptions(part1Options))
+            scale.DrawScaled(screen, part1, &part1Options)
 
             iconCount := 0
 
@@ -1300,7 +1300,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             icon1Width := 0
 
             for i := 0; i < icons1; i++ {
-                screen.DrawImage(icon, scale.ScaleOptions(iconOptions))
+                scale.DrawScaled(screen, icon, &iconOptions)
                 iconOptions.GeoM.Translate(float64(icon.Bounds().Dx()) + 1, 0)
                 icon1Width += icon.Bounds().Dx() + 1
             }
@@ -1316,17 +1316,17 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             part2 := gibberishPart.SubImage(image.Rect(icon1Width + 3, partIndex * partHeight + subLines, gibberish.Bounds().Dx(), partIndex * partHeight + subLines * 2)).(*ebiten.Image)
             part2Options := iconOptions
             part2Options.GeoM.Translate(3, 0)
-            screen.DrawImage(part2, scale.ScaleOptions(part2Options))
+            scale.DrawScaled(screen, part2, &part2Options)
 
             part3Options.GeoM.Translate(0, float64(icon.Bounds().Dy()+1))
 
             for i := 0; i < iconCount; i++ {
-                screen.DrawImage(icon, scale.ScaleOptions(part3Options))
+                scale.DrawScaled(screen, icon, &part3Options)
                 part3Options.GeoM.Translate(float64(icon.Bounds().Dx()) + 1, 0)
             }
 
             part3 := gibberishPart.SubImage(image.Rect((icon.Bounds().Dx() + 1) * iconCount, partIndex * partHeight + subLines * 2, gibberish.Bounds().Dx(), partIndex * partHeight + subLines * 3)).(*ebiten.Image)
-            screen.DrawImage(part3, scale.ScaleOptions(part3Options))
+            scale.DrawScaled(screen, part3, &part3Options)
 
             options2.GeoM.Translate(0, 22)
         }
@@ -1339,9 +1339,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             return cached
         }
 
-        width, height := scale.Scale2(120, 154)
-
-        out := ebiten.NewImage(width, height)
+        out := ebiten.NewImage(scale.Scale2(120, 154))
         out.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 0})
 
         if page < len(spellPages) {
@@ -1550,7 +1548,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
             options.GeoM.Translate(10, 10)
-            screen.DrawImage(background, scale.ScaleOptions(options))
+            scale.DrawScaled(screen, background, &options)
 
             flipOptions := options
 
@@ -1572,7 +1570,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                     // index = 3
 
                     flipOptions.GeoM.Translate(-17, -10)
-                    screen.DrawImage(bookFlip[index], scale.ScaleOptions(flipOptions))
+                    scale.DrawScaled(screen, bookFlip[index], &flipOptions)
 
                     if index == 0 {
                         if pageSideLeft >= 0 {
@@ -1657,7 +1655,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(pageTurnRightRect.Min.X), float64(pageTurnRightRect.Min.Y))
-                screen.DrawImage(pageTurnRight, scale.ScaleOptions(options))
+                scale.DrawScaled(screen, pageTurnRight, &options)
             }
         },
     })
@@ -1690,7 +1688,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(getAlpha())
                 options.GeoM.Translate(float64(pageTurnLeftRect.Min.X), float64(pageTurnLeftRect.Min.Y))
-                screen.DrawImage(pageTurnLeft, scale.ScaleOptions(options))
+                scale.DrawScaled(screen, pageTurnLeft, &options)
             }
 
         },

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -446,7 +446,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             // section := pageSpells.Spells[0].Section
             titleX, titleY := options.GeoM.Apply(float64(90), float64(11))
 
-            titleFont.PrintOptions2(pageImage, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, page.Title)
+            titleFont.PrintOptions(pageImage, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, page.Title)
 
             x, topY := options.GeoM.Apply(float64(25), float64(35))
 
@@ -495,7 +495,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
 
                     }
 
-                    spellTitleNormalFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, spell.Name)
+                    spellTitleNormalFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, spell.Name)
                     y += float64(spellTitleNormalFont.Height())
 
                     if page.IsResearch {
@@ -510,7 +510,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                         if turns > 1 {
                             turnString = "turns"
                         }
-                        spellTextNormalFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Research Cost:%v (%v %v)", spell.ResearchCost, turns, turnString))
+                        spellTextNormalFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Research Cost:%v (%v %v)", spell.ResearchCost, turns, turnString))
                         y += float64(spellTextNormalFont.Height())
                     } else {
                         turns := spell.Cost(true) / castingSkill
@@ -521,7 +521,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                         if turns > 1 {
                             turnString = "turns"
                         }
-                        spellTextNormalFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Casting cost:%v (%v %v)", spell.Cost(true), turns, turnString))
+                        spellTextNormalFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Casting cost:%v (%v %v)", spell.Cost(true), turns, turnString))
                         y += float64(spellTextNormalFont.Height())
                     }
 
@@ -536,7 +536,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                     }
 
                 } else {
-                    spellTitleAlienFont.PrintOptions2(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, spell.Name)
+                    spellTitleAlienFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, spell.Name)
                     wrapped := getSpellDescriptionAlienText(spell.Index)
                     spellTextAlienFont.RenderWrapped(pageImage, x, y + float64(10), wrapped, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
                 }
@@ -752,7 +752,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
             }
 
             if pickResearchSpell {
-                chooseFont.PrintOptions2(screen, 160, 180, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Choose a new spell to research")
+                chooseFont.PrintOptions(screen, 160, 180, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, "Choose a new spell to research")
             }
 
         },
@@ -998,9 +998,9 @@ func makeAdditionalPowerElements(cache *lbx.LbxCache, imageCache *util.ImageCach
             scale.DrawScaled(screen, background, &options)
 
             mx, my := options.GeoM.Apply(float64(8), float64(6))
-            fonts.BigOrange.PrintOptions2(screen, mx, my, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, "Additional Power:")
+            fonts.BigOrange.PrintOptions(screen, mx, my, font.FontOptions{Scale: scale.ScaleAmount, Options: &options}, "Additional Power:")
             mx, _ = options.GeoM.Apply(float64(background.Bounds().Dx() - 6), 0)
-            fonts.BigOrange.PrintOptions2(screen, mx, my, font.FontOptions{Scale: scale.ScaleAmount, Options: &options, Justify: font.FontJustifyRight}, fmt.Sprintf("+%v", math.Round(amount)))
+            fonts.BigOrange.PrintOptions(screen, mx, my, font.FontOptions{Scale: scale.ScaleAmount, Options: &options, Justify: font.FontJustifyRight}, fmt.Sprintf("+%v", math.Round(amount)))
         },
         Order: 0,
     })
@@ -1198,7 +1198,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
 
         titleX, titleY := options.GeoM.Apply(float64(60), float64(1))
 
-        titleFont.PrintOptions2(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, page.Title)
+        titleFont.PrintOptions(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, page.Title)
         gibberish, _ := imageCache.GetImage("spells.lbx", 10, 0)
         gibberishHeight := 18
 
@@ -1246,8 +1246,8 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             var textColorOptions ebiten.DrawImageOptions
             textColorOptions.ColorScale = textColorScale
 
-            infoFont.PrintOptions2(screen, spellX, spellY, font.FontOptions{Options: &textColorOptions, Scale: scale.ScaleAmount}, spell.Name)
-            infoFont.PrintOptions2(screen, spellX + float64(124), spellY, font.FontOptions{Options: &textColorOptions, Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", costRemaining))
+            infoFont.PrintOptions(screen, spellX, spellY, font.FontOptions{Options: &textColorOptions, Scale: scale.ScaleAmount}, spell.Name)
+            infoFont.PrintOptions(screen, spellX + float64(124), spellY, font.FontOptions{Options: &textColorOptions, Justify: font.FontJustifyRight, Scale: scale.ScaleAmount}, fmt.Sprintf("%v MP", costRemaining))
             icon := getMagicIcon(spell)
 
             nameLength := infoFont.MeasureTextWidth(spell.Name, 1) + 1
@@ -1308,7 +1308,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
             if overland && costRemaining < castingSkill {
                 x, y := iconOptions.GeoM.Apply(0, 0)
                 x += 2
-                infoFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &spellOptions, Scale: scale.ScaleAmount}, "Instant")
+                infoFont.PrintOptions(screen, x, y, font.FontOptions{Options: &spellOptions, Scale: scale.ScaleAmount}, "Instant")
                 icon1Width += int(infoFont.MeasureTextWidth("Instant", 1)) + 2
                 iconOptions.GeoM.Translate(infoFont.MeasureTextWidth("Instant", 1) + 2, 0)
             }

--- a/game/magic/summon/summon.go
+++ b/game/magic/summon/summon.go
@@ -9,6 +9,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/util"
 
@@ -271,7 +272,7 @@ func (summon *Summon) Update() SummonState {
 
     if summon.Counter % 2 == 0 {
         if summon.SummonHeight < summon.SummonPic.Bounds().Dy() {
-            summon.SummonHeight += 1 * data.ScreenScale
+            summon.SummonHeight += 1
         }
     }
 
@@ -286,8 +287,8 @@ func (summon *Summon) Draw(screen *ebiten.Image){
 
     // background, _ := summon.ImageCache.GetImage("spellscr.lbx", 9, 0)
     var options ebiten.DrawImageOptions
-    options.GeoM.Translate(float64(30 * data.ScreenScale), float64(40 * data.ScreenScale))
-    screen.DrawImage(summon.Background, &options)
+    options.GeoM.Translate(float64(30), float64(40))
+    scale.DrawScaled(screen, summon.Background, &options)
 
     wizardIndex := 46
     switch summon.Wizard {
@@ -308,24 +309,24 @@ func (summon *Summon) Draw(screen *ebiten.Image){
     }
 
     circleOptions := options
-    circleOptions.GeoM.Translate(float64(53 * data.ScreenScale), float64(54 * data.ScreenScale))
-    screen.DrawImage(summon.CircleBack.Frame(), &circleOptions)
+    circleOptions.GeoM.Translate(float64(53), float64(54))
+    scale.DrawScaled(screen, summon.CircleBack.Frame(), &circleOptions)
 
     wizard, _ := summon.ImageCache.GetImage("spellscr.lbx", wizardIndex, 0)
     wizardOptions := options
-    wizardOptions.GeoM.Translate(float64(7 * data.ScreenScale), float64(3 * data.ScreenScale))
-    screen.DrawImage(wizard, &wizardOptions)
+    wizardOptions.GeoM.Translate(float64(7), float64(3))
+    scale.DrawScaled(screen, wizard, &wizardOptions)
 
     monster := summon.SummonPic
     monsterOptions := options
-    monsterOptions.GeoM.Translate(float64(75 * data.ScreenScale), float64((30 + 70) * data.ScreenScale) - float64(summon.SummonHeight))
+    monsterOptions.GeoM.Translate(float64(75), float64((30 + 70)) - float64(summon.SummonHeight))
     partialMonster := monster.SubImage(image.Rect(0, 0, monster.Bounds().Dx(), summon.SummonHeight)).(*ebiten.Image)
-    screen.DrawImage(partialMonster, &monsterOptions)
+    scale.DrawScaled(screen, partialMonster, &monsterOptions)
 
-    circleOptions.GeoM.Translate(float64(11 * data.ScreenScale), float64(26 * data.ScreenScale))
+    circleOptions.GeoM.Translate(float64(11), float64(26))
     circleOptions.ColorScale.ScaleAlpha(1.0)
-    screen.DrawImage(summon.CircleFront.Frame(), &circleOptions)
+    scale.DrawScaled(screen, summon.CircleFront.Frame(), &circleOptions)
 
-    x, y := options.GeoM.Apply(float64(summon.Background.Bounds().Dx())/2, float64(summon.Background.Bounds().Dy() - 18 * data.ScreenScale))
-    summon.Font.PrintCenter(screen, x, y, float64(data.ScreenScale), options.ColorScale, summon.Title)
+    x, y := options.GeoM.Apply(float64(summon.Background.Bounds().Dx())/2, float64(summon.Background.Bounds().Dy() - 18))
+    summon.Font.PrintCenter(screen, x, y, scale.ScaleAmount, options.ColorScale, summon.Title)
 }

--- a/game/magic/ui/dialogs.go
+++ b/game/magic/ui/dialogs.go
@@ -221,7 +221,7 @@ func MakeErrorElement(ui UIContainer, cache *lbx.LbxCache, imageCache *util.Imag
 
     maxWidth := errorTop.Bounds().Dx() - errorMargin * 2
 
-    wrapped := errorFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
+    wrapped := errorFont.CreateWrappedText(float64(maxWidth), 1, message)
 
     bottom := float64(errorY + errorTopMargin) + wrapped.TotalHeight
 
@@ -236,14 +236,14 @@ func MakeErrorElement(ui UIContainer, cache *lbx.LbxCache, imageCache *util.Imag
         },
         Draw: func(this *UIElement, window *ebiten.Image){
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(float64(errorX * data.ScreenScale), float64(errorY * data.ScreenScale))
-            window.DrawImage(topDraw, &options)
+            options.GeoM.Translate(float64(errorX), float64(errorY))
+            window.DrawImage(topDraw, scale.ScaleOptions(options))
 
-            errorFont.RenderWrapped(window, float64((errorX + errorMargin) * data.ScreenScale + maxWidth / 2), float64(errorY + errorTopMargin) * float64(data.ScreenScale), wrapped, ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter})
+            errorFont.RenderWrapped(window, float64((errorX + errorMargin) + maxWidth / 2), float64(errorY + errorTopMargin), wrapped, ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount})
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(errorX * data.ScreenScale), float64(bottom))
-            window.DrawImage(errorBottom, &options)
+            options.GeoM.Translate(float64(errorX), float64(bottom))
+            window.DrawImage(errorBottom, scale.ScaleOptions(options))
         },
     }
 

--- a/game/magic/ui/dialogs.go
+++ b/game/magic/ui/dialogs.go
@@ -155,12 +155,12 @@ func MakeHelpElementWithLayer(container UIContainer, cache *lbx.LbxCache, imageC
                 titleX += extraImage.Bounds().Dx() + 5
             }
 
-            helpTitleFont.PrintOptions2(window, float64(titleX), infoY + float64(infoTopMargin + titleYAdjust), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, help.Headline)
+            helpTitleFont.PrintOptions(window, float64(titleX), infoY + float64(infoTopMargin + titleYAdjust), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, help.Headline)
             helpFont.RenderWrapped(window, float64(infoX + infoLeftMargin + infoBodyMargin), float64(helpTextY) + infoY, wrapped, font.FontOptions{Options: &options, Scale: scale.ScaleAmount})
 
             yPos := float64(helpTextY) + infoY + wrapped.TotalHeight + 2
             for i, moreWrapped := range moreHelp {
-                helpTitleFont.PrintOptions2(window, float64(titleX), yPos, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, helpEntries[i].Headline)
+                helpTitleFont.PrintOptions(window, float64(titleX), yPos, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, helpEntries[i].Headline)
                 helpFont.RenderWrapped(window, float64(infoX + infoLeftMargin + infoBodyMargin), yPos + float64(helpTitleFont.Height()) + 1, moreWrapped, font.FontOptions{Options: &options, Scale: scale.ScaleAmount})
                 yPos += float64(helpTitleFont.Height()) + 1 + float64(moreWrapped.TotalHeight) + 2
             }
@@ -772,7 +772,7 @@ func MakeSelectionUI(ui UIContainer, lbxCache *lbx.LbxCache, imageCache *util.Im
             options.GeoM.Translate((float64(cornerX + left.Bounds().Dx()) + requiredWidth), float64(cornerY + totalHeight))
             scale.DrawScaled(screen, bottomRight, &options)
 
-            topFont.PrintOptions2(screen, float64(cornerX + left.Bounds().Dx() + 4), float64(cornerY + 4), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, selectionTitle)
+            topFont.PrintOptions(screen, float64(cornerX + left.Bounds().Dx() + 4), float64(cornerY + 4), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, selectionTitle)
         },
     })
 
@@ -821,9 +821,9 @@ func MakeSelectionUI(ui UIContainer, lbxCache *lbx.LbxCache, imageCache *util.Im
 
                 y := float64(myY + 2)
 
-                buttonFont.PrintOptions2(screen, float64(myX + 2), y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, choice.Name)
+                buttonFont.PrintOptions(screen, float64(myX + 2), y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, choice.Name)
                 if choice.Hotkey != "" {
-                    buttonFont.PrintOptions2(screen, float64(myX) + requiredWidth - 2, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, choice.Hotkey)
+                    buttonFont.PrintOptions(screen, float64(myX) + requiredWidth - 2, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, choice.Hotkey)
                 }
             },
         })

--- a/game/magic/ui/dialogs.go
+++ b/game/magic/ui/dialogs.go
@@ -134,12 +134,12 @@ func MakeHelpElementWithLayer(container UIContainer, cache *lbx.LbxCache, imageC
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(infoX), float64(infoY))
             options.ColorScale.ScaleAlpha(getAlpha())
-            window.DrawImage(topImage, scale.ScaleOptions(options))
+            scale.DrawScaled(window, topImage, &options)
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(infoX), float64(bottom) + infoY)
             options.ColorScale.ScaleAlpha(getAlpha())
-            window.DrawImage(helpBottom, scale.ScaleOptions(options))
+            scale.DrawScaled(window, helpBottom, &options)
 
             // for debugging
             // vector.StrokeRect(window, float32(infoX), float32(infoY), float32(infoWidth), float32(infoHeight), 1, color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}, true)
@@ -151,7 +151,7 @@ func MakeHelpElementWithLayer(container UIContainer, cache *lbx.LbxCache, imageC
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(titleX), infoY + float64(infoTopMargin))
                 options.ColorScale.ScaleAlpha(getAlpha())
-                window.DrawImage(extraImage, scale.ScaleOptions(options))
+                scale.DrawScaled(window, extraImage, &options)
                 titleX += extraImage.Bounds().Dx() + 5
             }
 
@@ -237,13 +237,13 @@ func MakeErrorElement(ui UIContainer, cache *lbx.LbxCache, imageCache *util.Imag
         Draw: func(this *UIElement, window *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(errorX), float64(errorY))
-            window.DrawImage(topDraw, scale.ScaleOptions(options))
+            scale.DrawScaled(window, topDraw, &options)
 
             errorFont.RenderWrapped(window, float64((errorX + errorMargin) + maxWidth / 2), float64(errorY + errorTopMargin), wrapped, ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount})
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(errorX), float64(bottom))
-            window.DrawImage(errorBottom, scale.ScaleOptions(options))
+            scale.DrawScaled(window, errorBottom, &options)
         },
     }
 
@@ -264,11 +264,11 @@ func MakeConfirmDialogWithLayer(container UIContainer, cache *lbx.LbxCache, imag
 }
 
 func MakeConfirmDialogWithLayerFull(container UIContainer, cache *lbx.LbxCache, imageCache *util.ImageCache, layer UILayer, message string, center bool, confirm func(), cancel func(), yesButtons []*ebiten.Image, noButtons []*ebiten.Image) []*UIElement {
-    confirmX := 67 * data.ScreenScale
-    confirmY := 68 * data.ScreenScale
+    confirmX := 67
+    confirmY := 68
 
-    confirmMargin := 15 * data.ScreenScale
-    confirmTopMargin := 10 * data.ScreenScale
+    confirmMargin := 15
+    confirmTopMargin := 10
 
     const fadeSpeed = 7
 
@@ -310,7 +310,7 @@ func MakeConfirmDialogWithLayerFull(container UIContainer, cache *lbx.LbxCache, 
 
     maxWidth := confirmTop.Bounds().Dx() - confirmMargin * 2
 
-    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
+    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), 1, message)
 
     bottom := float64(confirmY + confirmTopMargin) + wrapped.TotalHeight
 
@@ -328,24 +328,24 @@ func MakeConfirmDialogWithLayerFull(container UIContainer, cache *lbx.LbxCache, 
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(confirmX), float64(confirmY))
             options.ColorScale.ScaleAlpha(getAlpha())
-            window.DrawImage(topDraw, &options)
+            scale.DrawScaled(window, topDraw, &options)
 
             if center {
-                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter})
+                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
             } else {
-                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{})
+                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
             }
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(confirmX), float64(bottom))
-            window.DrawImage(confirmBottom, &options)
+            scale.DrawScaled(window, confirmBottom, &options)
         },
     })
 
     // add yes/no buttons
     if err == nil {
-        yesX := confirmX + 101 * data.ScreenScale
-        yesY := bottom + float64(5 * data.ScreenScale)
+        yesX := confirmX + 101
+        yesY := bottom + float64(5)
 
         clicked := false
         elements = append(elements, &UIElement{
@@ -373,14 +373,14 @@ func MakeConfirmDialogWithLayerFull(container UIContainer, cache *lbx.LbxCache, 
                 if clicked {
                     index = 1
                 }
-                window.DrawImage(yesButtons[index], &options)
+                scale.DrawScaled(window, yesButtons[index], &options)
             },
         })
     }
 
     if err == nil {
-        noX := confirmX + 18 * data.ScreenScale
-        noY := bottom + float64(5 * data.ScreenScale)
+        noX := confirmX + 18
+        noY := bottom + float64(5)
 
         clicked := false
         elements = append(elements, &UIElement{
@@ -408,7 +408,7 @@ func MakeConfirmDialogWithLayerFull(container UIContainer, cache *lbx.LbxCache, 
                 if clicked {
                     index = 1
                 }
-                window.DrawImage(noButtons[index], &options)
+                scale.DrawScaled(window, noButtons[index], &options)
             },
         })
     }
@@ -421,11 +421,11 @@ func MakeLairConfirmDialog(ui UIContainer, cache *lbx.LbxCache, imageCache *util
 }
 
 func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCache *util.ImageCache, lairPicture *util.Animation, layer UILayer, message string, confirm func(), cancel func()) []*UIElement {
-    confirmX := 67 * data.ScreenScale
-    confirmY := 40 * data.ScreenScale
+    confirmX := 67
+    confirmY := 40
 
-    confirmMargin := 55 * data.ScreenScale
-    confirmTopMargin := 10 * data.ScreenScale
+    confirmMargin := 55
+    confirmTopMargin := 10
 
     const fadeSpeed = 7
 
@@ -465,9 +465,9 @@ func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCa
 
     confirmFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowFade)
 
-    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5 * data.ScreenScale
+    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5
 
-    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
+    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), 1, message)
 
     bottom := float64(confirmY + confirmTopMargin) + wrapped.TotalHeight
 
@@ -485,24 +485,24 @@ func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCa
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(confirmX), float64(confirmY))
             options.ColorScale.ScaleAlpha(getAlpha())
-            window.DrawImage(topDraw, &options)
+            scale.DrawScaled(window, topDraw, &options)
 
-            options.GeoM.Translate(float64(7 * data.ScreenScale), float64(7 * data.ScreenScale))
-            window.DrawImage(lairPicture.Frame(), &options)
+            options.GeoM.Translate(float64(7), float64(7))
+            scale.DrawScaled(window, lairPicture.Frame(), &options)
 
-            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter})
+            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(confirmX - 1 * data.ScreenScale), float64(bottom))
-            window.DrawImage(confirmBottom, &options)
+            options.GeoM.Translate(float64(confirmX - 1), float64(bottom))
+            scale.DrawScaled(window, confirmBottom, &options)
         },
     })
 
     // add yes/no buttons
     yesButtons, err := imageCache.GetImages("resource.lbx", 3)
     if err == nil {
-        yesX := confirmX + 101 * data.ScreenScale
-        yesY := bottom + float64(5 * data.ScreenScale)
+        yesX := confirmX + 101
+        yesY := bottom + float64(5)
 
         clicked := false
         elements = append(elements, &UIElement{
@@ -530,15 +530,15 @@ func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCa
                 if clicked {
                     index = 1
                 }
-                window.DrawImage(yesButtons[index], &options)
+                scale.DrawScaled(window, yesButtons[index], &options)
             },
         })
     }
 
     noButtons, err := imageCache.GetImages("resource.lbx", 4)
     if err == nil {
-        noX := confirmX + 18 * data.ScreenScale
-        noY := bottom + float64(5 * data.ScreenScale)
+        noX := confirmX + 18
+        noY := bottom + float64(5)
 
         clicked := false
         elements = append(elements, &UIElement{
@@ -566,7 +566,7 @@ func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCa
                 if clicked {
                     index = 1
                 }
-                window.DrawImage(noButtons[index], &options)
+                scale.DrawScaled(window, noButtons[index], &options)
             },
         })
     }
@@ -575,11 +575,11 @@ func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCa
 }
 
 func MakeLairShowDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCache *util.ImageCache, lairPicture *util.Animation, layer UILayer, message string, dismiss func()) []*UIElement {
-    confirmX := 67 * data.ScreenScale
-    confirmY := 40 * data.ScreenScale
+    confirmX := 67
+    confirmY := 40
 
-    confirmMargin := 55 * data.ScreenScale
-    confirmTopMargin := 10 * data.ScreenScale
+    confirmMargin := 55
+    confirmTopMargin := 10
 
     const fadeSpeed = 7
 
@@ -619,9 +619,9 @@ func MakeLairShowDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCache
 
     confirmFont := font.MakeOptimizedFontWithPalette(fonts[4], yellowFade)
 
-    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5 * data.ScreenScale
+    maxWidth := confirmTop.Bounds().Dx() - confirmMargin - 5
 
-    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), float64(data.ScreenScale), message)
+    wrapped := confirmFont.CreateWrappedText(float64(maxWidth), 1, message)
 
     bottom := float64(confirmY + confirmTopMargin) + max(wrapped.TotalHeight, float64(lairPicture.Frame().Bounds().Dy()))
 
@@ -642,16 +642,16 @@ func MakeLairShowDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCache
             var options ebiten.DrawImageOptions
             options.GeoM.Translate(float64(confirmX), float64(confirmY))
             options.ColorScale.ScaleAlpha(getAlpha())
-            window.DrawImage(topDraw, &options)
+            scale.DrawScaled(window, topDraw, &options)
 
-            options.GeoM.Translate(float64(7 * data.ScreenScale), float64(7 * data.ScreenScale))
-            window.DrawImage(lairPicture.Frame(), &options)
+            options.GeoM.Translate(float64(7), float64(7))
+            scale.DrawScaled(window, lairPicture.Frame(), &options)
 
-            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter})
+            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(confirmX), float64(bottom))
-            window.DrawImage(confirmBottom, &options)
+            scale.DrawScaled(window, confirmBottom, &options)
         },
     })
 
@@ -713,12 +713,12 @@ func MakeSelectionUI(ui UIContainer, lbxCache *lbx.LbxCache, imageCache *util.Im
     left, _ := imageCache.GetImage("resource.lbx", 5, 0)
     top, _ := imageCache.GetImage("resource.lbx", 7, 0)
 
-    requiredWidth := buttonFont.MeasureTextWidth(selectionTitle, float64(data.ScreenScale)) + 2
+    requiredWidth := buttonFont.MeasureTextWidth(selectionTitle, 1) + 2
 
     for _, choice := range choices {
-        width := buttonFont.MeasureTextWidth(choice.Name, float64(data.ScreenScale)) + 2
+        width := buttonFont.MeasureTextWidth(choice.Name, 1) + 2
         if choice.Hotkey != "" {
-            width += buttonFont.MeasureTextWidth(choice.Hotkey, float64(data.ScreenScale)) + 2
+            width += buttonFont.MeasureTextWidth(choice.Hotkey, 1) + 2
         }
         if width > requiredWidth {
             requiredWidth = width
@@ -742,42 +742,42 @@ func MakeSelectionUI(ui UIContainer, lbxCache *lbx.LbxCache, imageCache *util.Im
             bottom, _ := imageCache.GetImage("resource.lbx", 9, 0)
             options.GeoM.Reset()
             // FIXME: figure out why -3 is needed
-            options.GeoM.Translate(float64(cornerX * data.ScreenScale + left.Bounds().Dx()), float64(cornerY * data.ScreenScale + top.Bounds().Dy() + totalHeight - 3))
+            options.GeoM.Translate(float64(cornerX + left.Bounds().Dx()), float64(cornerY + top.Bounds().Dy() + totalHeight - 3))
             bottomSub := bottom.SubImage(image.Rect(0, 0, int(requiredWidth), bottom.Bounds().Dy())).(*ebiten.Image)
-            screen.DrawImage(bottomSub, &options)
+            scale.DrawScaled(screen, bottomSub, &options)
 
             bottomLeft, _ := imageCache.GetImage("resource.lbx", 6, 0)
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(cornerX * data.ScreenScale), float64(cornerY * data.ScreenScale + totalHeight))
-            screen.DrawImage(bottomLeft, &options)
+            options.GeoM.Translate(float64(cornerX), float64(cornerY + totalHeight))
+            scale.DrawScaled(screen, bottomLeft, &options)
 
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(cornerX * data.ScreenScale), float64(cornerY * data.ScreenScale))
+            options.GeoM.Translate(float64(cornerX), float64(cornerY))
             leftSub := left.SubImage(image.Rect(0, 0, left.Bounds().Dx(), totalHeight)).(*ebiten.Image)
-            screen.DrawImage(leftSub, &options)
+            scale.DrawScaled(screen, leftSub, &options)
 
             topSub := top.SubImage(image.Rect(0, 0, int(requiredWidth), top.Bounds().Dy())).(*ebiten.Image)
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(cornerX * data.ScreenScale + left.Bounds().Dx()), float64(cornerY * data.ScreenScale))
-            screen.DrawImage(topSub, &options)
+            options.GeoM.Translate(float64(cornerX + left.Bounds().Dx()), float64(cornerY))
+            scale.DrawScaled(screen, topSub, &options)
 
             right, _ := imageCache.GetImage("resource.lbx", 8, 0)
             options.GeoM.Reset()
-            options.GeoM.Translate(float64(cornerX * data.ScreenScale + left.Bounds().Dx()) + requiredWidth, float64(cornerY * data.ScreenScale))
+            options.GeoM.Translate(float64(cornerX + left.Bounds().Dx()) + requiredWidth, float64(cornerY))
             rightSub := right.SubImage(image.Rect(0, 0, right.Bounds().Dx(), totalHeight)).(*ebiten.Image)
-            screen.DrawImage(rightSub, &options)
+            scale.DrawScaled(screen, rightSub, &options)
 
             bottomRight, _ := imageCache.GetImage("resource.lbx", 10, 0)
             options.GeoM.Reset()
-            options.GeoM.Translate((float64(cornerX * data.ScreenScale + left.Bounds().Dx()) + requiredWidth), float64(cornerY * data.ScreenScale + totalHeight))
-            screen.DrawImage(bottomRight, &options)
+            options.GeoM.Translate((float64(cornerX + left.Bounds().Dx()) + requiredWidth), float64(cornerY + totalHeight))
+            scale.DrawScaled(screen, bottomRight, &options)
 
-            topFont.Print(screen, float64(cornerX * data.ScreenScale + left.Bounds().Dx() + 4 * data.ScreenScale), float64(cornerY * data.ScreenScale + 4 * data.ScreenScale), float64(data.ScreenScale), options.ColorScale, selectionTitle)
+            topFont.PrintOptions2(screen, float64(cornerX + left.Bounds().Dx() + 4), float64(cornerY + 4), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, selectionTitle)
         },
     })
 
-    x1 := cornerX * data.ScreenScale + left.Bounds().Dx()
-    y1 := cornerY * data.ScreenScale + top.Bounds().Dy()
+    x1 := cornerX + left.Bounds().Dx()
+    y1 := cornerY + top.Bounds().Dy()
 
     // FIXME: handle more than 9 choices
     for choiceIndex, choice := range choices {
@@ -814,16 +814,16 @@ func MakeSelectionUI(ui UIContainer, lbxCache *lbx.LbxCache, imageCache *util.Im
                 options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
 
                 use := images[imageIndex].SubImage(image.Rect(0, 0, int(requiredWidth), images[imageIndex].Bounds().Dy())).(*ebiten.Image)
-                screen.DrawImage(use, &options)
+                scale.DrawScaled(screen, use, &options)
 
                 options.GeoM.Translate(float64(use.Bounds().Dx()), 0)
-                screen.DrawImage(ends[imageIndex], &options)
+                scale.DrawScaled(screen, ends[imageIndex], &options)
 
-                y := float64(myY + 2 * data.ScreenScale)
+                y := float64(myY + 2)
 
-                buttonFont.Print(screen, float64(myX + 2), y, float64(data.ScreenScale), options.ColorScale, choice.Name)
+                buttonFont.PrintOptions2(screen, float64(myX + 2), y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, choice.Name)
                 if choice.Hotkey != "" {
-                    buttonFont.PrintRight(screen, float64(myX) + requiredWidth - 2, y, float64(data.ScreenScale), options.ColorScale, choice.Hotkey)
+                    buttonFont.PrintOptions2(screen, float64(myX) + requiredWidth - 2, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyRight}, choice.Hotkey)
                 }
             },
         })

--- a/game/magic/ui/dialogs.go
+++ b/game/magic/ui/dialogs.go
@@ -156,12 +156,12 @@ func MakeHelpElementWithLayer(container UIContainer, cache *lbx.LbxCache, imageC
             }
 
             helpTitleFont.PrintOptions2(window, float64(titleX), infoY + float64(infoTopMargin + titleYAdjust), font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, help.Headline)
-            helpFont.RenderWrapped(window, float64(infoX + infoLeftMargin + infoBodyMargin), float64(helpTextY) + infoY, wrapped, options.ColorScale, font.FontOptions{Options: &options, Scale: scale.ScaleAmount})
+            helpFont.RenderWrapped(window, float64(infoX + infoLeftMargin + infoBodyMargin), float64(helpTextY) + infoY, wrapped, font.FontOptions{Options: &options, Scale: scale.ScaleAmount})
 
             yPos := float64(helpTextY) + infoY + wrapped.TotalHeight + 2
             for i, moreWrapped := range moreHelp {
                 helpTitleFont.PrintOptions2(window, float64(titleX), yPos, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, helpEntries[i].Headline)
-                helpFont.RenderWrapped(window, float64(infoX + infoLeftMargin + infoBodyMargin), yPos + float64(helpTitleFont.Height()) + 1, moreWrapped, options.ColorScale, font.FontOptions{Options: &options, Scale: scale.ScaleAmount})
+                helpFont.RenderWrapped(window, float64(infoX + infoLeftMargin + infoBodyMargin), yPos + float64(helpTitleFont.Height()) + 1, moreWrapped, font.FontOptions{Options: &options, Scale: scale.ScaleAmount})
                 yPos += float64(helpTitleFont.Height()) + 1 + float64(moreWrapped.TotalHeight) + 2
             }
 
@@ -239,7 +239,7 @@ func MakeErrorElement(ui UIContainer, cache *lbx.LbxCache, imageCache *util.Imag
             options.GeoM.Translate(float64(errorX), float64(errorY))
             scale.DrawScaled(window, topDraw, &options)
 
-            errorFont.RenderWrapped(window, float64((errorX + errorMargin) + maxWidth / 2), float64(errorY + errorTopMargin), wrapped, ebiten.ColorScale{}, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount})
+            errorFont.RenderWrapped(window, float64((errorX + errorMargin) + maxWidth / 2), float64(errorY + errorTopMargin), wrapped, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount})
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(errorX), float64(bottom))
@@ -331,9 +331,9 @@ func MakeConfirmDialogWithLayerFull(container UIContainer, cache *lbx.LbxCache, 
             scale.DrawScaled(window, topDraw, &options)
 
             if center {
-                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
+                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
             } else {
-                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
+                confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin), float64(confirmY + confirmTopMargin), wrapped, font.FontOptions{Scale: scale.ScaleAmount, Options: &options})
             }
 
             options.GeoM.Reset()
@@ -490,7 +490,7 @@ func MakeLairConfirmDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCa
             options.GeoM.Translate(float64(7), float64(7))
             scale.DrawScaled(window, lairPicture.Frame(), &options)
 
-            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
+            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(confirmX - 1), float64(bottom))
@@ -647,7 +647,7 @@ func MakeLairShowDialogWithLayer(ui UIContainer, cache *lbx.LbxCache, imageCache
             options.GeoM.Translate(float64(7), float64(7))
             scale.DrawScaled(window, lairPicture.Frame(), &options)
 
-            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, options.ColorScale, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
+            confirmFont.RenderWrapped(window, float64(confirmX + confirmMargin + maxWidth / 2), float64(confirmY + confirmTopMargin), wrapped, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount, Options: &options})
 
             options.GeoM.Reset()
             options.GeoM.Translate(float64(confirmX), float64(bottom))

--- a/game/magic/unitview/ui.go
+++ b/game/magic/unitview/ui.go
@@ -236,7 +236,7 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
 
             x := float64(cancelRect.Min.X + cancelRect.Max.X) / 2
             y := float64(cancelRect.Min.Y + cancelRect.Max.Y) / 2
-            okDismissFont.PrintOptions2(screen, x, y - 5, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Dismiss")
+            okDismissFont.PrintOptions(screen, x, y - 5, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Dismiss")
         },
     })
 
@@ -263,7 +263,7 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
 
             x := float64(okRect.Min.X + okRect.Max.X) / 2
             y := float64(okRect.Min.Y + okRect.Max.Y) / 2
-            okDismissFont.PrintOptions2(screen, x, y - 5, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Ok")
+            okDismissFont.PrintOptions(screen, x, y - 5, font.FontOptions{Options: &options, Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, "Ok")
         },
     })
 
@@ -384,7 +384,7 @@ func MakeSmallListView(cache *lbx.LbxCache, ui *uilib.UI, stack []UnitView, titl
             screen.DrawImage(background, scale.ScaleOptions(options))
 
             titleX, titleY := options.GeoM.Apply(float64(background.Bounds().Dx() / 2), 8)
-            titleFont.PrintOptions2(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, title)
+            titleFont.PrintOptions(screen, titleX, titleY, font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}, title)
 
             /*
             util.DrawRect(screen, image.Rect(posX, posY, posX+1, posY + titleHeight), color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff})
@@ -451,19 +451,19 @@ func MakeSmallListView(cache *lbx.LbxCache, ui *uilib.UI, stack []UnitView, titl
                 }
 
                 x, y = unitOptions.GeoM.Apply(float64(unitBack.Bounds().Dx() + 2), 5)
-                mediumFont.PrintOptions2(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, unit.GetName())
+                mediumFont.PrintOptions(screen, x, y, font.FontOptions{Options: &options, Scale: scale.ScaleAmount}, unit.GetName())
 
                 rightOptions := font.FontOptions{Justify: font.FontJustifyRight, Options: &options, Scale: scale.ScaleAmount}
 
                 unitOptions.GeoM.Translate(133, 5)
                 x, y = unitOptions.GeoM.Apply(0, float64(1))
-                smallFont.PrintOptions2(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetMeleeAttackPower()))
+                smallFont.PrintOptions(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetMeleeAttackPower()))
                 // FIXME: show mythril/adamantium weapons?
                 screen.DrawImage(meleeImage, scale.ScaleOptions(unitOptions))
 
                 unitOptions.GeoM.Translate(20, 0)
                 x, y = unitOptions.GeoM.Apply(0, 1)
-                smallFont.PrintOptions2(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
+                smallFont.PrintOptions(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetRangedAttackPower()))
                 switch unit.GetRangedAttackDamageType() {
                     case units.DamageNone: // nothing
                     case units.DamageRangedMagical:
@@ -476,18 +476,18 @@ func MakeSmallListView(cache *lbx.LbxCache, ui *uilib.UI, stack []UnitView, titl
 
                 unitOptions.GeoM.Translate(20, 0)
                 x, y = unitOptions.GeoM.Apply(0, 1)
-                smallFont.PrintOptions2(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetDefense()))
+                smallFont.PrintOptions(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetDefense()))
                 screen.DrawImage(defenseImage, scale.ScaleOptions(unitOptions))
 
                 unitOptions.GeoM.Translate(20, 0)
                 x, y = unitOptions.GeoM.Apply(0, 1)
-                smallFont.PrintOptions2(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetHitPoints()))
+                smallFont.PrintOptions(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetHitPoints()))
 
                 screen.DrawImage(healthImage, scale.ScaleOptions(unitOptions))
 
                 unitOptions.GeoM.Translate(20, 0)
                 x, y = unitOptions.GeoM.Apply(0, 1)
-                smallFont.PrintOptions2(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetMovementSpeed()))
+                smallFont.PrintOptions(screen, x, y, rightOptions, fmt.Sprintf("%v", unit.GetMovementSpeed()))
 
                 screen.DrawImage(moveImage, scale.ScaleOptions(unitOptions))
 

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -94,22 +94,22 @@ func RenderUnitInfoNormal(screen *ebiten.Image, imageCache *util.ImageCache, uni
     }
 
     if extraTitle != "" {
-        descriptionFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
+        descriptionFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
         y += float64(descriptionFont.Height())
         defaultOptions.GeoM.Translate(0, float64(descriptionFont.Height()))
-        descriptionFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "The " + extraTitle)
+        descriptionFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "The " + extraTitle)
 
         y += float64(descriptionFont.Height())
         defaultOptions.GeoM.Translate(0, float64(descriptionFont.Height()))
     } else {
-        descriptionFont.PrintOptions2(screen, x, y+2, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
+        descriptionFont.PrintOptions(screen, x, y+2, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, name)
         y += 17
         defaultOptions.GeoM.Translate(0, 16)
     }
 
     defaultOptions.GeoM.Translate(0, float64(-1))
 
-    smallFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
+    smallFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
     y += float64(smallFont.Height() + 1)
 
     unitMoves := unit.GetMovementSpeed()
@@ -127,7 +127,7 @@ func RenderUnitInfoNormal(screen *ebiten.Image, imageCache *util.ImageCache, uni
         }
     }
 
-    smallFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Upkeep")
+    smallFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Upkeep")
 
     options := defaultOptions
     options.GeoM.Translate(smallFont.MeasureTextWidth("Upkeep ", 1), float64(smallFont.Height() + 2))
@@ -137,9 +137,9 @@ func RenderUnitInfoNormal(screen *ebiten.Image, imageCache *util.ImageCache, uni
 func RenderUnitInfoBuild(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitView, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, discountedCost int) {
     x, y := defaultOptions.GeoM.Apply(0, 0)
 
-    descriptionFont.PrintOptions2(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, unit.GetName())
+    descriptionFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, unit.GetName())
 
-    smallFont.PrintOptions2(screen, x, y + float64(11), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
+    smallFont.PrintOptions(screen, x, y + float64(11), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Moves")
 
     unitMoves := unit.GetMovementSpeed()
 
@@ -156,14 +156,14 @@ func RenderUnitInfoBuild(screen *ebiten.Image, imageCache *util.ImageCache, unit
         }
     }
 
-    smallFont.PrintOptions2(screen, x, y + float64(19), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Upkeep")
+    smallFont.PrintOptions(screen, x, y + float64(19), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, "Upkeep")
 
     options := defaultOptions
     options.GeoM.Translate(smallFont.MeasureTextWidth("Upkeep ", 1), 18)
     renderUpkeep(screen, imageCache, unit, options)
 
     cost := unit.GetProductionCost()
-    smallFont.PrintOptions2(screen, x, y + float64(27), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, fmt.Sprintf("Cost %v(%v)", discountedCost, cost))
+    smallFont.PrintOptions(screen, x, y + float64(27), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, fmt.Sprintf("Cost %v(%v)", discountedCost, cost))
 }
 
 func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions) {
@@ -173,7 +173,7 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
 
     fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
 
-    descriptionFont.PrintOptions2(screen, x, y, fontOptions, "Melee")
+    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Melee")
 
     // show rows of icons. the second row is offset a bit to the right and down
     showNIcons := func(icon *ebiten.Image, count int, icon2 *ebiten.Image, count2 int, negativeCount int, x, y float64) {
@@ -239,7 +239,7 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
     showNIcons(weaponIcon, unit.GetBaseMeleeAttackPower(), weaponGold, unit.GetFullMeleeAttackPower() - unit.GetBaseMeleeAttackPower(), unit.GetMeleeAttackPower() - unit.GetFullMeleeAttackPower(), x, y)
 
     y += float64(descriptionFont.Height())
-    descriptionFont.PrintOptions2(screen, x, y, fontOptions, "Range")
+    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Range")
 
     var rangeIcon *ebiten.Image
     var rangeIconGold *ebiten.Image
@@ -259,21 +259,21 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
     showNIcons(rangeIcon, unit.GetBaseRangedAttackPower(), rangeIconGold, unit.GetFullRangedAttackPower() - unit.GetBaseRangedAttackPower(), unit.GetRangedAttackPower() - unit.GetFullRangedAttackPower(), x, y)
 
     y += float64(descriptionFont.Height())
-    descriptionFont.PrintOptions2(screen, x, y, fontOptions, "Armor")
+    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Armor")
 
     armorIcon, _ := imageCache.GetImage("unitview.lbx", 22, 0)
     armorGold, _ := imageCache.GetImage("unitview.lbx", 44, 0)
     showNIcons(armorIcon, unit.GetBaseDefense(), armorGold, unit.GetFullDefense() - unit.GetBaseDefense(), unit.GetDefense() - unit.GetFullDefense(), x, y)
 
     y += float64(descriptionFont.Height())
-    descriptionFont.PrintOptions2(screen, x, y, fontOptions, "Resist")
+    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Resist")
 
     resistIcon, _ := imageCache.GetImage("unitview.lbx", 27, 0)
     resistGold, _ := imageCache.GetImage("unitview.lbx", 49, 0)
     showNIcons(resistIcon, unit.GetBaseResistance(), resistGold, unit.GetFullResistance() - unit.GetBaseResistance(), unit.GetResistance() - unit.GetFullResistance(), x, y)
 
     y += float64(descriptionFont.Height())
-    descriptionFont.PrintOptions2(screen, x, y, fontOptions, "Hits")
+    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Hits")
 
     healthIcon, _ := imageCache.GetImage("unitview.lbx", 23, 0)
     healthIconGold, _ := imageCache.GetImage("unitview.lbx", 45, 0)
@@ -290,7 +290,7 @@ func RenderExperienceBadge(screen *ebiten.Image, imageCache *util.ImageCache, un
     if showExperience {
         text = fmt.Sprintf("%v (%v ep)", experience.Name(), unit.GetExperience())
     }
-    showFont.PrintOptions2(screen, x + float64(pic.Bounds().Dx() + 2), y + float64(5), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, text)
+    showFont.PrintOptions(screen, x + float64(pic.Bounds().Dx() + 2), y + float64(5), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, text)
     return float64(pic.Bounds().Dy() + 1)
 }
 
@@ -391,7 +391,7 @@ func createUnitAbilitiesElements(cache *lbx.LbxCache, imageCache *util.ImageCach
                         x, y := options.GeoM.Apply(0, 0)
                         printX := x + float64(artifactPic.Bounds().Dx() + 2)
                         printY := y + float64(5)
-                        mediumFont.PrintOptions2(screen, printX, printY, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, showArtifact.Name)
+                        mediumFont.PrintOptions(screen, printX, printY, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, showArtifact.Name)
                     } else {
                         pic, _ := imageCache.GetImage("itemisc.lbx", slot.ImageIndex() + 8, 0)
                         screen.DrawImage(pic, scale.ScaleOptions(options))
@@ -426,7 +426,7 @@ func createUnitAbilitiesElements(cache *lbx.LbxCache, imageCache *util.ImageCach
 
                     printX := x + float64(pic.Bounds().Dx() + 2)
                     printY := y + float64(5)
-                    mediumFont.PrintOptions2(screen, printX, printY, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, ability.Name())
+                    mediumFont.PrintOptions(screen, printX, printY, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, ability.Name())
                 },
             })
 
@@ -473,7 +473,7 @@ func createUnitAbilitiesElements(cache *lbx.LbxCache, imageCache *util.ImageCach
 
                     printX := x + float64(pic.Bounds().Dx() + 2)
                     printY := y + float64(5)
-                    mediumFont.PrintOptions2(screen, printX, printY, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, enchantment.Name())
+                    mediumFont.PrintOptions(screen, printX, printY, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, enchantment.Name())
                 },
             })
 

--- a/game/magic/util/graphics.go
+++ b/game/magic/util/graphics.go
@@ -219,7 +219,7 @@ func MakeFadeOut(time uint64, counter *uint64) AlphaFadeFunc {
 /* create an animation by rotating the colors in a palette for a given lbx/index pair.
  * all the colors between indexLow and indexHigh will be rotated once in the animation
  */
-func MakePaletteRotateAnimation(lbxFile *lbx.LbxFile, scaler Scaler, index int, rotateIndexLow int, rotateIndexHigh int) *Animation {
+func MakePaletteRotateAnimation(lbxFile *lbx.LbxFile, index int, rotateIndexLow int, rotateIndexHigh int) *Animation {
     basePalette, err := lbxFile.GetPalette(index)
     if err != nil {
         return nil
@@ -246,7 +246,7 @@ func MakePaletteRotateAnimation(lbxFile *lbx.LbxFile, scaler Scaler, index int, 
             return nil
         }
 
-        images = append(images, ebiten.NewImageFromImage(scaler.ApplyScale(newImages[0])))
+        images = append(images, ebiten.NewImageFromImage(newImages[0]))
     }
 
     return MakeAnimation(images, true)

--- a/game/magic/util/graphics.go
+++ b/game/magic/util/graphics.go
@@ -95,24 +95,24 @@ type Distortion struct {
  * for each segment in 'distortion', make a quad from 'source' where the width is 'source width' / segments in the distortion
  * the distortion segments define where to place each corner of the quad
  */
-func DrawDistortion(screen *ebiten.Image, page *ebiten.Image, source *ebiten.Image, distortion Distortion, options ebiten.DrawImageOptions){
-    ax0, ay0 := options.GeoM.Apply(0, 0)
-    ax1, ay1 := options.GeoM.Apply(float64(page.Bounds().Dx()), float64(page.Bounds().Dy()))
+func DrawDistortion(screen *ebiten.Image, page *ebiten.Image, source *ebiten.Image, distortion Distortion, geom ebiten.GeoM){
+    ax0, ay0 := geom.Apply(0, 0)
+    ax1, ay1 := geom.Apply(float64(page.Bounds().Dx()), float64(page.Bounds().Dy()))
     subScreen := screen.SubImage(image.Rect(int(ax0), int(ay0), int(ax1), int(ay1))).(*ebiten.Image)
 
     // top left
-    x1, y1 := options.GeoM.Apply(float64(distortion.Top.X), float64(distortion.Top.Y))
+    x1, y1 := geom.Apply(float64(distortion.Top.X), float64(distortion.Top.Y))
     // bottom left
-    x4, y4 := options.GeoM.Apply(float64(distortion.Bottom.X), float64(distortion.Bottom.Y))
+    x4, y4 := geom.Apply(float64(distortion.Bottom.X), float64(distortion.Bottom.Y))
 
     segmentWidth := float32(source.Bounds().Dx()) / float32(len(distortion.Segments))
 
     for i := 0; i < len(distortion.Segments); i++ {
         segment := distortion.Segments[i]
         // top right
-        x2, y2 := options.GeoM.Apply(float64(segment.Top.X), float64(segment.Top.Y))
+        x2, y2 := geom.Apply(float64(segment.Top.X), float64(segment.Top.Y))
         // bottom right
-        x3, y3 := options.GeoM.Apply(float64(segment.Bottom.X), float64(segment.Bottom.Y))
+        x3, y3 := geom.Apply(float64(segment.Bottom.X), float64(segment.Bottom.Y))
 
         sx := float32(0)
         sy := float32(source.Bounds().Dy())

--- a/game/magic/util/graphics.go
+++ b/game/magic/util/graphics.go
@@ -7,7 +7,7 @@ import (
     "math"
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/shaders"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
 
     "github.com/hajimehoshi/ebiten/v2"
     "github.com/hajimehoshi/ebiten/v2/colorm"
@@ -253,15 +253,15 @@ func MakePaletteRotateAnimation(lbxFile *lbx.LbxFile, scaler Scaler, index int, 
 }
 
 func DrawTextCursor(screen *ebiten.Image, source *ebiten.Image, cursorX float64, y float64, counter uint64) {
-    width := float64(4 * data.ScreenScale)
-    height := float64(8 * data.ScreenScale)
+    width := float64(4)
+    height := float64(8)
 
-    yOffset := float64((counter*uint64(data.ScreenScale)/3) % (16 * uint64(data.ScreenScale))) - height
+    yOffset := float64((counter/3) % 16) - height
 
     vertices := [4]ebiten.Vertex{
         ebiten.Vertex{
-            DstX: float32(cursorX),
-            DstY: float32(y - yOffset),
+            DstX: float32(scale.Scale(cursorX)),
+            DstY: float32(scale.Scale(y - yOffset)),
             SrcX: 0,
             SrcY: 0,
             ColorA: 1,
@@ -270,8 +270,8 @@ func DrawTextCursor(screen *ebiten.Image, source *ebiten.Image, cursorX float64,
             ColorR: 1,
         },
         ebiten.Vertex{
-            DstX: float32(cursorX + width),
-            DstY: float32(y - yOffset),
+            DstX: float32(scale.Scale(cursorX + width)),
+            DstY: float32(scale.Scale(y - yOffset)),
             SrcX: 0,
             SrcY: 0,
             ColorA: 1,
@@ -280,8 +280,8 @@ func DrawTextCursor(screen *ebiten.Image, source *ebiten.Image, cursorX float64,
             ColorR: 1,
         },
         ebiten.Vertex{
-            DstX: float32(cursorX + width),
-            DstY: float32(y + height - yOffset),
+            DstX: float32(scale.Scale(cursorX + width)),
+            DstY: float32(scale.Scale(y + height - yOffset)),
             SrcX: 0,
             SrcY: 0,
             ColorA: 0.1,
@@ -290,8 +290,8 @@ func DrawTextCursor(screen *ebiten.Image, source *ebiten.Image, cursorX float64,
             ColorR: 1,
         },
         ebiten.Vertex{
-            DstX: float32(cursorX),
-            DstY: float32(y + height - yOffset),
+            DstX: float32(scale.Scale(cursorX)),
+            DstY: float32(scale.Scale(y + height - yOffset)),
             SrcX: 0,
             SrcY: 0,
             ColorA: 0.1,
@@ -301,7 +301,7 @@ func DrawTextCursor(screen *ebiten.Image, source *ebiten.Image, cursorX float64,
         },
     }
 
-    cursorArea := screen.SubImage(image.Rect(int(cursorX), int(y), int(cursorX + width), int(y + height))).(*ebiten.Image)
+    cursorArea := screen.SubImage(scale.ScaleRect(image.Rect(int(cursorX), int(y), int(cursorX + width), int(y + height)))).(*ebiten.Image)
     cursorArea.DrawTriangles(vertices[:], []uint16{0, 1, 2, 2, 3, 0}, source, nil)
 }
 

--- a/game/magic/util/image-cache.go
+++ b/game/magic/util/image-cache.go
@@ -185,7 +185,7 @@ func (cache *ImageCache) GetImagesTransform(lbxPath string, index int, extra str
 
     var out []*ebiten.Image
     for i := 0; i < len(sprites); i++ {
-        out = append(out, ebiten.NewImageFromImage(cache.ApplyScale(transform(sprites[i]))))
+        out = append(out, ebiten.NewImageFromImage(transform(sprites[i])))
     }
 
     cache.Cache[key] = out

--- a/game/magic/util/image-cache.go
+++ b/game/magic/util/image-cache.go
@@ -9,9 +9,8 @@ import (
     "image/color"
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
-    "github.com/kazzmir/master-of-magic/lib/xbr"
+    // "github.com/kazzmir/master-of-magic/lib/xbr"
     "github.com/kazzmir/master-of-magic/game/magic/shaders"
-    "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/hajimehoshi/ebiten/v2"
 )
 
@@ -29,8 +28,10 @@ type ImageCache struct {
 
     ShaderCache map[shaders.Shader]*ebiten.Shader
 
+    /*
     Scaler data.ScaleAlgorithm
     ScaleAmount int
+    */
 }
 
 func MakeImageCache(lbxCache *lbx.LbxCache) ImageCache {
@@ -38,8 +39,10 @@ func MakeImageCache(lbxCache *lbx.LbxCache) ImageCache {
         LbxCache: lbxCache,
         Cache:    make(map[string][]*ebiten.Image),
         ShaderCache: make(map[shaders.Shader]*ebiten.Shader),
+        /*
         Scaler: data.ScreenScaleAlgorithm,
         ScaleAmount: 1,
+        */
         // ScaleAmount: data.ScreenScale,
     }
 }
@@ -318,6 +321,7 @@ func Scale3x(input image.Image, smooth bool) image.Image {
 }
 
 func (cache *ImageCache) ApplyScale(input image.Image) image.Image {
+    /*
     if cache.ScaleAmount == 1 {
         return input
     }
@@ -339,6 +343,7 @@ func (cache *ImageCache) ApplyScale(input image.Image) image.Image {
             }
         case data.ScaleAlgorithmXbr: return xbr.ScaleImage(input, cache.ScaleAmount)
     }
+    */
 
     return input
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/ebitenui/ebitenui v0.6.0
 	github.com/hajimehoshi/ebiten/v2 v2.8.6
+	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 )
 
 require (
@@ -14,7 +15,6 @@ require (
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/go-text/typesetting v0.2.1 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
-	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect
 	golang.org/x/image v0.24.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -285,6 +285,7 @@ func (font *Font) PrintRight(image *ebiten.Image, x float64, y float64, scale fl
     */
 }
 
+/*
 func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, options FontOptions, text string) {
     var drawOptions ebiten.DrawImageOptions
     drawOptions.ColorScale = colorScale
@@ -309,8 +310,9 @@ func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, scale 
     } else {
         font.doPrint(image, useX, useY, scale, colorScale, false, options.ShadowColor, text)
     }
-    */
+    * /
 }
+*/
 
 func (font *Font) PrintOptions2(image *ebiten.Image, x float64, y float64, options FontOptions, text string) {
     useOptions := options.Options

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -367,7 +367,9 @@ func (font *Font) PrintWrap(image *ebiten.Image, x float64, y float64, maxWidth 
 }
 
 func (font *Font) PrintWrapCenter(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, text string) {
-    font.PrintWrap(image, x, y, maxWidth, scale, colorScale, FontOptions{Justify: FontJustifyCenter, Scale: scale}, text)
+    var options ebiten.DrawImageOptions
+    options.ColorScale = colorScale
+    font.PrintWrap(image, x, y, maxWidth, scale, colorScale, FontOptions{Justify: FontJustifyCenter, Scale: scale, Options: &options}, text)
     /*
     wrapped := font.CreateWrappedText(maxWidth, scale, text)
     font.RenderWrapped(image, x, y, wrapped, colorScale, FontOptions{Justify: FontJustifyCenter})

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -362,12 +362,12 @@ func (font *Font) splitText(text string, maxWidth float64, scale float64) (strin
 }
 
 func (font *Font) PrintWrap(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, options FontOptions, text string) {
-    wrapped := font.CreateWrappedText(maxWidth, scale, text)
+    wrapped := font.CreateWrappedText(maxWidth, 1, text)
     font.RenderWrapped(image, x, y, wrapped, colorScale, options)
 }
 
 func (font *Font) PrintWrapCenter(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, text string) {
-    font.PrintWrap(image, x, y, maxWidth, scale, colorScale, FontOptions{Justify: FontJustifyCenter}, text)
+    font.PrintWrap(image, x, y, maxWidth, scale, colorScale, FontOptions{Justify: FontJustifyCenter, Scale: scale}, text)
     /*
     wrapped := font.CreateWrappedText(maxWidth, scale, text)
     font.RenderWrapped(image, x, y, wrapped, colorScale, FontOptions{Justify: FontJustifyCenter})

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -363,7 +363,7 @@ func (font *Font) splitText(text string, maxWidth float64, scale float64) (strin
 
 func (font *Font) PrintWrap(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, options FontOptions, text string) {
     wrapped := font.CreateWrappedText(maxWidth, 1, text)
-    font.RenderWrapped(image, x, y, wrapped, colorScale, options)
+    font.RenderWrapped(image, x, y, wrapped, options)
 }
 
 func (font *Font) PrintWrapCenter(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, text string) {
@@ -388,7 +388,7 @@ func (text *WrappedText) Clear() {
 }
 
 // FIXME: remove colorScale argument
-func (font *Font) RenderWrapped(image *ebiten.Image, x float64, y float64, wrapped WrappedText, colorScale ebiten.ColorScale, options FontOptions) {
+func (font *Font) RenderWrapped(image *ebiten.Image, x float64, y float64, wrapped WrappedText, options FontOptions) {
     yPos := y
     for _, line := range wrapped.Lines {
         font.PrintOptions2(image, x, yPos, options, line)

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -241,7 +241,7 @@ func (font *Font) PrintDropShadow(destination *ebiten.Image, x float64, y float6
 func (font *Font) Print(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
     var options ebiten.DrawImageOptions
     options.ColorScale = colorScale
-    font.PrintOptions2(image, x, y, FontOptions{Scale: scale, Options: &options}, text)
+    font.PrintOptions(image, x, y, FontOptions{Scale: scale, Options: &options}, text)
     // font.doPrint(image, x, y, scale, colorScale, false, color.Black, text)
 }
 
@@ -268,7 +268,7 @@ func (font *Font) MeasureTextWidth(text string, scale float64) float64 {
 func (font *Font) PrintCenter(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
     var options ebiten.DrawImageOptions
     options.ColorScale = colorScale
-    font.PrintOptions2(image, x, y, FontOptions{Justify: FontJustifyCenter, Scale: scale, Options: &options}, text)
+    font.PrintOptions(image, x, y, FontOptions{Justify: FontJustifyCenter, Scale: scale, Options: &options}, text)
     /*
     width := font.MeasureTextWidth(text, scale)
     font.Print(image, x - width / 2, y, scale, colorScale, text)
@@ -278,7 +278,7 @@ func (font *Font) PrintCenter(image *ebiten.Image, x float64, y float64, scale f
 func (font *Font) PrintRight(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
     var options ebiten.DrawImageOptions
     options.ColorScale = colorScale
-    font.PrintOptions2(image, x, y, FontOptions{Justify: FontJustifyRight, Scale: scale, Options: &options}, text)
+    font.PrintOptions(image, x, y, FontOptions{Justify: FontJustifyRight, Scale: scale, Options: &options}, text)
     /*
     width := font.MeasureTextWidth(text, scale)
     font.Print(image, x - width, y, scale, colorScale, text)
@@ -290,7 +290,7 @@ func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, scale 
     var drawOptions ebiten.DrawImageOptions
     drawOptions.ColorScale = colorScale
     options.Options = &drawOptions
-    font.PrintOptions2(image, x, y, options, text)
+    font.PrintOptions(image, x, y, options, text)
     /*
     useX := x
     useY := y
@@ -314,7 +314,7 @@ func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, scale 
 }
 */
 
-func (font *Font) PrintOptions2(image *ebiten.Image, x float64, y float64, options FontOptions, text string) {
+func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, options FontOptions, text string) {
     useOptions := options.Options
     if useOptions == nil {
         useOptions = &ebiten.DrawImageOptions{}
@@ -393,7 +393,7 @@ func (text *WrappedText) Clear() {
 func (font *Font) RenderWrapped(image *ebiten.Image, x float64, y float64, wrapped WrappedText, options FontOptions) {
     yPos := y
     for _, line := range wrapped.Lines {
-        font.PrintOptions2(image, x, yPos, options, line)
+        font.PrintOptions(image, x, yPos, options, line)
         yPos += float64(font.Height()) + 1
     }
 }

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -363,7 +363,7 @@ func (font *Font) splitText(text string, maxWidth float64, scale float64) (strin
     return "", text
 }
 
-func (font *Font) PrintWrap(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, options FontOptions, text string) {
+func (font *Font) PrintWrap(image *ebiten.Image, x float64, y float64, maxWidth float64, options FontOptions, text string) {
     wrapped := font.CreateWrappedText(maxWidth, 1, text)
     font.RenderWrapped(image, x, y, wrapped, options)
 }
@@ -371,7 +371,7 @@ func (font *Font) PrintWrap(image *ebiten.Image, x float64, y float64, maxWidth 
 func (font *Font) PrintWrapCenter(image *ebiten.Image, x float64, y float64, maxWidth float64, scale float64, colorScale ebiten.ColorScale, text string) {
     var options ebiten.DrawImageOptions
     options.ColorScale = colorScale
-    font.PrintWrap(image, x, y, maxWidth, scale, colorScale, FontOptions{Justify: FontJustifyCenter, Scale: scale, Options: &options}, text)
+    font.PrintWrap(image, x, y, maxWidth, FontOptions{Justify: FontJustifyCenter, Scale: scale, Options: &options}, text)
     /*
     wrapped := font.CreateWrappedText(maxWidth, scale, text)
     font.RenderWrapped(image, x, y, wrapped, colorScale, FontOptions{Justify: FontJustifyCenter})

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -239,7 +239,10 @@ func (font *Font) PrintDropShadow(destination *ebiten.Image, x float64, y float6
 
 // print the text with no border/outline
 func (font *Font) Print(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
-    font.doPrint(image, x, y, scale, colorScale, false, color.Black, text)
+    var options ebiten.DrawImageOptions
+    options.ColorScale = colorScale
+    font.PrintOptions2(image, x, y, FontOptions{Scale: scale, Options: &options}, text)
+    // font.doPrint(image, x, y, scale, colorScale, false, color.Black, text)
 }
 
 func (font *Font) MeasureTextWidth(text string, scale float64) float64 {
@@ -263,16 +266,31 @@ func (font *Font) MeasureTextWidth(text string, scale float64) float64 {
 }
 
 func (font *Font) PrintCenter(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
+    var options ebiten.DrawImageOptions
+    options.ColorScale = colorScale
+    font.PrintOptions2(image, x, y, FontOptions{Justify: FontJustifyCenter, Scale: scale, Options: &options}, text)
+    /*
     width := font.MeasureTextWidth(text, scale)
     font.Print(image, x - width / 2, y, scale, colorScale, text)
+    */
 }
 
 func (font *Font) PrintRight(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
+    var options ebiten.DrawImageOptions
+    options.ColorScale = colorScale
+    font.PrintOptions2(image, x, y, FontOptions{Justify: FontJustifyRight, Scale: scale, Options: &options}, text)
+    /*
     width := font.MeasureTextWidth(text, scale)
     font.Print(image, x - width, y, scale, colorScale, text)
+    */
 }
 
 func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, options FontOptions, text string) {
+    var drawOptions ebiten.DrawImageOptions
+    drawOptions.ColorScale = colorScale
+    options.Options = &drawOptions
+    font.PrintOptions2(image, x, y, options, text)
+    /*
     useX := x
     useY := y
 
@@ -291,6 +309,7 @@ func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, scale 
     } else {
         font.doPrint(image, useX, useY, scale, colorScale, false, options.ShadowColor, text)
     }
+    */
 }
 
 func (font *Font) PrintOptions2(image *ebiten.Image, x float64, y float64, options FontOptions, text string) {

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -40,6 +40,7 @@ type Font struct {
     Columns int
     Glyphs []Glyph
     internalFont *LbxFont
+    GlyphImages map[int]*ebiten.Image
 }
 
 func MakeGPUSpriteMap(font *LbxFont) (*ebiten.Image, int, int, int, int) {
@@ -108,6 +109,7 @@ func MakeOptimizedFontWithPalette(font *LbxFont, palette color.Palette) *Font {
         Columns: columns,
         Glyphs: font.Glyphs,
         internalFont: font,
+        GlyphImages: make(map[int]*ebiten.Image),
     }
 }
 
@@ -116,6 +118,11 @@ func (font *Font) Height() int {
 }
 
 func (font *Font) getGlyphImage(index int) *ebiten.Image {
+    cached, ok := font.GlyphImages[index]
+    if ok {
+        return cached
+    }
+
     x := index % font.Columns
     y := index / font.Columns
 
@@ -124,7 +131,9 @@ func (font *Font) getGlyphImage(index int) *ebiten.Image {
     x2 := (x+1) * font.GlyphWidth
     y2 := (y+1) * font.GlyphHeight
 
-    return font.Image.SubImage(image.Rect(x1, y1, x2, y2)).(*ebiten.Image)
+    sub := font.Image.SubImage(image.Rect(x1, y1, x2, y2)).(*ebiten.Image)
+    font.GlyphImages[index] = sub
+    return sub
 }
 
 func toFloatArray(color color.Color) []float32 {

--- a/test/abilities/main.go
+++ b/test/abilities/main.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/util"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     mouselib "github.com/kazzmir/master-of-magic/lib/mouse"
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
@@ -199,7 +200,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/artifact/main.go
+++ b/test/artifact/main.go
@@ -8,6 +8,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/game/magic/audio"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/coroutine"
@@ -111,7 +112,7 @@ func (engine *Engine) Draw(screen *ebiten.Image){
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -121,7 +122,7 @@ func main(){
 
     size := monitorWidth / 390
 
-    ebiten.SetWindowSize(data.ScreenWidth / data.ScreenScale * size, data.ScreenHeight / data.ScreenScale * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
 
     ebiten.SetWindowTitle("page turn")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)

--- a/test/banish/main.go
+++ b/test/banish/main.go
@@ -11,6 +11,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/banish"
     "github.com/kazzmir/master-of-magic/game/magic/audio"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
 
@@ -85,7 +86,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/cast-spell/main.go
+++ b/test/cast-spell/main.go
@@ -6,6 +6,7 @@ import (
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/lib/lbx"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -96,13 +97,15 @@ func (engine *Engine) Draw(screen *ebiten.Image){
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    ebiten.SetWindowSize(data.ScreenWidth * 2, data.ScreenHeight * 2)
+    monitorWidth, _ := ebiten.Monitor().Size()
+    size := monitorWidth / 390
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
     ebiten.SetWindowTitle("page turn")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/city-enchantment/main.go
+++ b/test/city-enchantment/main.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/maplib"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/terrain"
     // "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/cityview"
@@ -95,6 +96,7 @@ func (engine *Engine) MakeUI() (*uilib.UI, context.Context, error) {
             Banner: data.BannerBlue,
         },
         TaxRate: fraction.Make(2, 1),
+        GlobalEnchantments: set.MakeSet[data.Enchantment](),
     }
 
     city := citylib.MakeCity("Boston", 3, 8, data.RaceHighElf, buildingInfo, &gameMap, &NoCityProvider{}, player)
@@ -183,7 +185,7 @@ func (engine *Engine) Draw(screen *ebiten.Image){
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/cityview/main.go
+++ b/test/cityview/main.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/cityview"
     "github.com/kazzmir/master-of-magic/game/magic/camera"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/terrain"
     "github.com/kazzmir/master-of-magic/game/magic/game"
@@ -241,7 +242,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -249,8 +250,7 @@ func main(){
 
     monitorWidth, _ := ebiten.Monitor().Size()
     size := monitorWidth / 390
-
-    ebiten.SetWindowSize(data.ScreenWidth / data.ScreenScale * size, data.ScreenHeight / data.ScreenScale * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
     ebiten.SetWindowTitle("city view")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/combat-info/main.go
+++ b/test/combat-info/main.go
@@ -11,6 +11,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/combat"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     // "github.com/kazzmir/master-of-magic/game/magic/hero"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
@@ -118,7 +119,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -131,7 +132,7 @@ func main(){
 
     monitorWidth, _ := ebiten.Monitor().Size()
     size := monitorWidth / 390
-    ebiten.SetWindowSize(data.ScreenWidth / data.ScreenScale * size, data.ScreenHeight / data.ScreenScale * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
 
     ebiten.SetWindowTitle("combat info")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -790,7 +790,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return scale.Scale2(data.ScreenWidthOriginal, data.ScreenHeightOriginal)
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -812,7 +812,7 @@ func main(){
 
     monitorWidth, _ := ebiten.Monitor().Size()
     size := monitorWidth / 390
-    ebiten.SetWindowSize(data.ScreenWidth / int(data.ScreenScale2) * size, data.ScreenHeight / int(data.ScreenScale2) * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
 
     ebiten.SetWindowTitle("combat screen")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)

--- a/test/diplomacy/main.go
+++ b/test/diplomacy/main.go
@@ -8,6 +8,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/diplomacy"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -83,13 +84,13 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    ebiten.SetWindowSize(data.ScreenWidth * 5, data.ScreenHeight * 5)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("diplomacy")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/font/main.go
+++ b/test/font/main.go
@@ -62,9 +62,9 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
     y += 60
     engine.VaultFonts.ItemName.Print(screen, 10, y, 4, ebiten.ColorScale{}, "This is a test of font outlines")
     y += 60
-    engine.VaultFonts.ItemName.PrintOptions(screen, 10, y, 4, ebiten.ColorScale{}, font.FontOptions{DropShadow: true, ShadowColor: color.RGBA{R: 255, G: 0, B: 0, A: 255}}, "This is a test of font outlines")
+    engine.VaultFonts.ItemName.PrintOptions2(screen, 10, y, font.FontOptions{DropShadow: true, ShadowColor: color.RGBA{R: 255, G: 0, B: 0, A: 255}, Scale: 4}, "This is a test of font outlines")
     y += 60
-    engine.VaultFonts.ItemName.PrintOptions(screen, 10, y, 4, ebiten.ColorScale{}, font.FontOptions{DropShadow: true}, "This is a test of font outlines")
+    engine.VaultFonts.ItemName.PrintOptions2(screen, 10, y, font.FontOptions{DropShadow: true, Scale: 4}, "This is a test of font outlines")
 
     y += 60
 

--- a/test/font/main.go
+++ b/test/font/main.go
@@ -62,9 +62,9 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
     y += 60
     engine.VaultFonts.ItemName.Print(screen, 10, y, 4, ebiten.ColorScale{}, "This is a test of font outlines")
     y += 60
-    engine.VaultFonts.ItemName.PrintOptions2(screen, 10, y, font.FontOptions{DropShadow: true, ShadowColor: color.RGBA{R: 255, G: 0, B: 0, A: 255}, Scale: 4}, "This is a test of font outlines")
+    engine.VaultFonts.ItemName.PrintOptions(screen, 10, y, font.FontOptions{DropShadow: true, ShadowColor: color.RGBA{R: 255, G: 0, B: 0, A: 255}, Scale: 4}, "This is a test of font outlines")
     y += 60
-    engine.VaultFonts.ItemName.PrintOptions2(screen, 10, y, font.FontOptions{DropShadow: true, Scale: 4}, "This is a test of font outlines")
+    engine.VaultFonts.ItemName.PrintOptions(screen, 10, y, font.FontOptions{DropShadow: true, Scale: 4}, "This is a test of font outlines")
 
     y += 60
 

--- a/test/font/main.go
+++ b/test/font/main.go
@@ -7,6 +7,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/fonts"
     "github.com/kazzmir/master-of-magic/game/magic/shaders"
@@ -79,13 +80,13 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    ebiten.SetWindowSize(data.ScreenWidth * 2, data.ScreenHeight * 2)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("intro")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/hire-hero/main.go
+++ b/test/hire-hero/main.go
@@ -10,6 +10,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
@@ -75,7 +76,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/hire-mercenaries/main.go
+++ b/test/hire-mercenaries/main.go
@@ -9,6 +9,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
@@ -73,7 +74,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/intro/intro.go
+++ b/test/intro/intro.go
@@ -8,6 +8,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/audio"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     introlib "github.com/kazzmir/master-of-magic/game/magic/intro"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -59,7 +60,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -77,7 +78,7 @@ func main(){
 
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    ebiten.SetWindowSize(data.ScreenWidth * 5, data.ScreenHeight * 5)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("intro")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/magicview/main.go
+++ b/test/magicview/main.go
@@ -10,6 +10,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/util"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -112,7 +113,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -122,7 +123,7 @@ func main(){
 
     size := monitorWidth / 390
 
-    ebiten.SetWindowSize(data.ScreenWidth / data.ScreenScale * size, data.ScreenHeight / data.ScreenScale * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
 
     ebiten.SetWindowTitle("magic view")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)

--- a/test/main-screen/main.go
+++ b/test/main-screen/main.go
@@ -6,6 +6,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/mainview"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
 
     "github.com/hajimehoshi/ebiten/v2"
     "github.com/hajimehoshi/ebiten/v2/inpututil"
@@ -54,13 +55,13 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    ebiten.SetWindowSize(data.ScreenWidth * 2, data.ScreenHeight * 2)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("main screen")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/merchant/main.go
+++ b/test/merchant/main.go
@@ -9,6 +9,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
 
@@ -106,7 +107,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/mirror/main.go
+++ b/test/mirror/main.go
@@ -9,7 +9,9 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/mirror"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/set"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     "github.com/kazzmir/master-of-magic/game/magic/hero"
@@ -45,6 +47,7 @@ func NewEngine(scenario int) (*Engine, error) {
                 data.RetortFamous,
             },
         },
+        GlobalEnchantments: set.MakeSet[data.Enchantment](),
         Fame: 100,
         Gold: 2123,
         Mana: 23455,
@@ -96,7 +99,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -106,7 +109,7 @@ func main(){
 
     size := monitorWidth / 390
 
-    ebiten.SetWindowSize(data.ScreenWidth / data.ScreenScale * size, data.ScreenHeight / data.ScreenScale * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
 
     ebiten.SetWindowTitle("mirror")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)

--- a/test/new-screen/main.go
+++ b/test/new-screen/main.go
@@ -6,6 +6,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
 
     "github.com/hajimehoshi/ebiten/v2"
     "github.com/hajimehoshi/ebiten/v2/inpututil"
@@ -56,14 +57,14 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
 
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    ebiten.SetWindowSize(data.ScreenWidth * 2, data.ScreenHeight * 2)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("new screen")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -4719,7 +4719,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return scale.Scale2(data.ScreenWidthOriginal, data.ScreenHeightOriginal)
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -295,7 +295,7 @@ func createScenario4(cache *lbx.LbxCache) *gamelib.Game {
                 Count: 3,
             },
             data.WizardBook{
-                Magic: data.ChaosMagic,
+                Magic: data.SorceryMagic,
                 Count: 8,
             },
         },

--- a/test/page-turn/main.go
+++ b/test/page-turn/main.go
@@ -166,25 +166,25 @@ func RightSideFlipLeftDistortions1(page *ebiten.Image) util.Distortion {
 func (engine *Engine) DrawPage1(screen *ebiten.Image, page *ebiten.Image, options ebiten.DrawImageOptions){
     screen.DrawImage(page, &options)
     distortions := spellbook.LeftSideDistortions1(page)
-    util.DrawDistortion(screen, page, engine.PageImage, distortions, options)
+    util.DrawDistortion(screen, page, engine.PageImage, distortions, options.GeoM)
 }
 
 func (engine *Engine) DrawPage2(screen *ebiten.Image, page *ebiten.Image, options ebiten.DrawImageOptions){
     screen.DrawImage(page, &options)
     distortions := spellbook.LeftSideDistortions2(page)
-    util.DrawDistortion(screen, page, engine.PageImage, distortions, options)
+    util.DrawDistortion(screen, page, engine.PageImage, distortions, options.GeoM)
 }
 
 func (engine *Engine) DrawPage3(screen *ebiten.Image, page *ebiten.Image, options ebiten.DrawImageOptions){
     screen.DrawImage(page, &options)
     distortions := spellbook.RightSideDistortions1(page)
-    util.DrawDistortion(screen, page, engine.PageImage, distortions, options)
+    util.DrawDistortion(screen, page, engine.PageImage, distortions, options.GeoM)
 }
 
 func (engine *Engine) DrawPage4(screen *ebiten.Image, page *ebiten.Image, options ebiten.DrawImageOptions){
     screen.DrawImage(page, &options)
     distortions := spellbook.RightSideDistortions2(page)
-    util.DrawDistortion(screen, page, engine.PageImage, distortions, options)
+    util.DrawDistortion(screen, page, engine.PageImage, distortions, options.GeoM)
 }
 
 func (engine *Engine) Draw(screen *ebiten.Image){

--- a/test/page-turn/main.go
+++ b/test/page-turn/main.go
@@ -274,9 +274,9 @@ func NewEngine() (*Engine, error){
     spellPage := ebiten.NewImage(150, 170)
     spellPage.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 0})
 
-    textFont.PrintWrap(spellPage, 0, 5, 135, 1, ebiten.ColorScale{}, font.FontOptions{}, "This is a test of the emergency broadcast system. This is only a test. If this were a real emergency, you would be instructed to do something else.")
+    textFont.PrintWrap(spellPage, 0, 5, 135, font.FontOptions{}, "This is a test of the emergency broadcast system. This is only a test. If this were a real emergency, you would be instructed to do something else.")
     // textFont.PrintWrap(spellPage, 0, 50, 135, 1, ebiten.ColorScale{}, "A sub-image returned by SubImage can be used as a rendering source and a rendering destination. If a sub-image is used as a rendering source, the image is used as if it is a small image. If a sub-image is used as a rendering destination, the region being rendered is clipped.")
-    textFont.PrintWrap(spellPage, 0, 50, 135, 1, ebiten.ColorScale{}, font.FontOptions{}, "aaaaa aaaaaa bbbbb bbbbb bbbb ccccc ccccc ccccc ccc dddd ddddd dddd dddd eeee eeee eeee")
+    textFont.PrintWrap(spellPage, 0, 50, 135, font.FontOptions{}, "aaaaa aaaaaa bbbbb bbbbb bbbb ccccc ccccc ccccc ccc dddd ddddd dddd dddd eeee eeee eeee")
 
     vector.DrawFilledCircle(spellPage, 10, 90, 5, color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}, true)
     vector.DrawFilledCircle(spellPage, 45, 90, 5, color.RGBA{R: 0x0, G: 0xff, B: 0, A: 0xff}, true)
@@ -286,9 +286,9 @@ func NewEngine() (*Engine, error){
 
     leftPage := ebiten.NewImage(150, 170)
     leftPage.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 0})
-    textFont.PrintWrap(leftPage, 5, 5, 135, 1, ebiten.ColorScale{}, font.FontOptions{}, "This is some text on the left page. Note that an important logic should not rely on values returned by RGBA64At, since the returned values can include very slight differences between some machines.")
+    textFont.PrintWrap(leftPage, 5, 5, 135, font.FontOptions{}, "This is some text on the left page. Note that an important logic should not rely on values returned by RGBA64At, since the returned values can include very slight differences between some machines.")
     rightPage := ebiten.NewImage(150, 170)
-    textFont.PrintWrap(rightPage, 5, 5, 135, 1, ebiten.ColorScale{}, font.FontOptions{}, "If the shader unit is texels, one of the specified image is non-nil and its size is different from (width, height), DrawTrianglesShader panics. If one of the specified image is non-nil and is disposed, DrawTrianglesShader panics.")
+    textFont.PrintWrap(rightPage, 5, 5, 135, font.FontOptions{}, "If the shader unit is texels, one of the specified image is non-nil and its size is different from (width, height), DrawTrianglesShader panics. If one of the specified image is non-nil and is disposed, DrawTrianglesShader panics.")
 
     return &Engine{
         Cache: cache,

--- a/test/scale/main.go
+++ b/test/scale/main.go
@@ -159,7 +159,7 @@ func NewEngine(scenario int) (*Engine, error) {
     }, nil
 }
 
-func (engine *Engine) ChangeScale(scaleAmount int, algorithm data.ScaleAlgorithm) {
+func (engine *Engine) ChangeScale(scaleAmount int, algorithm scale.ScaleAlgorithm) {
     /*
     data.ScreenScale = 1
     data.ScreenScaleAlgorithm = algorithm
@@ -182,16 +182,16 @@ func (engine *Engine) Update() error {
     for _, key := range keys {
         switch key {
             case ebiten.KeyEscape, ebiten.KeyCapsLock: return ebiten.Termination
-            case ebiten.KeyF1: engine.ChangeScale(1, data.ScaleAlgorithmNormal)
-            case ebiten.KeyF2: engine.ChangeScale(2, data.ScaleAlgorithmNormal)
-            case ebiten.KeyF3: engine.ChangeScale(3, data.ScaleAlgorithmNormal)
-            case ebiten.KeyF4: engine.ChangeScale(4, data.ScaleAlgorithmNormal)
-            case ebiten.KeyF5: engine.ChangeScale(2, data.ScaleAlgorithmScale)
-            case ebiten.KeyF6: engine.ChangeScale(3, data.ScaleAlgorithmScale)
-            case ebiten.KeyF7: engine.ChangeScale(4, data.ScaleAlgorithmScale)
-            case ebiten.KeyF8: engine.ChangeScale(2, data.ScaleAlgorithmXbr)
-            case ebiten.KeyF9: engine.ChangeScale(3, data.ScaleAlgorithmXbr)
-            case ebiten.KeyF10: engine.ChangeScale(4, data.ScaleAlgorithmXbr)
+            case ebiten.KeyF1: engine.ChangeScale(1, scale.ScaleAlgorithmNormal)
+            case ebiten.KeyF2: engine.ChangeScale(2, scale.ScaleAlgorithmNormal)
+            case ebiten.KeyF3: engine.ChangeScale(3, scale.ScaleAlgorithmNormal)
+            case ebiten.KeyF4: engine.ChangeScale(4, scale.ScaleAlgorithmNormal)
+            case ebiten.KeyF5: engine.ChangeScale(2, scale.ScaleAlgorithmScale)
+            case ebiten.KeyF6: engine.ChangeScale(3, scale.ScaleAlgorithmScale)
+            case ebiten.KeyF7: engine.ChangeScale(4, scale.ScaleAlgorithmScale)
+            case ebiten.KeyF8: engine.ChangeScale(2, scale.ScaleAlgorithmXbr)
+            case ebiten.KeyF9: engine.ChangeScale(3, scale.ScaleAlgorithmXbr)
+            case ebiten.KeyF10: engine.ChangeScale(4, scale.ScaleAlgorithmXbr)
         }
     }
 

--- a/test/scale/main.go
+++ b/test/scale/main.go
@@ -16,6 +16,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
     "github.com/kazzmir/master-of-magic/game/magic/console"
     "github.com/kazzmir/master-of-magic/game/magic/maplib"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     gamelib "github.com/kazzmir/master-of-magic/game/magic/game"
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
@@ -158,13 +159,16 @@ func NewEngine(scenario int) (*Engine, error) {
     }, nil
 }
 
-func (engine *Engine) ChangeScale(scale int, algorithm data.ScaleAlgorithm) {
+func (engine *Engine) ChangeScale(scaleAmount int, algorithm data.ScaleAlgorithm) {
+    /*
     data.ScreenScale = 1
     data.ScreenScaleAlgorithm = algorithm
     data.ScreenWidth = 320 * scale
     data.ScreenHeight = 200 * scale
+    */
+    scale.UpdateScale(float64(scaleAmount))
 
-    log.Printf("Changing scale to %v %v", data.ScreenScale, data.ScreenScaleAlgorithm)
+    log.Printf("Changing scale to %v %v", scaleAmount, algorithm)
 
     engine.Game.UpdateImages()
     engine.Game.RefreshUI()
@@ -223,7 +227,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
@@ -234,7 +238,7 @@ func main(){
 
     size := monitorWidth / 390
 
-    ebiten.SetWindowSize(data.ScreenWidth / data.ScreenScale * size, data.ScreenHeight / data.ScreenScale * size)
+    ebiten.SetWindowSize(data.ScreenWidth * size, data.ScreenHeight * size)
     ebiten.SetWindowTitle("new screen")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 
@@ -249,8 +253,10 @@ func main(){
         }
     }
 
+    /*
     data.ScreenWidth = data.ScreenWidthOriginal * 3
     data.ScreenHeight = data.ScreenHeightOriginal * 3
+    */
 
     audio.Initialize()
     mouse.Initialize()

--- a/test/shader/main.go
+++ b/test/shader/main.go
@@ -10,6 +10,7 @@ import (
     "strconv"
 
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/shaders"
     "github.com/kazzmir/master-of-magic/game/magic/terrain"
     "github.com/kazzmir/master-of-magic/game/magic/util"
@@ -156,7 +157,7 @@ func DrawScenario2(engine *Engine, screen *ebiten.Image){
     // FIXME: Test with sparkles
     // FIXME: Test with unit
     // FIXME: Test with other node type
-    natureNode := ebiten.NewImageFromImage(engine.ImageCache.ApplyScale(data.Tiles[terrain.IndexNatNode].Images[0]))
+    natureNode := ebiten.NewImageFromImage(data.Tiles[terrain.IndexNatNode].Images[0])
 
     shader, err := engine.ImageCache.GetShader(shaders.ShaderWarp)
     if err != nil {
@@ -179,7 +180,7 @@ func DrawScenario2(engine *Engine, screen *ebiten.Image){
 func DrawScenario3(engine *Engine, screen *ebiten.Image){
     screen.Fill(color.RGBA{R: 60, G: 60, B: 120, A: 255})
 
-    data.ScreenScale = 3
+    // data.ScreenScale = 3
 
     newCache := util.MakeImageCache(engine.Cache)
     engine.ImageCache = &newCache
@@ -225,14 +226,14 @@ func DrawScenario3(engine *Engine, screen *ebiten.Image){
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){
     log.SetFlags(log.Ldate | log.Lshortfile | log.Lmicroseconds)
 
-    data.ScreenScale = 1
-    ebiten.SetWindowSize(data.ScreenWidth * 2, data.ScreenHeight * 2)
+    scale.UpdateScale(1)
+    ebiten.SetWindowSize(data.ScreenWidth * 4, data.ScreenHeight * 4)
     ebiten.SetWindowTitle("shader test")
     ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 

--- a/test/summon/main.go
+++ b/test/summon/main.go
@@ -9,6 +9,7 @@ import (
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/game/magic/summon"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/units"
 
     "github.com/hajimehoshi/ebiten/v2"
@@ -70,7 +71,7 @@ func (engine *Engine) Draw(screen *ebiten.Image) {
 }
 
 func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-    return data.ScreenWidth, data.ScreenHeight
+    return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
 }
 
 func main(){

--- a/util/combat-simulator/main.go
+++ b/util/combat-simulator/main.go
@@ -678,7 +678,6 @@ func (engine *Engine) MakeBugUI() *ebitenui.UI {
 
 func (engine *Engine) MakeUI() *ebitenui.UI {
     imageCache := util.MakeImageCache(engine.Cache)
-    imageCache.ScaleAmount = 1
 
     face, _ := loadFont(19)
 

--- a/util/combat-simulator/main.go
+++ b/util/combat-simulator/main.go
@@ -21,6 +21,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/combat"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/mouse"
     "github.com/kazzmir/master-of-magic/game/magic/audio"
@@ -370,7 +371,7 @@ func (engine *Engine) Layout(outsideWidth, outsideHeight int) (screenWidth, scre
         case EngineModeMenu, EngineModeBugReport:
             return outsideWidth, outsideHeight
         case EngineModeCombat:
-            return data.ScreenWidth, data.ScreenHeight
+            return scale.Scale2(data.ScreenWidth, data.ScreenHeight)
     }
 
     return outsideWidth, outsideHeight


### PR DESCRIPTION
Use ebiten's geom scaling to render upscaled graphics rather than applying upscaling algorithms directly to images. The changes are roughly:
* use scale.DrawScaled instead of screen.DrawImage()
```
screen.DrawImage(img, &options) // old
scale.DrawScaled(screen, img, &options) // new
```
In some cases it is also feasible to use screen.DrawImage() but to explicitly scale the options
```
screen.DrawImage(img, scale.ScaleOptions(options))
```
However scale.ScaleOptions() allocates a new ebiten.DrawImageOptions, so it is less preferred then using the unallocating scale.DrawScaled() method.
* set the Scale field of font.FontOptions{} when using the font package to print text
```
somefont.PrintOptions(dest, x, y, font.FontOptions{Scale: scale.ScaleAmount}, "text")
```
* if using colorm to draw, then explicitly concat the scale.ScaledGeom to the options
```
var options colorm.DrawImageOptions
options.GeoM.Translate(x, y)
options.GeoM.Concat(scale.ScaledGeom)
colorm.DrawImage(..., &options)
```
* When taking a subimage of screen, create the rect with unscaled coordinates and apply scale.ScaleRect to the SubImage call
```
sub := screen.SubImage(scale.ScaleRect(image.Rect(x1, y1, x2, y2)).(*ebiten.Image)
```
* When using the vector package to draw, apply scale.Scale() to each float32 argument
```
vector.DrawFilledRect(dest, scale.Scale(float32(x1)), scale.Scale(float32(y1)), ...)
```

There are various other times when values need to be scaled, and there are convenience methods in the scale package to do so.

Sometimes values need to be unscaled, in particular mouse coordinates are unscaled to convert them back into the game coordinate system.