### PR TITLE
cast: add recall hero and word of recall

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -773,9 +773,11 @@ func (combat *CombatScreen) CreateRecallHeroProjectile(target *ArmyUnit) *Projec
     images, _ := combat.ImageCache.GetImages("specfx.lbx", 5)
     explodeImages := images
 
-    // TODO
+    recall := func(unit *ArmyUnit) {
+        combat.Model.RecallUnit(unit)
+    }
 
-    return combat.createUnitProjectile(target, explodeImages, UnitPositionMiddle, func (*ArmyUnit){})
+    return combat.createUnitProjectile(target, explodeImages, UnitPositionMiddle, recall)
 }
 
 func (combat *CombatScreen) CreateHealingProjectile(target *ArmyUnit) *Projectile {
@@ -1099,9 +1101,11 @@ func (combat *CombatScreen) CreateWordOfRecallProjectile(target *ArmyUnit) *Proj
     images, _ := combat.ImageCache.GetImages("specfx.lbx", 1)
     explodeImages := images
 
-    // TODO
+    recall := func(unit *ArmyUnit) {
+        combat.Model.RecallUnit(unit)
+    }
 
-    return combat.createUnitProjectile(target, explodeImages, UnitPositionMiddle, func (*ArmyUnit){})
+    return combat.createUnitProjectile(target, explodeImages, UnitPositionMiddle, recall)
 }
 
 func (combat *CombatScreen) CreateDispelMagicProjectile(target *ArmyUnit, caster *playerlib.Player, dispelStrength int) *Projectile {

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -3989,7 +3989,6 @@ func (model *CombatModel) InvokeSpell(spellSystem SpellSystem, player *playerlib
             }, targetAny)
         case "Word of Recall":
             // FIXME: check planar seal and summoning circle?
-            // FIXME: not summoned units
             model.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
                 model.AddProjectile(spellSystem.CreateWordOfRecallProjectile(target))
                 castedCallback()

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -3988,7 +3988,8 @@ func (model *CombatModel) InvokeSpell(spellSystem SpellSystem, player *playerlib
                 castedCallback()
             }, targetAny)
         case "Word of Recall":
-            // FIXME:  check planar seal and summoning circle?
+            // FIXME: check planar seal and summoning circle?
+            // FIXME: not summoned units
             model.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
                 model.AddProjectile(spellSystem.CreateWordOfRecallProjectile(target))
                 castedCallback()

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -1669,6 +1669,7 @@ type Army struct {
     Auto bool
     Fled bool
     Casted bool
+    RecalledUnits []*ArmyUnit
 
     Enchantments []data.CombatEnchantment
 }
@@ -3405,6 +3406,15 @@ func (model *CombatModel) RemoveUnit(unit *ArmyUnit){
     if unit == model.SelectedUnit {
         model.NextUnit()
     }
+}
+
+func (model *CombatModel) RecallUnit(unit *ArmyUnit) {
+    if unit.Team == TeamDefender {
+        model.DefendingArmy.RecalledUnits = append(model.DefendingArmy.RecalledUnits, unit)
+    } else {
+        model.AttackingArmy.RecalledUnits = append(model.AttackingArmy.RecalledUnits, unit)
+    }
+    model.RemoveUnit(unit)
 }
 
 func (model *CombatModel) IsAIControlled(unit *ArmyUnit) bool {

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -3865,6 +3865,7 @@ func (model *CombatModel) InvokeSpell(spellSystem SpellSystem, player *playerlib
             }, targetFantastic)
             castedCallback()
         case "Recall Hero":
+            // FIXME:  check planar seal and summoning circle?
             model.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
                 model.AddProjectile(spellSystem.CreateRecallHeroProjectile(target))
                 castedCallback()
@@ -3928,6 +3929,7 @@ func (model *CombatModel) InvokeSpell(spellSystem SpellSystem, player *playerlib
                 castedCallback()
             }, targetAny)
         case "Word of Recall":
