### PR TITLE
add heroism projectile

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -2330,7 +2330,7 @@ func (combat *CombatScreen) doAI(yield coroutine.YieldFunc, aiUnit *ArmyUnit) {
 
     // try a ranged attack first
     if aiUnit.RangedAttacks > 0 {
-        candidates := slices.Clone(otherArmy.Units)
+        candidates := slices.Clone(otherArmy.units)
         slices.SortFunc(candidates, func (a *ArmyUnit, b *ArmyUnit) int {
             return cmp.Compare(computeTileDistance(aiUnit.X, aiUnit.Y, a.X, a.Y), computeTileDistance(aiUnit.X, aiUnit.Y, b.X, b.Y))
         })
@@ -2343,7 +2343,7 @@ func (combat *CombatScreen) doAI(yield coroutine.YieldFunc, aiUnit *ArmyUnit) {
         }
     }
 
-    for _, unit := range otherArmy.Units {
+    for _, unit := range otherArmy.units {
         if combat.withinMeleeRange(aiUnit, unit) && combat.Model.canMeleeAttack(aiUnit, unit) {
             combat.doMelee(yield, aiUnit, unit)
             return
@@ -2402,7 +2402,7 @@ func (combat *CombatScreen) doAI(yield coroutine.YieldFunc, aiUnit *ArmyUnit) {
     }
 
     // should filter by enemies that we can attack, so non-flyers do not move toward flyers
-    candidates := filterReachable(slices.Clone(otherArmy.Units))
+    candidates := filterReachable(slices.Clone(otherArmy.units))
 
     slices.SortFunc(candidates, func (a *ArmyUnit, b *ArmyUnit) int {
         aPath := getPath(a)
@@ -2495,13 +2495,13 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
         return CombatStateDefenderFlee
     }
 
-    if len(combat.Model.AttackingArmy.Units) == 0 {
+    if len(combat.Model.AttackingArmy.units) == 0 {
         combat.Model.AddLogEvent("Defender wins!")
         combat.Model.Finish()
         return CombatStateDefenderWin
     }
 
-    if len(combat.Model.DefendingArmy.Units) == 0 {
+    if len(combat.Model.DefendingArmy.units) == 0 {
         combat.Model.AddLogEvent("Attacker wins!")
         combat.Model.Finish()
         return CombatStateAttackerWin
@@ -3427,12 +3427,12 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image){
     }
 
     // sort units in top down order before drawing them
-    allUnits := make([]*ArmyUnit, 0, len(combat.Model.DefendingArmy.Units) + len(combat.Model.AttackingArmy.Units))
-    for _, unit := range combat.Model.DefendingArmy.Units {
+    allUnits := make([]*ArmyUnit, 0, len(combat.Model.DefendingArmy.units) + len(combat.Model.AttackingArmy.units))
+    for _, unit := range combat.Model.DefendingArmy.units {
         allUnits = append(allUnits, unit)
     }
 
-    for _, unit := range combat.Model.AttackingArmy.Units {
+    for _, unit := range combat.Model.AttackingArmy.units {
         allUnits = append(allUnits, unit)
     }
 

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -797,6 +797,18 @@ func (combat *CombatScreen) CreateHealingProjectile(target *ArmyUnit) *Projectil
     return combat.createUnitProjectile(target, explodeImages, UnitPositionMiddle, heal)
 }
 
+func (combat *CombatScreen) CreateHeroismProjectile(target *ArmyUnit) *Projectile {
+    // FIXME: the images should be mostly with with transparency
+    images, _ := combat.ImageCache.GetImages("specfx.lbx", 3)
+    explodeImages := images
+
+    effect := func (unit *ArmyUnit){
+        unit.AddEnchantment(data.UnitEnchantmentHeroism)
+    }
+
+    return combat.createUnitProjectile(target, explodeImages, UnitPositionMiddle, effect)
+}
+
 func (combat *CombatScreen) CreateChaosChannelsProjectile(target *ArmyUnit) *Projectile {
     images, _ := combat.ImageCache.GetImages("specfx.lbx", 2)
     explodeImages := images

--- a/game/magic/combat/combat_test.go
+++ b/game/magic/combat/combat_test.go
@@ -57,6 +57,43 @@ func BenchmarkAngle(bench *testing.B){
     tmp(final)
 }
 
+func TestUnitHealth(test *testing.T) {
+    unit := units.MakeOverworldUnit(units.LizardSpearmen, 0, 0, data.PlaneArcanus)
+    armyUnit := ArmyUnit{
+        Unit: unit,
+    }
+
+    if armyUnit.Figures() != 8 {
+        test.Errorf("Error: figures should be 8")
+    }
+
+    if armyUnit.GetDamage() != 0 {
+        test.Errorf("Error: damage should be 0")
+    }
+
+    // each figure has 2 hp, so taking one damage should keep 8 figures
+    armyUnit.TakeDamage(1)
+
+    if armyUnit.Figures() != 8 {
+        test.Errorf("Error: figures should be 8")
+    }
+
+    if armyUnit.GetDamage() != 1 {
+        test.Errorf("Error: damage should be 1")
+    }
+
+    // kill one figure
+    armyUnit.TakeDamage(1)
+
+    if armyUnit.Figures() != 7 {
+        test.Errorf("Error: figures should be 7")
+    }
+
+    if armyUnit.GetDamage() != 2 {
+        test.Errorf("Error: damage should be 2")
+    }
+}
+
 type TestObserver struct {
     Melee func(attacker *ArmyUnit, defender *ArmyUnit, damageRoll int)
     Throw func(attacker *ArmyUnit, defender *ArmyUnit, defenderDamage int)

--- a/game/magic/combat/combat_test.go
+++ b/game/magic/combat/combat_test.go
@@ -157,9 +157,9 @@ func TestBasicMelee(test *testing.T){
 
     observer := &TestObserver{
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee = true
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee = true
             }
         },
@@ -167,7 +167,7 @@ func TestBasicMelee(test *testing.T){
     combat.Observer.AddObserver(observer)
 
     // even if both units kill each other, they both get to attack
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if !attackerMelee || !defenderMelee {
         test.Errorf("Error: attacker and defender should have both attacked")
@@ -206,9 +206,9 @@ func TestAttackerHaste(test *testing.T){
 
     observer := &TestObserver{
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee += 1
             }
         },
@@ -216,7 +216,7 @@ func TestAttackerHaste(test *testing.T){
     combat.Observer.AddObserver(observer)
 
     // attacker should get to attack twice
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if attackerMelee != 2 {
         test.Errorf("Error: attacker should have attacked twice")
@@ -263,9 +263,9 @@ func TestFirstStrike(test *testing.T){
 
     observer := &TestObserver{
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee += 1
             }
         },
@@ -273,7 +273,7 @@ func TestFirstStrike(test *testing.T){
     combat.Observer.AddObserver(observer)
 
     // attacker should get to attack first
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if attackerMelee != 1 {
         test.Errorf("Error: attacker should have attacked once")
@@ -323,16 +323,16 @@ func TestFirstStrikeNegate(test *testing.T){
 
     observer := &TestObserver{
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee += 1
             }
         },
     }
     combat.Observer.AddObserver(observer)
 
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if attackerMelee != 1 {
         test.Errorf("Error: attacker should have attacked once")
@@ -381,21 +381,21 @@ func TestThrowAttack(test *testing.T){
 
     observer := &TestObserver{
         Throw: func(throwAttacker *ArmyUnit, throwDefender *ArmyUnit, damage int){
-            if throwAttacker == attackingArmy.Units[0] {
+            if throwAttacker == attackingArmy.units[0] {
                 attackerThrow += 1
             }
         },
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee += 1
             }
         },
     }
     combat.Observer.AddObserver(observer)
 
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if attackerThrow != 1 {
         test.Errorf("Error: attacker should have thrown once")
@@ -453,26 +453,26 @@ func TestThrownTouchAttack(test *testing.T){
 
     observer := &TestObserver{
         Throw: func(throwAttacker *ArmyUnit, throwDefender *ArmyUnit, damage int){
-            if throwAttacker == attackingArmy.Units[0] {
+            if throwAttacker == attackingArmy.units[0] {
                 attackerThrow += 1
             }
         },
         PoisonTouch: func(poisonAttacker *ArmyUnit, poisonDefender *ArmyUnit, damage int){
-            if attackingArmy.Units[0] == poisonAttacker {
+            if attackingArmy.units[0] == poisonAttacker {
                 attackerPoison += 1
             }
         },
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee += 1
             }
         },
     }
     combat.Observer.AddObserver(observer)
 
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if attackerThrow != 1 {
         test.Errorf("Error: attacker should have thrown once")
@@ -529,14 +529,14 @@ func TestFear(test *testing.T){
 
     observer := &TestObserver{
         Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
-            if attackingArmy.Units[0] == meleeAttacker {
+            if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
-            } else if defendingArmy.Units[0] == meleeAttacker {
+            } else if defendingArmy.units[0] == meleeAttacker {
                 defenderMelee += 1
             }
         },
         Fear: func(fearAttacker *ArmyUnit, fearDefender *ArmyUnit, fear int){
-            if fearAttacker != attackingArmy.Units[0] {
+            if fearAttacker != attackingArmy.units[0] {
                 test.Errorf("Error: attacker should have caused fear")
             }
 
@@ -547,7 +547,7 @@ func TestFear(test *testing.T){
     }
     combat.Observer.AddObserver(observer)
 
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
     if attackerMelee != 1 {
         test.Errorf("Error: attacker should have attacked once")
@@ -586,15 +586,15 @@ func TestCounterAttackPenalty(test *testing.T){
 
     combat.Initialize(spellbook.Spells{}, 0, 0)
 
-    if defendingArmy.Units[0].GetCounterAttackToHit() != 30 {
+    if defendingArmy.units[0].GetCounterAttackToHit() != 30 {
         test.Errorf("Error: defender should have normal 30%% counter attack to-hit")
     }
 
     // attack twice
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
-    combat.meleeAttack(attackingArmy.Units[0], defendingArmy.Units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
+    combat.meleeAttack(attackingArmy.units[0], defendingArmy.units[0])
 
-    if defendingArmy.Units[0].GetCounterAttackToHit() != 20 {
+    if defendingArmy.units[0].GetCounterAttackToHit() != 20 {
         test.Errorf("Error: defender should have 20%% counter attack to-hit")
     }
 }

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -1653,6 +1653,18 @@ func (army *Army) RemoveEnchantment(enchamtent data.CombatEnchantment) {
     })
 }
 
+// remove mutations done to the underlying stack units
+func (army *Army) Cleanup() {
+    // loop through all unit references and set the enchantment provider to nil
+    for _, unit := range army.KilledUnits {
+        unit.Unit.SetEnchantmentProvider(nil)
+    }
+
+    for _, unit := range army.units {
+        unit.Unit.SetEnchantmentProvider(nil)
+    }
+}
+
 func (army *Army) GetUnits() []*ArmyUnit {
     return army.units
 }
@@ -3441,6 +3453,8 @@ func (model *CombatModel) RemoveUnit(unit *ArmyUnit){
         model.AttackingArmy.RemoveUnit(unit)
     }
 
+    unit.Unit.SetEnchantmentProvider(nil)
+
     model.Tiles[unit.Y][unit.X].Unit = nil
 
     if unit == model.SelectedUnit {
@@ -3588,6 +3602,9 @@ func (model *CombatModel) Finish() {
 
     killUnits(model.DefendingArmy)
     killUnits(model.AttackingArmy)
+
+    model.DefendingArmy.Cleanup()
+    model.AttackingArmy.Cleanup()
 }
 
 // returns true if the spell should be dispelled (due to counter magic, magic nodes, etc)

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -3747,6 +3747,7 @@ type SpellSystem interface {
     CreateCreatureBindingProjectile(target *ArmyUnit) *Projectile
     CreatePetrifyProjectile(target *ArmyUnit) *Projectile
     CreateChaosChannelsProjectile(target *ArmyUnit) *Projectile
+    CreateHeroismProjectile(target *ArmyUnit) *Projectile
 
     GetAllSpells() spellbook.Spells
 }
@@ -4441,9 +4442,33 @@ func (model *CombatModel) InvokeSpell(spellSystem SpellSystem, player *playerlib
                 }
             }
 
+        case "Heroism":
+            model.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
+                model.AddProjectile(spellSystem.CreateHeroismProjectile(target))
+                castedCallback()
+            }, func (target *ArmyUnit) bool {
+                if target.GetRace() == data.RaceFantastic {
+                    return false
+                }
+
+                if target.GetRealm() == data.DeathMagic {
+                    return false
+                }
+
+                // elite level for both units and heroes is 3
+                if target.GetExperienceData().ToInt() >= 3 {
+                    return false
+                }
+
+                if target.HasEnchantment(data.UnitEnchantmentHeroism) {
+                    return false
+                }
+
+                return true
+            })
+
         /*
         unit enchantments:
-        Heroism
         Holy Armor
         Holy Weapon
         Invulnerability

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -642,7 +642,7 @@ func (unit *ArmyUnit) GetRangedAttackDamageType() units.Damage {
 }
 
 func (unit *ArmyUnit) GetDamage() int {
-    return unit.Unit.GetMaxHealth() - unit.Unit.GetHealth()
+    return unit.Unit.GetDamage()
 }
 
 func (unit *ArmyUnit) GetRealm() data.MagicType {
@@ -2421,7 +2421,6 @@ func (model *CombatModel) addNewUnit(player *playerlib.Player, x int, y int, uni
     newUnit := ArmyUnit{
         Unit: &units.OverworldUnit{
             Unit: unit,
-            Health: unit.GetMaxHealth(),
         },
         Facing: facing,
         Moving: false,

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -1132,6 +1132,10 @@ func (unit *ArmyUnit) HasAbility(ability data.AbilityType) bool {
     return false
 }
 
+func (unit *ArmyUnit) HasEnchantmentOnly(enchantment data.UnitEnchantment) bool {
+    return slices.Contains(unit.Enchantments, enchantment)
+}
+
 func (unit *ArmyUnit) HasEnchantment(enchantment data.UnitEnchantment) bool {
     if unit.Unit.HasEnchantment(enchantment) {
         return true

--- a/game/magic/combat/spell_test.go
+++ b/game/magic/combat/spell_test.go
@@ -198,7 +198,7 @@ func TestFireballSpell(test *testing.T){
     spellObject := &TestSpellSystem{
         createFireballProjectile: func (target *ArmyUnit, cost int) *Projectile {
             createdFireball = true
-            if target != defendingArmy.Units[0] {
+            if target != defendingArmy.units[0] {
                 test.Errorf("Expected the defender to be targeted")
             }
 
@@ -217,7 +217,7 @@ func TestFireballSpell(test *testing.T){
                 test.Errorf("Expected event to be select unit")
             }
 
-            selectUnit.SelectTarget(defendingArmy.Units[0])
+            selectUnit.SelectTarget(defendingArmy.units[0])
         default:
             test.Errorf("Expected select unit event")
     }

--- a/game/magic/combat/spell_test.go
+++ b/game/magic/combat/spell_test.go
@@ -147,6 +147,10 @@ func (system *TestSpellSystem) CreateChaosChannelsProjectile(target *ArmyUnit) *
     return nil
 }
 
+func (system *TestSpellSystem) CreateHeroismProjectile(target *ArmyUnit) *Projectile {
+    return nil
+}
+
 func (system *TestSpellSystem) GetAllSpells() spellbook.Spells {
     return spellbook.Spells{}
 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -196,9 +196,9 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 unit.RemoveEnchantment(data.UnitEnchantmentLycanthropy)
                 overworldUnit, ok := unit.(*units.OverworldUnit)
                 if ok {
-                    damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
+                    // damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
                     overworldUnit.Unit = units.WereWolf
-                    overworldUnit.Health = overworldUnit.GetMaxHealth() - damage
+                    // overworldUnit.Health = overworldUnit.GetMaxHealth() - damage
                     overworldUnit.Experience = 0
                     // unit keeps weapon bonus and enchantments
                 }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4542,7 +4542,7 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
         attackerFame += winner
         defenderFame += loser
 
-        for _, unit := range attackingArmy.Units {
+        for _, unit := range attackingArmy.GetUnits() {
             if unit.Unit.GetHealth() > 0 {
                 attackerStack.AddUnit(unit.Unit)
                 unit.Unit.SetBanner(attacker.GetBanner())
@@ -4555,7 +4555,7 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
         defenderFame += winner
         attackerFame += loser
 
-        for _, unit := range defendingArmy.Units {
+        for _, unit := range defendingArmy.GetUnits() {
             if unit.Unit.GetHealth() > 0 {
                 defenderStack.AddUnit(unit.Unit)
                 unit.Unit.SetBanner(defender.GetBanner())

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -525,17 +525,21 @@ func (hero *Hero) GetHireFee() int {
 }
 
 func (hero *Hero) AdjustHealth(amount int) {
-    hero.Unit.Health += amount
-    if hero.Unit.Health < 0 {
-        hero.Unit.Health = 0
+    hero.Unit.Damage -= amount
+    if hero.Unit.Damage < 0 {
+        hero.Unit.Damage = 0
     }
-    if hero.Unit.Health > hero.GetMaxHealth() {
-        hero.Unit.Health = hero.GetMaxHealth()
+    if hero.Unit.Damage > hero.GetMaxHealth() {
+        hero.Unit.Damage = hero.GetMaxHealth()
     }
 
     if hero.GetHealth() <= 0 {
         hero.SetStatus(StatusDead)
     }
+}
+
+func (hero *Hero) GetDamage() int {
+    return hero.Unit.Damage
 }
 
 func (hero *Hero) GetBusy() units.BusyStatus {

--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -625,6 +625,10 @@ func (hero *Hero) GetEnchantments() []data.UnitEnchantment {
     return append(hero.Unit.GetEnchantments(), artifactsEnchantments...)
 }
 
+func (hero *Hero) SetEnchantmentProvider(provider units.EnchantmentProvider) {
+    hero.Unit.SetEnchantmentProvider(provider)
+}
+
 // note that HasEnchantment is not the same as contains(GetEnchantments(), enchantment) because HasEnchantment will search
 // in the artifacts as well. GetEnchantments will only return the enchantments that have been explicitly cast on a unit
 func (hero *Hero) HasEnchantment(enchantment data.UnitEnchantment) bool {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -310,7 +310,7 @@ func (player *Player) AddHero(hero *herolib.Hero) bool {
             player.Heroes[i] = hero
 
             // keep the current level of the hero when creating a new overworld unit (which stores the experience)
-            level := hero.GetExperienceLevel()
+            level := hero.GetHeroExperienceLevel()
             experienceInfo := player.MakeExperienceInfo()
 
             hero.Unit = units.MakeOverworldUnitFromUnit(hero.GetRawUnit(), fortressCity.X, fortressCity.Y, fortressCity.Plane, player.Wizard.Banner, experienceInfo)

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -48,6 +48,10 @@ type OverworldUnit struct {
     ExtraEnchantments EnchantmentProvider
 }
 
+func (unit *OverworldUnit) SetEnchantmentProvider(provider EnchantmentProvider) {
+    unit.ExtraEnchantments = provider
+}
+
 func (unit *OverworldUnit) AddEnchantment(enchantment data.UnitEnchantment) {
     unit.Enchantments = append(unit.Enchantments, enchantment)
     // keep list sorted

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -34,7 +34,8 @@ type OverworldUnit struct {
     X int
     Y int
     Id uint64
-    Health int
+    Damage int
+    // Health int
     // to get the level, use the conversion functions in experience.go
     Experience int
     WeaponBonus data.WeaponBonus
@@ -263,14 +264,15 @@ func (unit *OverworldUnit) GetRawUnit() Unit {
     return unit.Unit
 }
 
+// amount is a positive number to heal
 func (unit *OverworldUnit) AdjustHealth(amount int) {
-    unit.Health += amount
-    if unit.Health < 0 {
-        unit.Health = 0
+    unit.Damage -= amount
+    if unit.Damage < 0 {
+        unit.Damage = 0
     }
 
-    if unit.Health > unit.GetMaxHealth() {
-        unit.Health = unit.GetMaxHealth()
+    if unit.Damage > unit.GetMaxHealth() {
+        unit.Damage = unit.GetMaxHealth()
     }
 }
 
@@ -291,7 +293,11 @@ func (unit *OverworldUnit) GetCombatRangeIndex(facing Facing) int {
 }
 
 func (unit *OverworldUnit) GetHealth() int {
-    return unit.Health
+    return unit.GetMaxHealth() - unit.Damage
+}
+
+func (unit *OverworldUnit) GetDamage() int {
+    return unit.Damage
 }
 
 func (unit *OverworldUnit) GetMaxHealth() int {
@@ -731,7 +737,6 @@ func MakeOverworldUnitFromUnit(unit Unit, x int, y int, plane data.Plane, banner
         Banner: banner,
         Plane: plane,
         MovesLeft: fraction.FromInt(unit.MovementSpeed),
-        Health: unit.GetMaxHealth(),
         ExperienceInfo: experienceInfo,
         X: x,
         Y: y,

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -21,6 +21,10 @@ const (
     BusyStatusPatrol // any unit can patrol
 )
 
+type EnchantmentProvider interface {
+    HasEnchantmentOnly(data.UnitEnchantment) bool
+}
+
 type OverworldUnit struct {
     ExperienceInfo ExperienceInfo
     Unit Unit
@@ -39,6 +43,7 @@ type OverworldUnit struct {
     Busy BusyStatus
 
     Enchantments []data.UnitEnchantment
+    ExtraEnchantments EnchantmentProvider
 }
 
 func (unit *OverworldUnit) AddEnchantment(enchantment data.UnitEnchantment) {
@@ -50,7 +55,7 @@ func (unit *OverworldUnit) AddEnchantment(enchantment data.UnitEnchantment) {
 }
 
 func (unit *OverworldUnit) HasEnchantment(enchantment data.UnitEnchantment) bool {
-    return slices.Contains(unit.Enchantments, enchantment)
+    return slices.Contains(unit.Enchantments, enchantment) || (unit.ExtraEnchantments != nil && unit.ExtraEnchantments.HasEnchantmentOnly(enchantment))
 }
 
 func (unit *OverworldUnit) GetBusy() BusyStatus {

--- a/game/magic/units/overworld.go
+++ b/game/magic/units/overworld.go
@@ -43,6 +43,8 @@ type OverworldUnit struct {
     Busy BusyStatus
 
     Enchantments []data.UnitEnchantment
+
+    // this should be set during combat to the ArmyUnit, and unset at all other times
     ExtraEnchantments EnchantmentProvider
 }
 

--- a/game/magic/units/stack-unit.go
+++ b/game/magic/units/stack-unit.go
@@ -31,6 +31,7 @@ type StackUnit interface {
     AddEnchantment(data.UnitEnchantment)
     HasEnchantment(data.UnitEnchantment) bool
     RemoveEnchantment(data.UnitEnchantment)
+    SetEnchantmentProvider(EnchantmentProvider)
 
     MeleeEnchantmentBonus(data.UnitEnchantment) int
     DefenseEnchantmentBonus(data.UnitEnchantment) int

--- a/game/magic/units/stack-unit.go
+++ b/game/magic/units/stack-unit.go
@@ -82,6 +82,7 @@ type StackUnit interface {
     GetAttackSound() AttackSound
     GetCombatRangeIndex(Facing) int
     GetHealth() int
+    GetDamage() int
     GetMaxHealth() int
     GetMovementSound() MovementSound
     GetRangeAttackSound() RangeAttackSound

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -40,10 +40,9 @@ type Engine struct {
 }
 
 func createWarlockArmy(player *player.Player) *combat.Army {
-    return &combat.Army{
-        Player: player,
-        Units: []*combat.ArmyUnit{
-            /*
+    army := &combat.Army{Player: player}
+
+    /*
             &combat.ArmyUnit{
                 Unit: units.HighElfSpearmen,
                 Facing: units.FacingDownRight,
@@ -52,12 +51,15 @@ func createWarlockArmy(player *player.Player) *combat.Army {
                 Health: units.HighElfSpearmen.GetMaxHealth(),
             },
             */
-            &combat.ArmyUnit{
-                Unit: units.MakeOverworldUnitFromUnit(units.Warlocks, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-                Facing: units.FacingDownRight,
-                X: 12,
-                Y: 10,
-            },
+            /*
+    unit1 := &combat.ArmyUnit{
+        Unit: units.MakeOverworldUnitFromUnit(units.Warlocks, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
+        Facing: units.FacingDownRight,
+        X: 12,
+        Y: 10,
+    },
+    */
+    unit1 := units.MakeOverworldUnitFromUnit(units.Warlocks, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo())
             /*
             &combat.ArmyUnit{
                 Unit: units.HighElfSpearmen,
@@ -74,8 +76,9 @@ func createWarlockArmy(player *player.Player) *combat.Army {
                 Health: units.HighElfSpearmen.GetMaxHealth(),
             },
             */
-        },
-    }
+
+    army.AddUnit(unit1)
+    return army
 }
 
 func createWarlockArmyN(player *player.Player, count int) *combat.Army {
@@ -132,90 +135,50 @@ func createHighMenBowmanArmyN(player *player.Player, count int) combat.Army {
 }
 
 func createHighMenBowmanArmy(player *player.Player) *combat.Army {
-    return &combat.Army{
-        Player: player,
-        Units: []*combat.ArmyUnit{
-            &combat.ArmyUnit{
-                Unit: units.MakeOverworldUnitFromUnit(units.HighMenBowmen, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-                Facing: units.FacingDownRight,
-                X: 12,
-                Y: 10,
-            },
-        },
-    }
+    army := combat.Army{Player: player}
+    unit := units.MakeOverworldUnitFromUnit(units.HighMenBowmen, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo())
+    army.AddUnit(unit)
+    return &army
 }
 
 func createGreatDrakeArmy(player *player.Player) *combat.Army{
-    return &combat.Army{
-        Player: player,
-        Units: []*combat.ArmyUnit{
-            &combat.ArmyUnit{
-                Unit: units.MakeOverworldUnitFromUnit(units.GreatDrake, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-                Facing: units.FacingUpLeft,
-                X: 10,
-                Y: 17,
-            },
-            &combat.ArmyUnit{
-                Unit: units.MakeOverworldUnitFromUnit(units.GreatDrake, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-                Facing: units.FacingUpLeft,
-                X: 9,
-                Y: 18,
-            },
-        },
-    }
+    army := combat.Army{Player: player}
+    army.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
+    army.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
+    return &army
 }
 
 func createSettlerArmy(player *player.Player, count int) *combat.Army{
-    var armyUnits []*combat.ArmyUnit
+    army := combat.Army{Player: player}
 
-    for i := 0; i < count; i++ {
-        armyUnits = append(armyUnits, &combat.ArmyUnit{
-            Unit: units.MakeOverworldUnitFromUnit(units.HighElfSettlers, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-            Facing: units.FacingUpLeft,
-            X: 10,
-            Y: 17,
-        })
+    for range count {
+        army.AddUnit(units.MakeOverworldUnitFromUnit(units.HighElfSettlers, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
     }
 
-    return &combat.Army{
-        Player: player,
-        Units: armyUnits,
-    }
+    return &army
 }
 
 func createArchAngelArmy(player *player.Player) *combat.Army {
-    var armyUnits []*combat.ArmyUnit
+    army := combat.Army{Player: player}
 
-    armyUnits = append(armyUnits, &combat.ArmyUnit{
-        Unit: units.MakeOverworldUnitFromUnit(units.ArchAngel, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-    })
+    army.AddUnit(units.MakeOverworldUnitFromUnit(units.ArchAngel, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
 
-    return &combat.Army{
-        Player: player,
-        Units: armyUnits,
-    }
+    return &army
 }
 
 func createDeathCreatureArmy(player *player.Player) *combat.Army {
-    var armyUnits []*combat.ArmyUnit
+    army := combat.Army{Player: player}
 
-    armyUnits = append(armyUnits, &combat.ArmyUnit{
-        Unit: units.MakeOverworldUnitFromUnit(units.DemonLord, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-    })
+    army.AddUnit(units.MakeOverworldUnitFromUnit(units.DemonLord, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
 
     // not death, but whatever
-    armyUnits = append(armyUnits, &combat.ArmyUnit{
-        Unit: units.MakeOverworldUnitFromUnit(units.HellHounds, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-    })
+    army.AddUnit(units.MakeOverworldUnitFromUnit(units.HellHounds, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
 
-    return &combat.Army{
-        Player: player,
-        Units: armyUnits,
-    }
+    return &army
 }
 
-func createHeroArmy(player *player.Player, cache *lbx.LbxCache) *combat.Army{
-    var armyUnits []*combat.ArmyUnit
+func createHeroArmy(player *player.Player, cache *lbx.LbxCache) *combat.Army {
+    army := combat.Army{Player: player}
 
     rakir := herolib.MakeHero(units.MakeOverworldUnitFromUnit(units.HeroRakir, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()), herolib.HeroRakir, "bubba")
 
@@ -232,9 +195,7 @@ func createHeroArmy(player *player.Player, cache *lbx.LbxCache) *combat.Army{
         },
     }
 
-    armyUnits = append(armyUnits, &combat.ArmyUnit{
-        Unit: rakir,
-    })
+    army.AddUnit(rakir)
 
     allSpells, _ := spellbook.ReadSpellsFromCache(cache)
 
@@ -255,29 +216,19 @@ func createHeroArmy(player *player.Player, cache *lbx.LbxCache) *combat.Army{
     torin := herolib.MakeHero(units.MakeOverworldUnitFromUnit(units.HeroTorin, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()), herolib.HeroTorin, "warby")
     torin.Equipment[0] = &item
 
-    armyUnits = append(armyUnits, &combat.ArmyUnit{
-        Unit: torin,
-    })
+    army.AddUnit(torin)
 
-    return &combat.Army{
-        Player: player,
-        Units: armyUnits,
-    }
+    return &army
 }
 
 func createWeakArmy(player *player.Player) *combat.Army {
-    var armyUnits []*combat.ArmyUnit
+    army := combat.Army{Player: player}
 
     for range 2 {
-        armyUnits = append(armyUnits, &combat.ArmyUnit{
-            Unit: units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
-        })
+        army.AddUnit(units.MakeOverworldUnitFromUnit(units.HighElfSpearmen, 1, 1, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()))
     }
 
-    return &combat.Army{
-        Player: player,
-        Units: armyUnits,
-    }
+    return &army
 }
 
 type BasicCatchment struct {
@@ -316,8 +267,8 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     defendingArmy := createLizardmenArmy(defendingPlayer, 3)
     defendingArmy.LayoutUnits(combat.TeamDefender)
 
-    defendingArmy.Units[0].AddCurse(data.UnitCurseBlackSleep)
-    defendingArmy.Units[1].AddCurse(data.UnitCurseConfusion)
+    defendingArmy.GetUnits()[0].AddCurse(data.UnitCurseBlackSleep)
+    defendingArmy.GetUnits()[1].AddCurse(data.UnitCurseConfusion)
 
     /*
     defendingArmy.AddEnchantment(data.CombatEnchantmentCounterMagic)
@@ -396,7 +347,7 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
     for range 2 {
-        attackingArmy.KillUnit(attackingArmy.Units[0])
+        attackingArmy.KillUnit(attackingArmy.GetUnits()[0])
     }
 
     // attackingArmy.Units[0].AddCurse(data.UnitCurseConfusion)
@@ -690,22 +641,20 @@ func makeScenario8(cache *lbx.LbxCache) *combat.CombatScreen {
 
     attackingArmy := createArchAngelArmy(attackingPlayer)
 
-    attackingArmy.Units = append(attackingArmy.Units, &combat.ArmyUnit{
-        Unit: units.MakeOverworldUnitFromUnit(units.GiantSpiders, 1, 1, data.PlaneArcanus, attackingPlayer.Wizard.Banner, attackingPlayer.MakeExperienceInfo()),
-    })
+    attackingArmy.AddUnit(units.MakeOverworldUnitFromUnit(units.GiantSpiders, 1, 1, data.PlaneArcanus, attackingPlayer.Wizard.Banner, attackingPlayer.MakeExperienceInfo()))
 
     attackingArmy.LayoutUnits(combat.TeamAttacker)
 
     attackingArmy.AddEnchantment(data.CombatEnchantmentWrack)
 
-    for _, unit := range attackingArmy.Units {
+    for _, unit := range attackingArmy.GetUnits() {
         unit.AddCurse(data.UnitCurseVertigo)
         unit.AddCurse(data.UnitCurseShatter)
     }
 
     defendingArmy.AddEnchantment(data.CombatEnchantmentEntangle)
 
-    for _, unit := range defendingArmy.Units {
+    for _, unit := range defendingArmy.GetUnits() {
         unit.AddEnchantment(data.UnitEnchantmentGiantStrength)
         unit.AddEnchantment(data.UnitEnchantmentHolyArmor)
     }

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -388,6 +388,7 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Call Chaos"))
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Raise Dead"))
     attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Animate Dead"))
+    attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Heroism"))
 
     // attackingArmy := createGreatDrakeArmy(&attackingPlayer)
     // attackingArmy := createWarlockArmyN(attackingPlayer, 3)


### PR DESCRIPTION
1. add heroism combat spell
2. track damage to a unit rather than its health, so that if the health of the unit increases the damage does not change
3. every unit has a reference to its containing ArmyUnit during combat that must be removed when combat ends via unit.SetEnchantmentProvider(nil)