### PR TITLE
cast evil omens

### DIFF
--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -315,7 +315,7 @@ func getName(artifact *Artifact, customName string) string {
     return prefix + base + postfix
 }
 
-func calculateCost(artifact *Artifact, costs map[Power]int, artificer bool, runemaster bool) int {
+func calculateCost(artifact *Artifact, costs map[Power]int) int {
     base := 0
     switch artifact.Type {
         case ArtifactTypeSword: base = 100
@@ -346,21 +346,10 @@ func calculateCost(artifact *Artifact, costs map[Power]int, artificer bool, rune
     }
 
     cost := base + powerCost + spellCost
-
-    reduction := 0.0
-
-    if artificer {
-        reduction += 0.5
-    }
-
-    if runemaster {
-        reduction += 0.25
-    }
-
-    return int(float64(cost) - float64(cost) * reduction)
+    return cost
 }
 
-func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, fonts ArtifactFonts, picLow int, picHigh int, powerGroups [][]Power, costs map[Power]int, artifact *Artifact, customName *string, selectCount *int, artificer bool, runemaster bool) []*uilib.UIElement {
+func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, fonts ArtifactFonts, picLow int, picHigh int, powerGroups [][]Power, costs map[Power]int, artifact *Artifact, customName *string, selectCount *int) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
     // image
@@ -543,7 +532,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                             *selectCount -= 1
                             artifact.RemovePower(power)
                             artifact.Name = getName(artifact, *customName)
-                            artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                            artifact.Cost = calculateCost(artifact, costs)
                             lastPower = nil
                         } else {
                             // something was already selected in this group, so the count doesn't change
@@ -551,7 +540,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                             artifact.RemovePower(*lastPower)
                             artifact.AddPower(power)
                             artifact.Name = getName(artifact, *customName)
-                            artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                            artifact.Cost = calculateCost(artifact, costs)
                             lastPower = &power
                         }
                     } else {
@@ -560,7 +549,7 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
                             groupSelect = i
                             artifact.AddPower(power)
                             artifact.Name = getName(artifact, *customName)
-                            artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                            artifact.Cost = calculateCost(artifact, costs)
                             lastPower = &power
                         } else {
                             ui.AddElement(uilib.MakeErrorElement(ui, cache, imageCache, "Only four powers may be enchanted into an item", func(){}))
@@ -804,7 +793,7 @@ func makeSpellChoiceElements(ui *uilib.UI, imageCache *util.ImageCache, fonts Ar
     return elements
 }
 
-func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, artifact *Artifact, customName *string, fonts ArtifactFonts, powers []Power, compatibilities map[Power]set.Set[ArtifactType], costs map[Power]int, selectCount *int, magicLevel MagicLevel, availableSpells spellbook.Spells, artificer bool, runemaster bool) []*uilib.UIElement {
+func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, artifact *Artifact, customName *string, fonts ArtifactFonts, powers []Power, compatibilities map[Power]set.Set[ArtifactType], costs map[Power]int, selectCount *int, wizard spellbook.Wizard, availableSpells spellbook.Spells) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
     var group1 []Power