+            // FIXME:  check planar seal and summoning circle?
             model.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
                 model.AddProjectile(spellSystem.CreateWordOfRecallProjectile(target))
                 castedCallback()

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -3993,7 +3993,13 @@ func (model *CombatModel) InvokeSpell(spellSystem SpellSystem, player *playerlib
             model.DoTargetUnitSpell(player, spell, TargetFriend, func(target *ArmyUnit){
                 model.AddProjectile(spellSystem.CreateWordOfRecallProjectile(target))
                 castedCallback()
-            }, targetAny)
+            }, func (target *ArmyUnit) bool {
+                if target.Summoned {
+                    return false
+                }
+
+                return true
+            })
         case "Disintegrate":
             model.DoTargetUnitSpell(player, spell, TargetEnemy, func(target *ArmyUnit){
                 model.AddProjectile(spellSystem.CreateDisintegrateProjectile(target))

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -538,7 +538,6 @@ func (enchantment UnitEnchantment) LbxIndex() int {
 func (enchantment UnitEnchantment) CastAnimationIndex() int {
     switch enchantment {
         // nature
-        // FIXME: verify
         case UnitEnchantmentGiantStrength: return 0
         case UnitEnchantmentElementalArmor: return 0
         case UnitEnchantmentResistElements: return 0

--- a/game/magic/data/enchantment.go
+++ b/game/magic/data/enchantment.go
@@ -171,7 +171,6 @@ const (
     UnitEnchantmentBerserk
     UnitEnchantmentBlackChannels
     UnitEnchantmentWraithForm
-    UnitEnchantmentLycanthropy
 
     // curses
     UnitCurseConfusion
@@ -461,7 +460,6 @@ func (enchantment UnitEnchantment) LbxFile() string {
         case UnitEnchantmentBerserk: return "special2.lbx"
         case UnitEnchantmentBlackChannels: return "special.lbx"
         case UnitEnchantmentWraithForm: return "special.lbx"
-        case UnitEnchantmentLycanthropy: return "special.lbx"
 
         case UnitCurseConfusion: return "special2.lbx"
         case UnitCurseCreatureBinding: return "special.lbx"
@@ -555,7 +553,6 @@ func (enchantment UnitEnchantment) CastAnimationIndex() int {
         case UnitEnchantmentBerserk: return 4
         case UnitEnchantmentBlackChannels: return 4
         case UnitEnchantmentWraithForm: return 4
-        case UnitEnchantmentLycanthropy: return 4
 
         // chaos
         case UnitEnchantmentImmolation: return 2

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -568,12 +568,19 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             }
             after := func (unit units.StackUnit) bool {
                 summonCity := player.FindSummoningCity()
-                if summonCity != nil {
-                    unit.SetX(summonCity.X)
-                    unit.SetY(summonCity.Y)
+                if summonCity == nil {
+                    return false
                 }
 
-                // FIXME: maybe relocate
+                unit.SetX(summonCity.X)
+                unit.SetY(summonCity.Y)
+
+                allStacks := player.FindAllStacks(summonCity.X, summonCity.Y, summonCity.Plane)
+                for i := 1; i < len(allStacks); i++ {
+                    player.MergeStacks(allStacks[0], allStacks[i])
+                }
+
+                game.ResolveStackAt(summonCity.X, summonCity.Y, summonCity.Plane)
 
                 unit.SetBusy(units.BusyStatusNone)
 
@@ -847,6 +854,7 @@ func (game *Game) doSummonUnit(player *playerlib.Player, unit units.Unit) {
     if summonCity != nil {
         overworldUnit := units.MakeOverworldUnitFromUnit(unit, summonCity.X, summonCity.Y, summonCity.Plane, player.Wizard.Banner, player.MakeExperienceInfo())
         player.AddUnit(overworldUnit)
+        game.ResolveStackAt(summonCity.X, summonCity.Y, summonCity.Plane)
         game.RefreshUI()
     }
 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -195,9 +195,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             after := func (unit units.StackUnit) bool {
                 overworldUnit, ok := unit.(*units.OverworldUnit)
                 if ok {
-                    // damage := overworldUnit.GetMaxHealth() - overworldUnit.Health
                     overworldUnit.Unit = units.WereWolf
-                    // overworldUnit.Health = overworldUnit.GetMaxHealth() - damage
                     overworldUnit.Experience = 0
                     // unit keeps weapon bonus and enchantments
                 }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -567,22 +567,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                return true
             }
             after := func (unit units.StackUnit) bool {
-                summonCity := player.FindSummoningCity()
-                if summonCity == nil {
-                    return false
-                }
-
-                unit.SetX(summonCity.X)
-                unit.SetY(summonCity.Y)
-
-                allStacks := player.FindAllStacks(summonCity.X, summonCity.Y, summonCity.Plane)
-                for i := 1; i < len(allStacks); i++ {
-                    player.MergeStacks(allStacks[0], allStacks[i])
-                }
-
-                game.ResolveStackAt(summonCity.X, summonCity.Y, summonCity.Plane)
-
-                unit.SetBusy(units.BusyStatusNone)
+                game.RelocateUnit(player, unit)
 
                 return true
             }

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -555,7 +555,7 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
             }
             after := func (unit units.StackUnit) bool {
                 // FIXME: make a helper function which makes sure tile are not overcrowed
-                fortressCity := player.FindFortressCity()
+                fortressCity := player.FindSummoningCity()
                 if fortressCity != nil {
                     unit.SetX(fortressCity.X)
                     unit.SetY(fortressCity.Y)

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -420,7 +420,6 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 Great Unsummoning
                 Spell Binding
                 Stasis
-                Word of Recall
                 Fire Storm
                 Black Wind
                 Death Wish
@@ -548,6 +547,23 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 return true
             }
             game.doCastNewCityBuilding(spell, player, LocationTypeFriendlyCity, building.BuildingFortress, "Your fortress is already in this city", after)
+        case "Word of Recall":
+            before := func (unit units.StackUnit) bool {
+                // FIXME: this may bypass planar seal
+                // FIXME: this will do nothing if already at fortress city
+               return true
+            }
+            after := func (unit units.StackUnit) bool {
+                // FIXME: make a helper function which makes sure tile are not overcrowed
+                fortressCity := player.FindFortressCity()
+                if fortressCity != nil {
+                    unit.SetX(fortressCity.X)
+                    unit.SetY(fortressCity.Y)
+                }
+
+                return true
+            }
+            game.doCastOnUnit(player, spell, 1, before, after)
 
         default:
             log.Printf("Warning: casting unhandled spell '%v'", spell.Name)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3297,7 +3297,11 @@ func (game *Game) FindNearbyPosition(player *playerlib.Player, stack *playerlib.
                 }
             }
 
-            // FIXME: what to do in case of a friendly stack with not enough room?
+            // can not contain a friendly with too less room
+            existing := player.FindStack(cx, cy, plane)
+            if existing != nil && (len(existing.Units()) + len(stack.Units())) > 9 {
+                occupied = true
+            }
 
             if occupied {
                 continue

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2321,6 +2321,8 @@ func (game *Game) doHireHero(yield coroutine.YieldFunc, cost int, hero *herolib.
                 name := game.doInput(yield, "Hero Name", hero.GetName(), 70, 50)
                 hero.SetName(name)
 
+                game.ResolveStackAt(hero.GetX(), hero.GetY(), hero.GetPlane())
+
                 game.RefreshUI()
             }
         } else {
@@ -2487,6 +2489,7 @@ func (game *Game) doHireMercenaries(yield coroutine.YieldFunc, cost int, units [
         if hired {
             for _, unit := range units {
                 player.AddUnit(unit)
+                game.ResolveStackAt(unit.GetX(), unit.GetY(), unit.GetPlane())
             }
             player.Gold -= cost
             game.RefreshUI()
@@ -3256,8 +3259,8 @@ func (game *Game) doMoveCamera(yield coroutine.YieldFunc, x int, y int) {
     game.Camera.Center(game.CurrentMap().WrapX(x), y)
 }
 
-func (game *Game) doMoveFleeingDefender(player *playerlib.Player, stack *playerlib.UnitStack) {
-    // try to relocate a fleeing stack, kills units that are unable
+// try to find a nearby position that the given stack can move to
+func (game *Game) FindNearbyPosition(player *playerlib.Player, stack *playerlib.UnitStack) ([]image.Point, []image.Point) {
     x := stack.X()
     y := stack.Y()
     plane := stack.Plane()
@@ -3310,6 +3313,85 @@ func (game *Game) doMoveFleeingDefender(player *playerlib.Player, stack *playerl
             }
         }
     }
+
+    return positions, waterPositions
+}
+
+func (game *Game) ResolveStackAt(x int, y int, plane data.Plane) {
+    stack, player := game.FindStack(x, y, plane)
+    if stack == nil {
+        return
+    }
+
+    count := len(stack.Units())
+    if count <= 9 {
+        return
+    }
+
+    // try to move random units to a nearby tile
+    stackUnits := stack.Units()
+    for _, i := range rand.Perm(len(stackUnits)) {
+        unit := stackUnits[i]
+
+        subStack := playerlib.MakeUnitStackFromUnits([]units.StackUnit{unit})
+        positions, _ := game.FindNearbyPosition(player, subStack)
+
+        if len(positions) != 0 {
+            position := positions[rand.IntN(len(positions))]
+            unit.SetX(position.X)
+            unit.SetY(position.Y)
+
+            stack.RemoveUnit(unit)
+            player.AddStack(subStack)
+
+            allStacks := player.FindAllStacks(position.X, position.Y, stack.Plane())
+            for i := 1; i < len(allStacks); i++ {
+                player.MergeStacks(allStacks[0], allStacks[i])
+            }
+
+            count -= 1
+            if count <= 9 {
+                break
+            }
+        }
+    }
+
+    // kill units until if not enough room
+    if count > 9 {
+        stackUnits = stack.Units()
+        slices.SortFunc(stackUnits, func(unitA, unitB units.StackUnit) int {
+            // non-heros before heroes
+            if unitA.IsHero() != unitB.IsHero() {
+                if unitA.IsHero() {
+                    return 1
+                }
+                return -1
+            }
+
+            // low-leveled heroes first
+            if unitA.IsHero() && unitB.IsHero() {
+                return unitA.GetExperience() - unitB.GetExperience()
+            }
+
+            // low production or casting cost first
+            minCostA := min(unitA.GetRawUnit().ProductionCost, unitA.GetRawUnit().CastingCost)
+            minCostB := min(unitB.GetRawUnit().ProductionCost, unitB.GetRawUnit().CastingCost)
+            return minCostA - minCostB
+        })
+
+        for _, unit := range stackUnits {
+            player.RemoveUnit(unit)
+            count -= 1
+            if count <= 9 {
+                break
+            }
+        }
+    }
+}
+
+// try to relocate a fleeing stack, kills units that are unable
+func (game *Game) doMoveFleeingDefender(player *playerlib.Player, stack *playerlib.UnitStack) {
+    positions, waterPositions := game.FindNearbyPosition(player, stack)
 
     // kill units that can not move to water if only water is available
     if len(positions) == 0 && len(waterPositions) != 0 {
@@ -3866,11 +3948,9 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
                     create := decision.(*playerlib.AICreateUnitDecision)
                     log.Printf("ai %v creating %+v", player.Wizard.Name, create)
 
-                    existingStack := player.FindStack(create.X, create.Y, create.Plane)
-                    if existingStack == nil || len(existingStack.Units()) < 9 {
-                        overworldUnit := units.MakeOverworldUnitFromUnit(create.Unit, create.X, create.Y, create.Plane, player.Wizard.Banner, player.MakeExperienceInfo())
-                        player.AddUnit(overworldUnit)
-                    }
+                    overworldUnit := units.MakeOverworldUnitFromUnit(create.Unit, create.X, create.Y, create.Plane, player.Wizard.Banner, player.MakeExperienceInfo())
+                    player.AddUnit(overworldUnit)
+                    game.ResolveStackAt(create.X, create.Y, create.Plane)
                 case *playerlib.AIBuildOutpostDecision:
                     build := decision.(*playerlib.AIBuildOutpostDecision)
 
@@ -6643,6 +6723,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
                 }
                 overworldUnit.AddExperience(newUnit.Experience)
                 player.AddUnit(overworldUnit)
+                game.ResolveStackAt(city.X, city.Y, city.Plane)
 
                 if player.AIBehavior != nil {
                     player.AIBehavior.ProducedUnit(city, player)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3297,6 +3297,8 @@ func (game *Game) FindNearbyPosition(player *playerlib.Player, stack *playerlib.
                 }
             }
 
+            // FIXME: what to do in case of a friendly stack with not enough room?
+
             if occupied {
                 continue
             }
@@ -3380,6 +3382,7 @@ func (game *Game) ResolveStackAt(x int, y int, plane data.Plane) {
         })
 
         for _, unit := range stackUnits {
+            log.Printf("Unit %v killed by ResolveStack", unit)
             player.RemoveUnit(unit)
             count -= 1
             if count <= 9 {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3359,7 +3359,7 @@ func (game *Game) ResolveStackAt(x int, y int, plane data.Plane) {
         }
     }
 
-    // kill units until if not enough room
+    // kill units until enough room
     if count > 9 {
         stackUnits = stack.Units()
         slices.SortFunc(stackUnits, func(unitA, unitB units.StackUnit) int {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3259,7 +3259,7 @@ func (game *Game) doMoveCamera(yield coroutine.YieldFunc, x int, y int) {
     game.Camera.Center(game.CurrentMap().WrapX(x), y)
 }
 
-// try to find a nearby position that the given stack can move to
+// try to find a nearby position that the given unit can move to
 func (game *Game) FindEscapePosition(player *playerlib.Player, unit units.StackUnit) []image.Point {
     x := unit.GetX()
     y := unit.GetY()

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -8004,8 +8004,7 @@ func (game *Game) RelocateUnit(player *playerlib.Player, unit units.StackUnit) {
         return
     }
 
-    unit.SetX(summonCity.X)
-    unit.SetY(summonCity.Y)
+    player.UpdateUnitLocation(unit, summonCity.X, summonCity.Y, summonCity.Plane)
 
     allStacks := player.FindAllStacks(summonCity.X, summonCity.Y, summonCity.Plane)
     for i := 1; i < len(allStacks); i++ {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -879,7 +879,8 @@ func (player *Player) MergeStacks(stack1 *UnitStack, stack2 *UnitStack) *UnitSta
 }
 
 // teleport/move the unit to a new location. The unit should be removed from its current stack and added to a whatever
-// stack exists at the given location
+// stack exists at the given location.
+// a presumption is that the unit is already part of the player's Units list. The unit is not added to the Units list in this method
 func (player *Player) UpdateUnitLocation(unit units.StackUnit, x int, y int, plane data.Plane) {
     oldStack := player.FindStackByUnit(unit)
     if oldStack != nil {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -931,13 +931,10 @@ func (player *Player) AddUnit(unit units.StackUnit) units.StackUnit {
     player.UnitId += 1
     player.Units = append(player.Units, unit)
 
-    // FIXME: maybe relocate
-
     stack := player.FindStack(unit.GetX(), unit.GetY(), unit.GetPlane())
     if stack == nil {
         stack = MakeUnitStack()
         player.Stacks = append(player.Stacks, stack)
-    } else {
     }
 
     stack.AddUnit(unit)

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -878,6 +878,32 @@ func (player *Player) MergeStacks(stack1 *UnitStack, stack2 *UnitStack) *UnitSta
     return stack1
 }
 
+// teleport/move the unit to a new location. The unit should be removed from its current stack and added to a whatever
+// stack exists at the given location
+func (player *Player) UpdateUnitLocation(unit units.StackUnit, x int, y int, plane data.Plane) {
+    oldStack := player.FindStackByUnit(unit)
+    if oldStack != nil {
+        oldStack.RemoveUnit(unit)
+        if oldStack.IsEmpty() {
+            player.Stacks = slices.DeleteFunc(player.Stacks, func (s *UnitStack) bool {
+                return s == oldStack
+            })
+        }
+    }
+
+    unit.SetX(x)
+    unit.SetY(y)
+    unit.SetPlane(plane)
+
+    newStack := player.FindStack(unit.GetX(), unit.GetY(), unit.GetPlane())
+    if newStack == nil {
+        newStack = MakeUnitStack()
+        player.Stacks = append(player.Stacks, newStack)
+    }
+
+    newStack.AddUnit(unit)
+}
+
 func (player *Player) RemoveUnit(unit units.StackUnit) {
 
     for i := 0; i < len(player.Heroes); i++ {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -931,6 +931,8 @@ func (player *Player) AddUnit(unit units.StackUnit) units.StackUnit {
     player.UnitId += 1
     player.Units = append(player.Units, unit)
 
+    // FIXME: maybe relocate
+
     stack := player.FindStack(unit.GetX(), unit.GetY(), unit.GetPlane())
     if stack == nil {
         stack = MakeUnitStack()

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1034,6 +1034,8 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
     player.KnownSpells.AddSpell(allSpells.FindByName("Change Terrain"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Transmute"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Spell Blast"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Recall Hero"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Word of Recall"))
 
     // city spells
     player.KnownSpells.AddSpell(allSpells.FindByName("Wall of Fire"))

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -4597,7 +4597,7 @@ func createScenario50(cache *lbx.LbxCache) *gamelib.Game {
 }
 
 // Relocate units
-func createScenario51(cache *lbx.LbxCache) *gamelib.Game {
+func createScenario51_52(cache *lbx.LbxCache, kill bool) *gamelib.Game {
     log.Printf("Running scenario 50: relocate units")
     wizard := setup.WizardCustom{
         Name: "bob",
@@ -4616,20 +4616,19 @@ func createScenario51(cache *lbx.LbxCache) *gamelib.Game {
         Magic: data.MagicSettingNormal,
         Difficulty: data.DifficultyAverage,
     })
-
     game.Plane = data.PlaneArcanus
-
-    player := game.AddPlayer(wizard, true)
-
-    player.CastingSkillPower += 500000
 
     allSpells, _ := spellbook.ReadSpellsFromCache(cache)
 
+    player := game.AddPlayer(wizard, true)
+    player.CastingSkillPower += 500000
+    player.Gold = 1000
+    player.Mana = 10000
     player.KnownSpells.AddSpell(allSpells.FindByName("Magic Spirit"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Word of Recall"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
 
-    x, y, _ := game.FindValidCityLocation(game.Plane)
+    x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 
     city := citylib.MakeCity("Test City", x, y, data.RaceHalfling, game.BuildingInfo, game.CurrentMap(), game, player)
     city.Population = 16190
@@ -4640,32 +4639,22 @@ func createScenario51(cache *lbx.LbxCache) *gamelib.Game {
     city.Race = wizard.Race
     city.Farmers = 13
     city.Workers = 3
-
     city.AddBuilding(buildinglib.BuildingFortress)
     city.AddBuilding(buildinglib.BuildingGranary)
-
     city.ResetCitizens()
 
     player.AddCity(city)
-
-    player.Gold = 1000
-    player.Mana = 10000
-
     player.LiftFog(x, y, 4, data.PlaneArcanus)
-
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.Slingers, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.HalflingSpearmen, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.HalflingShamans, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
-
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.MagicSpirit, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.Nagas, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
     player.AddUnit(units.MakeOverworldUnitFromUnit(units.SkyDrake, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
-
     player.HeroPool[hero.HeroRakir].Unit.Experience = 0
     player.HeroPool[hero.HeroShinBo].Unit.Experience = 100
     player.HeroPool[hero.HeroAerie].Unit.Experience = 200
     player.HeroPool[hero.HeroBShan].Unit.Experience = 300
-
     player.AddHero(player.HeroPool[hero.HeroRakir])
     player.AddHero(player.HeroPool[hero.HeroAerie])
     player.AddHero(player.HeroPool[hero.HeroBShan])
@@ -4684,6 +4673,38 @@ func createScenario51(cache *lbx.LbxCache) *gamelib.Game {
         },
         Cost: 200,
     }
+
+    enemyWizard := setup.WizardCustom{
+        Name: "enemy",
+        Banner: data.BannerGreen,
+        Race: data.RaceDraconian,
+    }
+    enemy := game.AddPlayer(enemyWizard, false)
+    x1 := game.ArcanusMap.WrapX(x-1)
+    x2 := game.ArcanusMap.WrapX(x+1)
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x1, y-1, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x1, y, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x1, y+1, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y-1, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+    enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x, y+1, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+    if kill {
+        enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x2, y-1, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+        enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x2, y, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+        enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.DraconianSpearmen, x2, y+1, data.PlaneArcanus, enemyWizard.Banner, enemy.MakeExperienceInfo()))
+    }
+
+    x, y, _ = game.FindValidCityLocation(game.Plane)
+
+    city = citylib.MakeCity("Test City", x, y, enemy.Wizard.Race, game.BuildingInfo, game.CurrentMap(), game, enemy)
+    city.Population = 14000
+    city.Plane = data.PlaneArcanus
+    city.ProducingBuilding = buildinglib.BuildingHousing
+    city.ProducingUnit = units.UnitNone
+    city.AddBuilding(buildinglib.BuildingGranary)
+    city.Farmers = 10
+    city.Workers = 4
+    city.ResetCitizens()
+    enemy.AddCity(city)
 
     return game
 }
@@ -4744,7 +4765,8 @@ func NewEngine(scenario int) (*Engine, error) {
         case 48: game = createScenario48(cache)
         case 49: game = createScenario49(cache)
         case 50: game = createScenario50(cache)
-        case 51: game = createScenario51(cache)
+        case 51: game = createScenario51_52(cache, false)
+        case 52: game = createScenario51_52(cache, true)
         default: game = createScenario1(cache)
     }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -4603,7 +4603,11 @@ func createScenario50(cache *lbx.LbxCache) *gamelib.Game {
 
 // Relocate units
 func createScenario51_52(cache *lbx.LbxCache, kill bool) *gamelib.Game {
-    log.Printf("Running scenario 50: relocate units")
+    scenario := 51
+    if kill {
+        scenario = 52
+    }
+    log.Printf("Running scenario %v: relocate units", scenario)
     wizard := setup.WizardCustom{
         Name: "bob",
         Banner: data.BannerRed,

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -4596,6 +4596,98 @@ func createScenario50(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// Relocate units
+func createScenario51(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 50: relocate units")
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerRed,
+        Race: data.RaceHalfling,
+        Retorts: []data.Retort{},
+        Books: []data.WizardBook{
+            {
+                Magic: data.SorceryMagic,
+                Count: 11,
+            },
+        },
+    }
+
+    game := gamelib.MakeGame(cache, setup.NewGameSettings{
+        Magic: data.MagicSettingNormal,
+        Difficulty: data.DifficultyAverage,
+    })
+
+    game.Plane = data.PlaneArcanus
+
+    player := game.AddPlayer(wizard, true)
+
+    player.CastingSkillPower += 500000
+
+    allSpells, _ := spellbook.ReadSpellsFromCache(cache)
+
+    player.KnownSpells.AddSpell(allSpells.FindByName("Magic Spirit"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Word of Recall"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
+
+    x, y, _ := game.FindValidCityLocation(game.Plane)
+
+    city := citylib.MakeCity("Test City", x, y, data.RaceHalfling, game.BuildingInfo, game.CurrentMap(), game, player)
+    city.Population = 16190
+    city.Plane = data.PlaneArcanus
+    city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
+    city.ProducingBuilding = buildinglib.BuildingNone
+    city.ProducingUnit = units.HalflingSpearmen
+    city.Race = wizard.Race
+    city.Farmers = 13
+    city.Workers = 3
+
+    city.AddBuilding(buildinglib.BuildingFortress)
+    city.AddBuilding(buildinglib.BuildingGranary)
+
+    city.ResetCitizens()
+
+    player.AddCity(city)
+
+    player.Gold = 1000
+    player.Mana = 10000
+
+    player.LiftFog(x, y, 4, data.PlaneArcanus)
+
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.Slingers, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.HalflingSpearmen, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.HalflingShamans, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.MagicSpirit, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.Nagas, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+    player.AddUnit(units.MakeOverworldUnitFromUnit(units.SkyDrake, x, y, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo()))
+
+    player.HeroPool[hero.HeroRakir].Unit.Experience = 0
+    player.HeroPool[hero.HeroShinBo].Unit.Experience = 100
+    player.HeroPool[hero.HeroAerie].Unit.Experience = 200
+    player.HeroPool[hero.HeroBShan].Unit.Experience = 300
+
+    player.AddHero(player.HeroPool[hero.HeroRakir])
+    player.AddHero(player.HeroPool[hero.HeroAerie])
+    player.AddHero(player.HeroPool[hero.HeroBShan])
+
+    game.Events <- &gamelib.GameEventHireHero{
+        Player: player,
+        Hero: player.HeroPool[hero.HeroShinBo],
+        Cost: 200,
+    }
+
+    game.Events <- &gamelib.GameEventHireMercenaries{
+        Player: player,
+        Units: []*units.OverworldUnit{
+            units.MakeOverworldUnitFromUnit(units.Berserkers, x, y, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
+            units.MakeOverworldUnitFromUnit(units.Berserkers, x, y, data.PlaneArcanus, player.Wizard.Banner, player.MakeExperienceInfo()),
+        },
+        Cost: 200,
+    }
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -4652,6 +4744,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 48: game = createScenario48(cache)
         case 49: game = createScenario49(cache)
         case 50: game = createScenario50(cache)
+        case 51: game = createScenario51(cache)
         default: game = createScenario1(cache)
     }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -4625,8 +4625,9 @@ func createScenario51_52(cache *lbx.LbxCache, kill bool) *gamelib.Game {
     player.Gold = 1000
     player.Mana = 10000
     player.KnownSpells.AddSpell(allSpells.FindByName("Magic Spirit"))
-    player.KnownSpells.AddSpell(allSpells.FindByName("Word of Recall"))
     player.KnownSpells.AddSpell(allSpells.FindByName("Summon Hero"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Recall Hero"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Word of Recall"))
 
     x, y, _ := game.FindValidCityLocationOnShore(game.Plane)
 


### PR DESCRIPTION
Adds [Word of Recall](https://masterofmagic.fandom.com/wiki/Word_of_Recall) and [Recall Hero](https://masterofmagic.fandom.com/wiki/Recall_Hero) spells.

Also adds some bit of code to relocate units in case the stack at the summoning circle is full. The same logic is used when summoning units or producing units. I'm not 100% sure but I think original moved a random unit so I did that.

I'm not sure what happens if there is no room to move existing units so I added some logic to sort units by some sort of "value" (for example heros are sacrified last).

I also refactored the existing flee function to reuse the common parts.