@@ -852,7 +841,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
         selected := make([]bool, len(group))
         for i, power := range group {
             artifactTypes := compatibilities[power]
-            if artifactTypes.Contains(artifact.Type) && magicLevel.MagicLevel(power.Magic) >= power.Amount {
+            if artifactTypes.Contains(artifact.Type) && wizard.MagicLevel(power.Magic) >= power.Amount {
                 totalItems += 1
                 xRect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth(power.Name, 1)), y + fonts.PowerFont.Height())
                 elements = append(elements, &uilib.UIElement{
@@ -871,7 +860,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                                     *selectCount -= 1
                                     artifact.RemovePower(power)
                                     artifact.Name = getName(artifact, *customName)
-                                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                                    artifact.Cost = calculateCost(artifact, costs)
                                     lastPower = nil
                                 } else {
                                     // something was already selected in this group, so the count doesn't change
@@ -879,7 +868,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                                     artifact.RemovePower(*lastPower)
                                     artifact.AddPower(power)
                                     artifact.Name = getName(artifact, *customName)
-                                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                                    artifact.Cost = calculateCost(artifact, costs)
                                     lastPower = &power
                                 }
                             } else {
@@ -888,7 +877,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                                     groupSelect = i
                                     artifact.AddPower(power)
                                     artifact.Name = getName(artifact, *customName)
-                                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                                    artifact.Cost = calculateCost(artifact, costs)
                                     lastPower = &power
                                 } else {
                                     ui.AddElement(uilib.MakeErrorElement(ui, cache, imageCache, "Only four powers may be enchanted into an item", func(){}))
@@ -900,7 +889,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                             if selected[i] {
                                 artifact.RemovePower(power)
                                 artifact.Name = getName(artifact, *customName)
-                                artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                                artifact.Cost = calculateCost(artifact, costs)
                                 selected[i] = false
                                 *selectCount -= 1
                             } else if *selectCount < 4 {
@@ -909,7 +898,7 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
 
                                 artifact.AddPower(power)
                                 artifact.Name = getName(artifact, *customName)
-                                artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                                artifact.Cost = calculateCost(artifact, costs)
                             } else {
                                 ui.AddElement(uilib.MakeErrorElement(ui, cache, imageCache, "Only four powers may be enchanted into an item", func(){}))
                             }
@@ -966,13 +955,13 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
                         }
                         artifact.AddPower(addedPower)
                         artifact.Name = getName(artifact, *customName)
-                        artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                        artifact.Cost = calculateCost(artifact, costs)
                     }))
                 } else {
                     artifact.RemovePower(addedPower)
                     addedPower = Power{Type: PowerTypeNone}
                     artifact.Name = getName(artifact, *customName)
-                    artifact.Cost = calculateCost(artifact, costs, artificer, runemaster)
+                    artifact.Cost = calculateCost(artifact, costs)
                 }
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
@@ -1188,7 +1177,7 @@ func makeFonts(cache *lbx.LbxCache) ArtifactFonts {
 /* returns the artifact that was created and true,
  * otherwise false for cancelled
  */
-func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, creationType CreationScreen, magicLevel MagicLevel, artificer bool, runemaster bool, availableSpells spellbook.Spells, draw *func(*ebiten.Image)) (*Artifact, bool) {
+func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, creationType CreationScreen, wizard spellbook.Wizard, availableSpells spellbook.Spells, draw *func(*ebiten.Image)) (*Artifact, bool) {
     fonts := makeFonts(cache)
 
     imageCache := util.MakeImageCache(cache)
@@ -1228,8 +1217,8 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
         artifact.Type = artifactType
         groups := groupPowers(powers, costs, compatibilities, artifactType, creationType)
         selectCount := 0
-        elements := makePowersFull(ui, cache, &imageCache, fonts, picLow, picHigh, groups, costs, &artifact, &customName, &selectCount, artificer, runemaster)
-        abilityElements := makeAbilityElements(ui, cache, &imageCache, &artifact, &customName, fonts, powers, compatibilities, costs, &selectCount, magicLevel, availableSpells, artificer, runemaster)
+        elements := makePowersFull(ui, cache, &imageCache, fonts, picLow, picHigh, groups, costs, &artifact, &customName, &selectCount)
+        abilityElements := makeAbilityElements(ui, cache, &imageCache, &artifact, &customName, fonts, powers, compatibilities, costs, &selectCount, wizard, availableSpells)
         return PowerArtifact{
             Elements: elements,
             AbilityElements: abilityElements,
@@ -1263,7 +1252,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
         ui.AddElements(powers[index].AbilityElements)
         currentArtifact = powers[index].Artifact
         currentArtifact.Name = getName(currentArtifact, customName)
-        currentArtifact.Cost = calculateCost(currentArtifact, costs, artificer, runemaster)
+        currentArtifact.Cost = calculateCost(currentArtifact, costs)
     }
 
     var selectedButton *uilib.UIElement
@@ -1318,7 +1307,20 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
 
     ui.AddElement(&uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            fonts.PowerFontWhite.PrintOptions(screen, 198, 185, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost: %v", currentArtifact.Cost))
+            spellName := ""
+            switch creationType {
+                case CreationEnchantItem: spellName = "Enchant Item"
+                case CreationCreateArtifact: spellName = "Create Artifact"
+            }
+            spell := spellbook.Spell{
+                Name: spellName,
+                OverrideCost: currentArtifact.Cost,
+                Magic: data.ArcaneMagic,
+                Eligibility: spellbook.EligibilityOverlandOnly,
+                Section: spellbook.SectionSpecial,
+            }
+
+            fonts.PowerFontWhite.PrintOptions(screen, 198, 185, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost: %v", spellbook.ComputeSpellCost(wizard, spell, false, false)))
         },
     })
 

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -441,7 +441,7 @@ func MakeRandomArtifact(cache *lbx.LbxCache) Artifact {
 
     artifact.Image = chooseImage(artifact.Type)
 
-    artifact.Cost = calculateCost(&artifact, costs, false, false)
+    artifact.Cost = calculateCost(&artifact, costs)
     artifact.Name = getName(&artifact, "")
 
     return artifact

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -333,9 +333,15 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
                 TODO:
                 Aura of Majesty
                 Time Stop
-                Evil Omens
                 Zombie Mastery
         */
+        case "Evil Omens":
+            enchantment := data.EnchantmentEvilOmens
+            if !player.GlobalEnchantments.Contains(enchantment) {
+                game.Events <- &GameEventCastGlobalEnchantment{Player: player, Enchantment: enchantment}
+                player.GlobalEnchantments.Insert(enchantment)
+                game.RefreshUI()
+            }
         case "Meteor Storm":
             enchantment := data.EnchantmentMeteorStorm
             if !player.GlobalEnchantments.Contains(enchantment) {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5227,9 +5227,6 @@ func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerl
 
             castingCost := player.ComputeEffectiveSpellCost(spell, true)
 
-            // FIXME: if the player has runemaster and the spell is arcane, then apply a -25% reduction. Don't apply
-            // to create artifact or enchant item because the reduction has already been applied
-
             if castingCost <= player.Mana && castingCost <= player.RemainingCastingSkill {
                 player.Mana -= castingCost
                 player.RemainingCastingSkill -= castingCost

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5195,7 +5195,7 @@ func (game *Game) MakeInfoUI(cornerX int, cornerY int) []*uilib.UIElement {
 }
 
 func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerlib.Player){
-    game.HudUI.AddElements(spellbook.MakeSpellBookCastUI(game.HudUI, game.Cache, player.KnownSpells.OverlandSpells(), make(map[spellbook.Spell]int), player.ComputeOverworldCastingSkill(), player.CastingSpell, player.CastingSpellProgress, true, func (spell spellbook.Spell, picked bool){
+    game.HudUI.AddElements(spellbook.MakeSpellBookCastUI(game.HudUI, game.Cache, player.KnownSpells.OverlandSpells(), make(map[spellbook.Spell]int), player.ComputeOverworldCastingSkill(), player.CastingSpell, player.CastingSpellProgress, true, player, func (spell spellbook.Spell, picked bool){
         if picked {
             if spell.Name == "Create Artifact" || spell.Name == "Enchant Item" {
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5101,7 +5101,7 @@ func (game *Game) ShowApprenticeUI(yield coroutine.YieldFunc, player *playerlib.
     }
 
     power := game.ComputePower(player)
-    spellbook.ShowSpellBook(yield, game.Cache, player.ResearchPoolSpells, player.KnownSpells, player.ResearchCandidateSpells, player.ResearchingSpell, player.ResearchProgress, int(player.SpellResearchPerTurn(power)), player.ComputeOverworldCastingSkill(), spellbook.Spell{}, false, nil, &newDrawer)
+    spellbook.ShowSpellBook(yield, game.Cache, player.ResearchPoolSpells, player.KnownSpells, player.ResearchCandidateSpells, player.ResearchingSpell, player.ResearchProgress, player.SpellResearchPerTurn(power), player.ComputeOverworldCastingSkill(), spellbook.Spell{}, false, nil, player, &newDrawer)
 }
 
 func (game *Game) ResearchNewSpell(yield coroutine.YieldFunc, player *playerlib.Player){
@@ -5119,7 +5119,7 @@ func (game *Game) ResearchNewSpell(yield coroutine.YieldFunc, player *playerlib.
 
     if len(player.ResearchCandidateSpells.Spells) > 0 {
         power := game.ComputePower(player)
-        spellbook.ShowSpellBook(yield, game.Cache, player.ResearchPoolSpells, player.KnownSpells, player.ResearchCandidateSpells, spellbook.Spell{}, 0, int(player.SpellResearchPerTurn(power)), player.ComputeOverworldCastingSkill(), spellbook.Spell{}, true, &player.ResearchingSpell, &newDrawer)
+        spellbook.ShowSpellBook(yield, game.Cache, player.ResearchPoolSpells, player.KnownSpells, player.ResearchCandidateSpells, spellbook.Spell{}, 0, player.SpellResearchPerTurn(power), player.ComputeOverworldCastingSkill(), spellbook.Spell{}, true, &player.ResearchingSpell, player, &newDrawer)
     }
 }
 
@@ -6848,7 +6848,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
 
     if player.ResearchingSpell.Valid() {
         // log.Printf("wizard %v power=%v researching=%v progress=%v/%v perturn=%v", player.Wizard.Name, power, player.ResearchingSpell.Name, player.ResearchProgress, player.ResearchingSpell.ResearchCost, player.SpellResearchPerTurn(power))
-        player.ResearchProgress += int(player.SpellResearchPerTurn(power))
+        player.ResearchProgress += player.ComputeEffectiveResearchPerTurn(player.SpellResearchPerTurn(power), player.ResearchingSpell)
         if player.ResearchProgress >= player.ResearchingSpell.ResearchCost {
 
             if player.IsHuman() {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5225,7 +5225,7 @@ func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerl
                 player.CreateArtifact = created
             }
 
-            castingCost := spell.Cost(true)
+            castingCost := player.ComputeEffectiveSpellCost(spell, true)
 
             // FIXME: if the player has runemaster and the spell is arcane, then apply a -25% reduction. Don't apply
             // to create artifact or enchant item because the reduction has already been applied
@@ -6831,7 +6831,9 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
             manaSpent = player.RemainingCastingSkill
         }
 
-        remainingMana := player.CastingSpell.Cost(true) - player.CastingSpellProgress
+        spellCost := player.ComputeEffectiveSpellCost(player.CastingSpell, true)
+
+        remainingMana := spellCost - player.CastingSpellProgress
         if remainingMana < manaSpent {
             manaSpent = remainingMana
         }
@@ -6839,7 +6841,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
         player.CastingSpellProgress += manaSpent
         player.Mana -= manaSpent
 
-        if player.CastingSpell.Cost(true) <= player.CastingSpellProgress {
+        if spellCost <= player.CastingSpellProgress {
             game.doCastSpell(player, player.CastingSpell)
             player.CastingSpell = spellbook.Spell{}
             player.CastingSpellProgress = 0

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5214,7 +5214,7 @@ func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerl
                     case "Enchant Item": creation = artifact.CreationEnchantItem
                 }
 
-                created, cancel := artifact.ShowCreateArtifactScreen(yield, game.Cache, creation, &player.Wizard, player.Wizard.RetortEnabled(data.RetortArtificer), player.Wizard.RetortEnabled(data.RetortRunemaster), player.KnownSpells.CombatSpells(), &drawFunc)
+                created, cancel := artifact.ShowCreateArtifactScreen(yield, game.Cache, creation, &player.Wizard, player.KnownSpells.CombatSpells(), &drawFunc)
                 if cancel {
                     return
                 }

--- a/game/magic/game/learn-spell.go
+++ b/game/magic/game/learn-spell.go
@@ -134,5 +134,5 @@ func (game *Game) doLearnSpell(yield coroutine.YieldFunc, player *playerlib.Play
 
     power := game.ComputePower(player)
     // show new spell being learned
-    spellbook.ShowSpellBook(yield, game.Cache, player.ResearchPoolSpells, player.KnownSpells, player.ResearchCandidateSpells, spellbook.Spell{}, 0, int(player.SpellResearchPerTurn(power)), player.ComputeCastingSkill(), learnedSpell, false, nil, &newDrawer)
+    spellbook.ShowSpellBook(yield, game.Cache, player.ResearchPoolSpells, player.KnownSpells, player.ResearchCandidateSpells, spellbook.Spell{}, 0, player.SpellResearchPerTurn(power), player.ComputeCastingSkill(), learnedSpell, false, nil, player, &newDrawer)
 }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -673,8 +673,7 @@ func (player *Player) SpellResearchPerTurn(power int) float64 {
 }
 
 // the casting cost of a spell can be reduced based on retorts/spell books
-func (player *Player) ComputeEffectiveSpellCost(spell spellbook.Spell, overland bool) int {
-    wizard := &player.Wizard
+func computeEffectiveSpellCost(wizard *setup.WizardCustom, spell spellbook.Spell, overland bool, hasEvilOmens bool) int {
     base := float64(spell.Cost(overland))
     modifier := float64(0)
 
@@ -707,13 +706,17 @@ func (player *Player) ComputeEffectiveSpellCost(spell spellbook.Spell, overland 
 
     evilOmens := float64(1.0)
 
-    if player.GlobalEnchantmentsProvider.HasEnchantment(data.EnchantmentEvilOmens) {
+    if hasEvilOmens {
         if spell.Magic == data.LifeMagic || spell.Magic == data.NatureMagic {
             evilOmens = 1.5
         }
     }
 
     return int(max(0, base * (1 - modifier) * evilOmens))
+}
+
+func (player *Player) ComputeEffectiveSpellCost(spell spellbook.Spell, overland bool) int {
+    return computeEffectiveSpellCost(&player.Wizard, spell, overland, player.GlobalEnchantmentsProvider.HasEnchantment(data.EnchantmentEvilOmens))
 }
 
 func (player *Player) GoldPerTurn() int {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -614,38 +614,42 @@ func (player *Player) CastingSkillPerTurn(power int) int {
 
 // returns the true effective research per turn for the given spell by taking retorts/spell books into account
 // example: a wizard with runemaster researching an arcane spell will produce 25% more research points
-func (player *Player) ComputeEffectiveResearchPerTurn(research float64, spell spellbook.Spell) int {
+func computeEffectiveResearchPerTurn(wizard *setup.WizardCustom, research float64, spell spellbook.Spell) int {
     modifier := float64(0)
 
-    if player.Wizard.RetortEnabled(data.RetortRunemaster) && spell.Magic == data.ArcaneMagic {
+    if wizard.RetortEnabled(data.RetortRunemaster) && spell.Magic == data.ArcaneMagic {
         modifier += 0.25
     }
 
-    if player.Wizard.RetortEnabled(data.RetortSageMaster) {
+    if wizard.RetortEnabled(data.RetortSageMaster) {
         modifier += 0.25
     }
 
-    if player.Wizard.RetortEnabled(data.RetortConjurer) && spell.IsSummoning() {
+    if wizard.RetortEnabled(data.RetortConjurer) && spell.IsSummoning() {
         modifier += 0.25
     }
 
-    if player.Wizard.RetortEnabled(data.RetortChaosMastery) && spell.Magic == data.ChaosMagic {
+    if wizard.RetortEnabled(data.RetortChaosMastery) && spell.Magic == data.ChaosMagic {
         modifier += 0.15
     }
 
-    if player.Wizard.RetortEnabled(data.RetortNatureMastery) && spell.Magic == data.NatureMagic {
+    if wizard.RetortEnabled(data.RetortNatureMastery) && spell.Magic == data.NatureMagic {
         modifier += 0.15
     }
 
-    if player.Wizard.RetortEnabled(data.RetortSorceryMastery) && spell.Magic == data.SorceryMagic {
+    if wizard.RetortEnabled(data.RetortSorceryMastery) && spell.Magic == data.SorceryMagic {
         modifier += 0.15
     }
 
     // for each book above 7, increase points by 10%
-    realmBooks := max(0, player.Wizard.MagicLevel(spell.Magic) - 7)
+    realmBooks := max(0, wizard.MagicLevel(spell.Magic) - 7)
     modifier += float64(realmBooks) * 0.1
 
     return int(research * (1 + modifier))
+}
+
+func (player *Player) ComputeEffectiveResearchPerTurn(research float64, spell spellbook.Spell) int {
+    return computeEffectiveResearchPerTurn(&player.Wizard, research, spell)
 }
 
 // this returns the raw research production per turn, not accounting for retorts or spellbooks

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -672,51 +672,8 @@ func (player *Player) SpellResearchPerTurn(power int) float64 {
     return research
 }
 
-// the casting cost of a spell can be reduced based on retorts/spell books
-func computeEffectiveSpellCost(wizard *setup.WizardCustom, spell spellbook.Spell, overland bool, hasEvilOmens bool) int {
-    base := float64(spell.Cost(overland))
-    modifier := float64(0)
-
-    if wizard.RetortEnabled(data.RetortRunemaster) && spell.Magic == data.ArcaneMagic {
-        modifier += 0.25
-    }
-
-    if wizard.RetortEnabled(data.RetortChaosMastery) && spell.Magic == data.ChaosMagic {
-        modifier += 0.15
-    }
-
-    if wizard.RetortEnabled(data.RetortNatureMastery) && spell.Magic == data.NatureMagic {
-        modifier += 0.15
-    }
-
-    if wizard.RetortEnabled(data.RetortSorceryMastery) && spell.Magic == data.SorceryMagic {
-        modifier += 0.15
-    }
-
-    if wizard.RetortEnabled(data.RetortConjurer) && spell.IsSummoning() {
-        modifier += 0.25
-    }
-
-    // artificer for enchant item and create artifact are handled directly in the artifact creation screen
-    // in artifact/create-artifact.go
-
-    // for each book above 7, reduce cost by 10%
-    realmBooks := max(0, wizard.MagicLevel(spell.Magic) - 7)
-    modifier += float64(realmBooks) * 0.1
-
-    evilOmens := float64(1.0)
-
-    if hasEvilOmens {
-        if spell.Magic == data.LifeMagic || spell.Magic == data.NatureMagic {
-            evilOmens = 1.5
-        }
-    }
-
-    return int(max(0, base * (1 - modifier) * evilOmens))
-}
-
 func (player *Player) ComputeEffectiveSpellCost(spell spellbook.Spell, overland bool) int {
-    return computeEffectiveSpellCost(&player.Wizard, spell, overland, player.GlobalEnchantmentsProvider.HasEnchantment(data.EnchantmentEvilOmens))
+    return spellbook.ComputeSpellCost(&player.Wizard, spell, overland, player.GlobalEnchantmentsProvider.HasEnchantment(data.EnchantmentEvilOmens))
 }
 
 func (player *Player) GoldPerTurn() int {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -672,6 +672,50 @@ func (player *Player) SpellResearchPerTurn(power int) float64 {
     return research
 }
 
+// the casting cost of a spell can be reduced based on retorts/spell books
+func (player *Player) ComputeEffectiveSpellCost(spell spellbook.Spell, overland bool) int {
+    wizard := &player.Wizard
+    base := float64(spell.Cost(overland))
+    modifier := float64(0)
+
+    if wizard.RetortEnabled(data.RetortRunemaster) && spell.Magic == data.ArcaneMagic {
+        modifier += 0.25
+    }
+
+    if wizard.RetortEnabled(data.RetortChaosMastery) && spell.Magic == data.ChaosMagic {
+        modifier += 0.15
+    }
+
+    if wizard.RetortEnabled(data.RetortNatureMastery) && spell.Magic == data.NatureMagic {
+        modifier += 0.15
+    }
+
+    if wizard.RetortEnabled(data.RetortSorceryMastery) && spell.Magic == data.SorceryMagic {
+        modifier += 0.15
+    }
+
+    if wizard.RetortEnabled(data.RetortConjurer) && spell.IsSummoning() {
+        modifier += 0.25
+    }
+
+    // artificer for enchant item and create artifact are handled directly in the artifact creation screen
+    // in artifact/create-artifact.go
+
+    // for each book above 7, reduce cost by 10%
+    realmBooks := max(0, wizard.MagicLevel(spell.Magic) - 7)
+    modifier += float64(realmBooks) * 0.1
+
+    evilOmens := float64(1.0)
+
+    if player.GlobalEnchantmentsProvider.HasEnchantment(data.EnchantmentEvilOmens) {
+        if spell.Magic == data.LifeMagic || spell.Magic == data.NatureMagic {
+            evilOmens = 1.5
+        }
+    }
+
+    return int(max(0, base * (1 - modifier) * evilOmens))
+}
+
 func (player *Player) GoldPerTurn() int {
     gold := 0
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -612,6 +612,43 @@ func (player *Player) CastingSkillPerTurn(power int) int {
     return int(float64(power) * player.PowerDistribution.Skill * bonus)
 }
 
+// returns the true effective research per turn for the given spell by taking retorts/spell books into account
+// example: a wizard with runemaster researching an arcane spell will produce 25% more research points
+func (player *Player) ComputeEffectiveResearchPerTurn(research float64, spell spellbook.Spell) int {
+    modifier := float64(0)
+
+    if player.Wizard.RetortEnabled(data.RetortRunemaster) && spell.Magic == data.ArcaneMagic {
+        modifier += 0.25
+    }
+
+    if player.Wizard.RetortEnabled(data.RetortSageMaster) {
+        modifier += 0.25
+    }
+
+    if player.Wizard.RetortEnabled(data.RetortConjurer) && spell.IsSummoning() {
+        modifier += 0.25
+    }
+
+    if player.Wizard.RetortEnabled(data.RetortChaosMastery) && spell.Magic == data.ChaosMagic {
+        modifier += 0.15
+    }
+
+    if player.Wizard.RetortEnabled(data.RetortNatureMastery) && spell.Magic == data.NatureMagic {
+        modifier += 0.15
+    }
+
+    if player.Wizard.RetortEnabled(data.RetortSorceryMastery) && spell.Magic == data.SorceryMagic {
+        modifier += 0.15
+    }
+
+    // for each book above 7, increase points by 10%
+    realmBooks := max(0, player.Wizard.MagicLevel(spell.Magic) - 7)
+    modifier += float64(realmBooks) * 0.1
+
+    return int(research * (1 + modifier))
+}
+
+// this returns the raw research production per turn, not accounting for retorts or spellbooks
 func (player *Player) SpellResearchPerTurn(power int) float64 {
     research := float64(0)
 

--- a/game/magic/player/player_test.go
+++ b/game/magic/player/player_test.go
@@ -2,7 +2,6 @@ package player
 
 import (
     "testing"
-    "math"
 
     "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
@@ -79,72 +78,4 @@ func TestResearchPoints(test *testing.T) {
     if computeEffectiveResearchPerTurn(&wizard, points, natureSpell) != int(points * (1 + 0.1 + 0.25)) {
         test.Errorf("Research points computation doesn't work")
     }
-}
-
-func TestSpellCost(test *testing.T) {
-    natureSpell := spellbook.Spell{
-        CastCost: 50,
-        Magic: data.NatureMagic,
-        Section: spellbook.SectionSpecial,
-    }
-
-    wizard := setup.WizardCustom{
-        Books: []data.WizardBook{
-            data.WizardBook{
-                Magic: data.NatureMagic,
-                Count: 1,
-            },
-        },
-        Retorts: []data.Retort{
-        },
-    }
-
-    value := computeEffectiveSpellCost(&wizard, natureSpell, true, false)
-    if value != 50*5 {
-        test.Errorf("casting cost for nature spell with no modifiers was wrong. expected=%v actual=%v", 50*5, value)
-    }
-
-    // 30% reduction
-    wizard = setup.WizardCustom{
-        Books: []data.WizardBook{
-            data.WizardBook{
-                Magic: data.NatureMagic,
-                Count: 10,
-            },
-        },
-        Retorts: []data.Retort{
-        },
-    }
-
-    value = computeEffectiveSpellCost(&wizard, natureSpell, true, false)
-    if value != 50*5*7/10 {
-        test.Errorf("casting cost for nature spell was wrong. expected=%v actual=%v", 50*5*7/10, value)
-    }
-
-    // 30% reduction + nature mastery
-    wizard = setup.WizardCustom{
-        Books: []data.WizardBook{
-            data.WizardBook{
-                Magic: data.NatureMagic,
-                Count: 10,
-            },
-        },
-        Retorts: []data.Retort{
-            data.RetortNatureMastery,
-        },
-    }
-
-    value = computeEffectiveSpellCost(&wizard, natureSpell, true, false)
-    expected := 50*5*(100 - (30 + 15))/100
-    if value != expected {
-        test.Errorf("casting cost for nature spell was wrong. expected=%v actual=%v", expected, value)
-    }
-
-    // evil omens
-    value = computeEffectiveSpellCost(&wizard, natureSpell, true, true)
-    expected = int(math.Floor(50.0*5*(100 - (30 + 15))/100 * 3/2))
-    if value != expected {
-        test.Errorf("casting cost for nature spell with evil omens. expected=%v actual=%v", expected, value)
-    }
-
 }

--- a/game/magic/player/player_test.go
+++ b/game/magic/player/player_test.go
@@ -2,6 +2,7 @@ package player
 
 import (
     "testing"
+    "math"
 
     "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
@@ -78,4 +79,72 @@ func TestResearchPoints(test *testing.T) {
     if computeEffectiveResearchPerTurn(&wizard, points, natureSpell) != int(points * (1 + 0.1 + 0.25)) {
         test.Errorf("Research points computation doesn't work")
     }
+}
+
+func TestSpellCost(test *testing.T) {
+    natureSpell := spellbook.Spell{
+        CastCost: 50,
+        Magic: data.NatureMagic,
+        Section: spellbook.SectionSpecial,
+    }
+
+    wizard := setup.WizardCustom{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 1,
+            },
+        },
+        Retorts: []data.Retort{
+        },
+    }
+
+    value := computeEffectiveSpellCost(&wizard, natureSpell, true, false)
+    if value != 50*5 {
+        test.Errorf("casting cost for nature spell with no modifiers was wrong. expected=%v actual=%v", 50*5, value)
+    }
+
+    // 30% reduction
+    wizard = setup.WizardCustom{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 10,
+            },
+        },
+        Retorts: []data.Retort{
+        },
+    }
+
+    value = computeEffectiveSpellCost(&wizard, natureSpell, true, false)
+    if value != 50*5*7/10 {
+        test.Errorf("casting cost for nature spell was wrong. expected=%v actual=%v", 50*5*7/10, value)
+    }
+
+    // 30% reduction + nature mastery
+    wizard = setup.WizardCustom{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 10,
+            },
+        },
+        Retorts: []data.Retort{
+            data.RetortNatureMastery,
+        },
+    }
+
+    value = computeEffectiveSpellCost(&wizard, natureSpell, true, false)
+    expected := 50*5*(100 - (30 + 15))/100
+    if value != expected {
+        test.Errorf("casting cost for nature spell was wrong. expected=%v actual=%v", expected, value)
+    }
+
+    // evil omens
+    value = computeEffectiveSpellCost(&wizard, natureSpell, true, true)
+    expected = int(math.Floor(50.0*5*(100 - (30 + 15))/100 * 3/2))
+    if value != expected {
+        test.Errorf("casting cost for nature spell with evil omens. expected=%v actual=%v", expected, value)
+    }
+
 }

--- a/game/magic/player/player_test.go
+++ b/game/magic/player/player_test.go
@@ -5,6 +5,8 @@ import (
 
     "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
 )
 
 func TestHeroNames(test *testing.T) {
@@ -49,5 +51,31 @@ func TestSkillReduction(test *testing.T) {
     actualReduction := player.ReduceCastingSkill(7)
     if actualReduction != 5 {
         test.Errorf("Reduction of 5 by 7 doesn't work: reduced by %d, actual skill after reduction is %d", actualReduction, player.ComputeCastingSkill())
+    }
+}
+
+func TestResearchPoints(test *testing.T) {
+    natureSpell := spellbook.Spell{
+        ResearchCost: 200,
+        Magic: data.NatureMagic,
+    }
+
+    // 10% from nature magic books, 25% from sage master
+    wizard := setup.WizardCustom{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 8,
+            },
+        },
+        Retorts: []data.Retort{
+            data.RetortSageMaster,
+        },
+    }
+
+    points := 15.0
+
+    if computeEffectiveResearchPerTurn(&wizard, points, natureSpell) != int(points * (1 + 0.1 + 0.25)) {
+        test.Errorf("Research points computation doesn't work")
     }
 }

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -404,6 +404,7 @@ func (wizard *WizardCustom) SetMagicLevel(kind data.MagicType, count int){
     wizard.Books = out
 }
 
+// number of books for the given magic type
 func (wizard *WizardCustom) MagicLevel(kind data.MagicType) int {
     for _, book := range wizard.Books {
         if book.Magic == kind {
@@ -413,7 +414,6 @@ func (wizard *WizardCustom) MagicLevel(kind data.MagicType) int {
 
     return 0
 }
-
 
 type NewWizardScreen struct {
     LbxCache *lbx.LbxCache

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -7,6 +7,7 @@ import (
     "image"
     "image/color"
     "log"
+    "slices"
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
     "github.com/kazzmir/master-of-magic/lib/font"
@@ -1060,8 +1061,22 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
         },
     }
 
-    // for each magic book, create a UI element that contains the book dimensions and can draw the book
+    // check that the retorts are still valid, and disable any that are not
+    checkRetorts := func() {
+        var removed []data.Retort
+        for _, retort := range slices.Clone(screen.CustomWizard.Retorts) {
+            if !SatisifiedDependencies(retort, &screen.CustomWizard) {
+                screen.CustomWizard.ToggleRetort(retort, 0)
+                removed = append(removed, retort)
+            }
+        }
 
+        if len(removed) > 0 {
+            screen.UI.AddElement(uilib.MakeErrorElement(screen.UI, screen.LbxCache, &imageCache, fmt.Sprintf("Retorts %v became ineligible", JoinAbilities(removed)), func(){}))
+        }
+    }
+
+    // for each magic book, create a UI element that contains the book dimensions and can draw the book
     for _, book := range books {
         bookY := book.Y
         bookMagic := book.Kind
@@ -1077,6 +1092,7 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
             Rect: image.Rect(x1, y1, x2, y2),
             LeftClick: func(this *uilib.UIElement){
                 screen.CustomWizard.SetMagicLevel(bookMagic, 0)
+                checkRetorts()
             },
             Draw: func(this *uilib.UIElement, window *ebiten.Image){
             },
@@ -1133,6 +1149,8 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
                             screen.CustomWizard.SetMagicLevel(bookMagic, screen.CustomWizard.MagicLevel(bookMagic) + picksLeft())
                         }
                     }
+
+                    checkRetorts()
                 },
                 RightClick: func(this *uilib.UIElement){
                     helpEntries := screen.Help.GetEntriesByName(book.Help)

--- a/game/magic/spellbook/data.go
+++ b/game/magic/spellbook/data.go
@@ -60,6 +60,10 @@ func (spell Spell) Cost(overland bool) int {
     return spell.BaseCost(overland)
 }
 
+func (spell Spell) IsSummoning() bool {
+    return spell.Section == SectionSummoning
+}
+
 // overland=true if casting in overland, otherwise casting in combat
 // this does not include any additional costs for the spell
 func (spell Spell) BaseCost(overland bool) int {

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -1266,7 +1266,7 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
         for _, spell := range page.Spells.Spells {
 
             // invalid spell?
-            if spell.Invalid() || spell.Cost(false) == 0 {
+            if spell.Invalid() {
                 continue
             }
 
@@ -1337,7 +1337,12 @@ func MakeSpellBookCastUI(ui *uilib.UI, cache *lbx.LbxCache, spells Spells, charg
                 // in combat the number of icons is how many times the spell can be cast given the casting cost of the spell
                 // and the casting skill of the user
 
-                iconCount = castingSkill / caster.ComputeEffectiveSpellCost(spell, false)
+                // if this ever occurs this is a bug, the cost of a combat spell should never be 0
+                if spell.Cost(false) == 0 {
+                    iconCount = 1
+                } else {
+                    iconCount = castingSkill / caster.ComputeEffectiveSpellCost(spell, false)
+                }
             }
 
             iconOptions := spellOptions

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -251,8 +251,9 @@ func ComputeSpellCost(wizard Wizard, spell Spell, overland bool, hasEvilOmens bo
         modifier += 0.25
     }
 
-    // artificer for enchant item and create artifact are handled directly in the artifact creation screen
-    // in artifact/create-artifact.go
+    if wizard.RetortEnabled(data.RetortArtificer) && (spell.Name == "Enchant Item" || spell.Name == "Create Artifact") {
+        modifier += 0.5
+    }
 
     // for each book above 7, reduce cost by 10%
     realmBooks := max(0, wizard.MagicLevel(spell.Magic) - 7)

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -217,6 +217,8 @@ type SpellCaster interface {
     // given research points and a spell, return the actual number of research points per turn
     // made towards that spell
     ComputeEffectiveResearchPerTurn(float64, Spell) int
+    // the actual cost to cast the spell
+    ComputeEffectiveSpellCost(spell Spell, overland bool) int
 }
 
 /* three modes:
@@ -519,7 +521,9 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                         spellTextNormalFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Research Cost:%v (%v %v)", spell.ResearchCost, turns, turnString))
                         y += float64(spellTextNormalFont.Height())
                     } else {
-                        turns := spell.Cost(true) / castingSkill
+                        spellCost := caster.ComputeEffectiveSpellCost(spell, true)
+
+                        turns := spellCost / castingSkill
                         if turns < 1 {
                             turns = 1
                         }
@@ -527,7 +531,7 @@ func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spe
                         if turns > 1 {
                             turnString = "turns"
                         }
-                        spellTextNormalFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Casting cost:%v (%v %v)", spell.Cost(true), turns, turnString))
+                        spellTextNormalFont.PrintOptions(pageImage, x, y, font.FontOptions{Scale: scale.ScaleAmount, Options: &scaleOptions}, fmt.Sprintf("Casting cost:%v (%v %v)", spellCost, turns, turnString))
                         y += float64(spellTextNormalFont.Height())
                     }
 

--- a/game/magic/spellbook/spell_test.go
+++ b/game/magic/spellbook/spell_test.go
@@ -1,0 +1,95 @@
+package spellbook
+
+import (
+    "testing"
+    "math"
+    "slices"
+
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+)
+
+type testWizard struct {
+    Books []data.WizardBook
+    Retorts []data.Retort
+}
+
+func (wizard *testWizard) RetortEnabled(retort data.Retort) bool {
+    return slices.Contains(wizard.Retorts, retort)
+}
+
+func (wizard *testWizard) MagicLevel(magic data.MagicType) int {
+    for _, book := range wizard.Books {
+        if book.Magic == magic {
+            return book.Count
+        }
+    }
+
+    return 0
+}
+
+func TestSpellCost(test *testing.T) {
+    natureSpell := Spell{
+        CastCost: 50,
+        Magic: data.NatureMagic,
+        Section: SectionSpecial,
+    }
+
+    wizard := testWizard{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 1,
+            },
+        },
+        Retorts: []data.Retort{
+        },
+    }
+
+    value := ComputeSpellCost(&wizard, natureSpell, true, false)
+    if value != 50*5 {
+        test.Errorf("casting cost for nature spell with no modifiers was wrong. expected=%v actual=%v", 50*5, value)
+    }
+
+    // 30% reduction
+    wizard = testWizard{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 10,
+            },
+        },
+        Retorts: []data.Retort{
+        },
+    }
+
+    value = ComputeSpellCost(&wizard, natureSpell, true, false)
+    if value != 50*5*7/10 {
+        test.Errorf("casting cost for nature spell was wrong. expected=%v actual=%v", 50*5*7/10, value)
+    }
+
+    // 30% reduction + nature mastery
+    wizard = testWizard{
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.NatureMagic,
+                Count: 10,
+            },
+        },
+        Retorts: []data.Retort{
+            data.RetortNatureMastery,
+        },
+    }
+
+    value = ComputeSpellCost(&wizard, natureSpell, true, false)
+    expected := 50*5*(100 - (30 + 15))/100
+    if value != expected {
+        test.Errorf("casting cost for nature spell was wrong. expected=%v actual=%v", expected, value)
+    }
+
+    // evil omens
+    value = ComputeSpellCost(&wizard, natureSpell, true, true)
+    expected = int(math.Floor(50.0*5*(100 - (30 + 15))/100 * 3/2))
+    if value != expected {
+        test.Errorf("casting cost for nature spell with evil omens. expected=%v actual=%v", expected, value)
+    }
+}

--- a/test/artifact/main.go
+++ b/test/artifact/main.go
@@ -24,20 +24,34 @@ type Engine struct {
     Cache *lbx.LbxCache
     Coroutine *coroutine.Coroutine
 
-    Artificer bool
-    Runemaster bool
     ShowUpdate int
+    Books Books
 }
 
 type Books struct {
+    Artificer bool
+    Runemaster bool
 }
 
 func (books *Books) MagicLevel(magic data.MagicType) int {
     switch magic {
         case data.ChaosMagic: return 11
+        case data.MagicNone: return 0
     }
 
-    return 11
+    return 0
+}
+
+func (books *Books) RetortEnabled(retort data.Retort) bool {
+    if retort == data.RetortArtificer {
+        return books.Artificer
+    }
+
+    if retort == data.RetortRunemaster {
+        return books.Runemaster
+    }
+
+    return false
 }
 
 func NewEngine() (*Engine, error) {
@@ -60,7 +74,7 @@ func (engine *Engine) ArtifactRoutine() func (coroutine.YieldFunc) error {
     }
 
     return func(yield coroutine.YieldFunc) error {
-        create, cancel := artifact.ShowCreateArtifactScreen(yield, engine.Cache, artifact.CreationCreateArtifact, &Books{}, engine.Artificer, engine.Runemaster, spells.CombatSpells(), &engine.Drawer)
+        create, cancel := artifact.ShowCreateArtifactScreen(yield, engine.Cache, artifact.CreationCreateArtifact, &engine.Books, spells.CombatSpells(), &engine.Drawer)
         if !cancel {
             log.Printf("Create artifact: %+v", create)
         } else {
@@ -80,15 +94,15 @@ func (engine *Engine) Update() error {
         switch key {
             case ebiten.KeyEscape, ebiten.KeyCapsLock: return ebiten.Termination
             case ebiten.KeyF1:
-                engine.Artificer = !engine.Artificer
+                engine.Books.Artificer = !engine.Books.Artificer
                 engine.ShowUpdate = 60
                 engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
-                log.Printf("Artificer %v Runemaster %v", engine.Artificer, engine.Runemaster)
+                log.Printf("Artificer %v Runemaster %v", engine.Books.Artificer, engine.Books.Runemaster)
             case ebiten.KeyF2:
-                engine.Runemaster = !engine.Runemaster
+                engine.Books.Runemaster = !engine.Books.Runemaster
                 engine.ShowUpdate = 60
                 engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
-                log.Printf("Artificer %v Runemaster %v", engine.Artificer, engine.Runemaster)
+                log.Printf("Artificer %v Runemaster %v", engine.Books.Artificer, engine.Books.Runemaster)
         }
     }
 
@@ -107,7 +121,7 @@ func (engine *Engine) Draw(screen *ebiten.Image){
     engine.Drawer(screen)
 
     if engine.ShowUpdate > 0 {
-        ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Artificer %v Runemaster %v", engine.Artificer, engine.Runemaster), 0, 0)
+        ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Artificer %v Runemaster %v", engine.Books.Artificer, engine.Books.Runemaster), 0, 0)
     }
 }
 

--- a/test/cast-spell/main.go
+++ b/test/cast-spell/main.go
@@ -30,6 +30,17 @@ func NewEngine() (*Engine, error) {
     return engine, nil
 }
 
+type Caster struct {
+}
+
+func (caster *Caster) ComputeEffectiveResearchPerTurn(research float64, spell spellbook.Spell) int {
+    return int(research)
+}
+
+func (caster *Caster) ComputeEffectiveSpellCost(spell spellbook.Spell, overland bool) int {
+    return spell.Cost(overland) / 2
+}
+
 func (engine *Engine) MakeUI() *uilib.UI {
     allSpells, err := spellbook.ReadSpellsFromCache(engine.Cache)
     if err != nil {
@@ -66,7 +77,7 @@ func (engine *Engine) MakeUI() *uilib.UI {
     }
     ui.SetElementsFromArray(nil)
 
-    more := spellbook.MakeSpellBookCastUI(ui, engine.Cache, spells, make(map[spellbook.Spell]int), 60, spellbook.Spell{}, 0, true, func (result spellbook.Spell, picked bool){
+    more := spellbook.MakeSpellBookCastUI(ui, engine.Cache, spells, make(map[spellbook.Spell]int), 60, spellbook.Spell{}, 0, true, &Caster{}, func (result spellbook.Spell, picked bool){
         if picked {
             log.Printf("Picked spell %+v", result)
         }

--- a/test/combat/main.go
+++ b/test/combat/main.go
@@ -297,13 +297,19 @@ func makeScenario1(cache *lbx.LbxCache) *combat.CombatScreen {
     attackingPlayer := player.MakePlayer(setup.WizardCustom{
             Name: "Merlin",
             Banner: data.BannerGreen,
+            Books: []data.WizardBook{
+                data.WizardBook{
+                    Magic: data.ChaosMagic,
+                    Count: 8,
+                },
+            },
         }, true, 0, 0, nil, &noGlobalEnchantments{})
 
     fortressCity := citylib.MakeCity("xyz", 10, 10, attackingPlayer.Wizard.Race, nil, &BasicCatchment{}, nil, attackingPlayer)
     fortressCity.Buildings.Insert(buildinglib.BuildingFortress)
     attackingPlayer.AddCity(fortressCity)
 
-    attackingPlayer.CastingSkillPower = 10000
+    attackingPlayer.CastingSkillPower = 1000
     attackingPlayer.Mana = 1000
 
     // attackingPlayer.KnownSpells.AddSpell(allSpells.FindByName("Fireball"))

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -975,9 +975,11 @@ func createScenario13(cache *lbx.LbxCache) *gamelib.Game {
 
     player := game.AddPlayer(wizard, true)
 
-    player.CastingSkillPower += 500000
+    player.CastingSkillPower += 100000
 
     allSpells, _ := spellbook.ReadSpellsFromCache(cache)
+
+    player.ResearchPoolSpells = allSpells
 
     // summoning
     player.KnownSpells.AddSpell(allSpells.FindByName("Guardian Spirit"))

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -72,6 +72,7 @@ func createScenario1(cache *lbx.LbxCache) *gamelib.Game {
         Retorts: []data.Retort{
             data.RetortAlchemy,
             data.RetortSageMaster,
+            data.RetortRunemaster,
         },
         Books: []data.WizardBook{
             data.WizardBook{


### PR DESCRIPTION
* compute the cost of a spell while taking all retorts and spell book modifiers into account, as well as the evil omens global enchantment
* compute extra research progress for some types of spells, also based on retorts/spell books
* fix a bug in the new wizard custom books ui where a retort can be selected without the proper number/type of spell books
* remove artificer/runemaster from create artifact, and just let the final spell cost be computed the same as every other spell