### PR TITLE
ui: add tooltip to unit stats

### DIFF
--- a/game/magic/armyview/view.go
+++ b/game/magic/armyview/view.go
@@ -105,11 +105,7 @@ func (view *ArmyScreen) MakeUI() *uilib.UI {
                 view.DrawMinimap(minimapArea, 10, 10, view.Player.GetFog(data.PlaneArcanus), data.PlaneArcanus, this.Counter)
             }
 
-            this.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            this.StandardDraw(screen)
 
             // vector.DrawFilledRect(minimapArea, float32(minimapRect.Min.X), float32(minimapRect.Min.Y), float32(minimapRect.Bounds().Dx()), float32(minimapRect.Bounds().Dy()), util.PremultiplyAlpha(color.RGBA{R: 0xff, G: 0, B: 0, A: 128}), false)
         },

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -1190,11 +1190,7 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
             background, _ := imageCache.GetImage("spellscr.lbx", 13, 0)
             scale.DrawScaled(screen, background, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/citylistview/view.go
+++ b/game/magic/citylistview/view.go
@@ -98,11 +98,7 @@ func (view *CityListScreen) MakeUI() *uilib.UI {
             var options ebiten.DrawImageOptions
             scale.DrawScaled(screen, background, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
 
             bigFont.PrintCenter(screen, float64(160), float64(5), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("The Cities Of %v", view.Player.Wizard.Name))
 

--- a/game/magic/cityview/build-screen.go
+++ b/game/magic/cityview/build-screen.go
@@ -126,12 +126,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 scale.DrawScaled(screen, mainInfo, &options)
             }
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
-
+            ui.StandardDraw(screen)
         },
     }
 
@@ -237,6 +232,7 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
         bannerUnit := units.MakeOverworldUnitFromUnit(unit, 0, 0, city.Plane, city.GetBanner(), nil, &units.NoEnchantments{})
         productionCost := city.UnitProductionCost(&unit)
         mainGroup.AddElement(&uilib.UIElement{
+            Order: -1,
             Draw: func(this *uilib.UIElement, screen *ebiten.Image) {
                 var options ebiten.DrawImageOptions
                 options.GeoM.Translate(float64(104), float64(28))
@@ -246,9 +242,11 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
                 options.GeoM.Translate(float64(130), float64(7))
                 unitview.RenderUnitInfoBuild(screen, imageCache, bannerUnit, fonts.DescriptionFont, fonts.SmallFont, options, productionCost)
 
+                /*
                 options.GeoM.Reset()
                 options.GeoM.Translate(float64(85), float64(48))
                 unitview.RenderUnitInfoStats(screen, imageCache, bannerUnit, 10, fonts.DescriptionFont, fonts.SmallFont, options)
+                */
 
                 /*
                 options.GeoM.Reset()
@@ -260,6 +258,12 @@ func makeBuildUI(cache *lbx.LbxCache, imageCache *util.ImageCache, city *citylib
         var getAlpha util.AlphaFadeFunc = func () float32 {
             return 1
         }
+
+        var defaultOptions ebiten.DrawImageOptions
+        defaultOptions.GeoM.Translate(float64(85), float64(48))
+
+        mainGroup.AddElements(unitview.CreateUnitInfoStatsElements(imageCache, bannerUnit, 10, fonts.DescriptionFont, fonts.SmallFont, defaultOptions, &getAlpha, 0))
+
         mainGroup.AddElements(unitview.MakeUnitAbilitiesElements(mainGroup, cache, imageCache, bannerUnit, fonts.MediumFont, 85, 108, &ui.Counter, 0, &getAlpha, true, 0, false))
         // ui.AddElements(mainElements)
     }

--- a/game/magic/cityview/city-screen.go
+++ b/game/magic/cityview/city-screen.go
@@ -659,11 +659,7 @@ func (cityScreen *CityScreen) MakeUI(newBuilding buildinglib.Building) *uilib.UI
     ui := &uilib.UI{
         Cache: cityScreen.LbxCache,
         Draw: func(ui *uilib.UI, screen *ebiten.Image) {
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 
@@ -2369,11 +2365,7 @@ func SimplifiedView(cache *lbx.LbxCache, city *citylib.City, player *playerlib.P
             unitsX, unitsY := options.GeoM.Apply(float64(6), float64(43))
             fonts.DescriptionFont.PrintOptions(screen, unitsX, unitsY, fontOptions, fmt.Sprintf("Units   %v", currentUnitName))
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -1822,6 +1822,8 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                 }
             }
 
+            // FIXME: this should show the player's army, not always the attacking one
+
             y := 173
             right := 239
             combat.HudFont.PrintOptions(screen, float64(200), float64(y), font.FontOptions{Scale: scale.ScaleAmount}, "Skill:")
@@ -1896,11 +1898,7 @@ func (combat *CombatScreen) MakeUI(player *playerlib.Player) *uilib.UI {
                 combat.DrawHealthBar(screen, 123, 197, combat.Model.SelectedUnit)
             }
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/combat/end-screen.go
+++ b/game/magic/combat/end-screen.go
@@ -65,11 +65,7 @@ func (end *CombatEndScreen) MakeUI() *uilib.UI {
 
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/combat/unit-view.go
+++ b/game/magic/combat/unit-view.go
@@ -71,8 +71,11 @@ func MakeUnitView(cache *lbx.LbxCache, ui *uilib.UI, unit *ArmyUnit) *uilib.UIEl
     const fadeSpeed = 7
     getAlpha := ui.MakeFadeIn(fadeSpeed)
 
+    var layer uilib.UILayer = 1
+
     group.AddElement(&uilib.UIElement{
-        Layer: 1,
+        Layer: layer,
+        Order: -1,
         NotLeftClicked: func(element *uilib.UIElement) {
             getAlpha = ui.MakeFadeOut(fadeSpeed)
             ui.AddDelay(fadeSpeed, func(){
@@ -106,10 +109,12 @@ func MakeUnitView(cache *lbx.LbxCache, ui *uilib.UI, unit *ArmyUnit) *uilib.UIEl
 
             RenderUnitInfo(screen, &imageCache, unit, fonts, options)
 
+            /*
             options.GeoM.Reset()
             options.GeoM.Translate(float64(31), float64(6))
             options.GeoM.Translate(float64(10), float64(50))
             unitview.RenderUnitInfoStats(screen, &imageCache, unit, 15, fonts.DescriptionFont, fonts.SmallFont, options)
+            */
 
             /*
             options.GeoM.Translate(0, 60)
@@ -118,7 +123,13 @@ func MakeUnitView(cache *lbx.LbxCache, ui *uilib.UI, unit *ArmyUnit) *uilib.UIEl
         },
     })
 
-    group.AddElements(unitview.MakeUnitAbilitiesElements(group, cache, &imageCache, unit, fonts.MediumFont, 40, 114, &ui.Counter, 1, &getAlpha, false, 0, false))
+    var defaultOptions ebiten.DrawImageOptions
+    defaultOptions.GeoM.Translate(float64(31), float64(6))
+    defaultOptions.GeoM.Translate(float64(10), float64(50))
+
+    group.AddElements(unitview.CreateUnitInfoStatsElements(&imageCache, unit, 15, fonts.DescriptionFont, fonts.SmallFont, defaultOptions, &getAlpha, layer))
+
+    group.AddElements(unitview.MakeUnitAbilitiesElements(group, cache, &imageCache, unit, fonts.MediumFont, 40, 114, &ui.Counter, layer, &getAlpha, false, 0, false))
 
     return group
 }

--- a/game/magic/diplomacy/diplomacy.go
+++ b/game/magic/diplomacy/diplomacy.go
@@ -214,11 +214,7 @@ func ShowDiplomacyScreen(cache *lbx.LbxCache, player *playerlib.Player, enemy *p
 
     ui := &uilib.UI{
         Draw: func (ui *uilib.UI, screen *ebiten.Image){
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
         LeftClick: func(){
             if !clickedOnce {

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -1632,11 +1632,7 @@ func (game *Game) doSelectUnit(yield coroutine.YieldFunc, player *playerlib.Play
 
     ui := uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
         LeftClick: func(){
             quit = true
@@ -1919,11 +1915,7 @@ func (game *Game) selectLocationForSpell(yield coroutine.YieldFunc, spell spellb
             options.GeoM.Translate(float64(240), float64(174))
             scale.DrawScaled(screen, cancelBackground, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
 
             game.Fonts.WhiteFont.PrintRight(screen, float64(276), float64(68), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v GP", game.Players[0].Gold))
             game.Fonts.WhiteFont.PrintRight(screen, float64(313), float64(68), scale.ScaleAmount, ebiten.ColorScale{}, fmt.Sprintf("%v MP", game.Players[0].Mana))

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1167,11 +1167,7 @@ func (game *Game) doInput(yield coroutine.YieldFunc, title string, name string, 
 
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
     ui.SetElementsFromArray(nil)
@@ -2208,11 +2204,7 @@ func (game *Game) doGameMenu(yield coroutine.YieldFunc) {
             var options ebiten.DrawImageOptions
             scale.DrawScaled(screen, background, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 
@@ -4325,11 +4317,7 @@ func (game *Game) confirmRazeTown(yield coroutine.YieldFunc, city *citylib.City)
     ui := &uilib.UI{
         Cache: game.Cache,
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5980,11 +5980,7 @@ func (game *Game) MakeHudUI() *uilib.UI {
             mainHud, _ := game.ImageCache.GetImage("main.lbx", 0, 0)
             scale.DrawScaled(screen, mainHud, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
         HandleKeys: func(keys []ebiten.Key){
             for _, key := range keys {

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -46,6 +46,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
+        Order: 0,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
             var options ebiten.DrawImageOptions
@@ -85,6 +86,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
         },
     })
 
+    /*
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
         Order: 1,
@@ -101,6 +103,14 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
             unitview.RenderUnitInfoStats(screen, &imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, options)
         },
     })
+    */
+
+    var statsOptions ebiten.DrawImageOptions
+    statsOptions.GeoM.Translate(0, yTop)
+    statsOptions.GeoM.Translate(float64(31), float64(6))
+    statsOptions.GeoM.Translate(float64(10), float64(50))
+
+    uiGroup.AddElements(unitview.CreateUnitInfoStatsElements(&imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, statsOptions, &getAlpha))
 
     uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, hero, fonts.MediumFont, 40, 124, &ui.Counter, 1, &getAlpha, true, 0, false))
 
@@ -122,6 +132,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
     hireIndex := 0
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
+        Order: 1,
         Rect: hireRect,
         LeftClick: func(this *uilib.UIElement){
             hireIndex = 1
@@ -167,6 +178,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
     rejectIndex := 0
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
+        Order: 1,
         Rect: rejectRect,
         LeftClick: func(this *uilib.UIElement){
             rejectIndex = 1

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -110,7 +110,7 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
     statsOptions.GeoM.Translate(float64(31), float64(6))
     statsOptions.GeoM.Translate(float64(10), float64(50))
 
-    uiGroup.AddElements(unitview.CreateUnitInfoStatsElements(&imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, statsOptions, &getAlpha))
+    uiGroup.AddElements(unitview.CreateUnitInfoStatsElements(&imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, statsOptions, &getAlpha, 1))
 
     uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, hero, fonts.MediumFont, 40, 124, &ui.Counter, 1, &getAlpha, true, 0, false))
 

--- a/game/magic/game/hero.go
+++ b/game/magic/game/hero.go
@@ -70,16 +70,35 @@ func MakeHireHeroScreenUI(cache *lbx.LbxCache, ui *uilib.UI, hero *herolib.Hero,
 
             unitview.RenderUnitInfoNormal(screen, &imageCache, hero, hero.GetTitle(), "", fonts.DescriptionFont, fonts.SmallFont, options)
 
+            /*
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
             options.GeoM.Translate(float64(31), float64(6))
             options.GeoM.Translate(float64(10), float64(50))
             unitview.RenderUnitInfoStats(screen, &imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, options)
+            */
 
             /*
             options.GeoM.Translate(0, 60)
             unitview.RenderUnitAbilities(screen, &imageCache, hero, mediumFont, options, true, 0)
             */
+        },
+    })
+
+    uiGroup.AddElement(&uilib.UIElement{
+        Layer: 1,
+        Order: 1,
+        Tooltip: func(element *uilib.UIElement) (string, *font.Font) {
+            return "3", fonts.DescriptionFont
+        },
+        Rect: image.Rect(31, int(yTop) + 6 + 50, 31 + 150, int(yTop) + 6 + 50 + 50),
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(0, yTop)
+            options.GeoM.Translate(float64(31), float64(6))
+            options.GeoM.Translate(float64(10), float64(50))
+            options.ColorScale.ScaleAlpha(getAlpha())
+            unitview.RenderUnitInfoStats(screen, &imageCache, hero, 15, fonts.DescriptionFont, fonts.SmallFont, options)
         },
     })
 

--- a/game/magic/game/mercenaries.go
+++ b/game/magic/game/mercenaries.go
@@ -32,6 +32,7 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
 
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
+        Order: -1,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
             var options ebiten.DrawImageOptions
@@ -49,13 +50,22 @@ func MakeHireMercenariesScreenUI(cache *lbx.LbxCache, ui *uilib.UI, unit *units.
             options.GeoM.Translate(float64(51), float64(7))
             unitview.RenderUnitInfoNormal(screen, &imageCache, unit, "", unit.Unit.Race.String(), fonts.DescriptionFont, fonts.SmallFont, options)
 
+            /*
             options.GeoM.Reset()
             options.GeoM.Translate(0, yTop)
             options.GeoM.Translate(float64(31), float64(6))
             options.GeoM.Translate(float64(10), float64(50))
             unitview.RenderUnitInfoStats(screen, &imageCache, unit, 15, fonts.DescriptionFont, fonts.SmallFont, options)
+            */
         },
     })
+
+    var statsOptions ebiten.DrawImageOptions
+    statsOptions.GeoM.Translate(0, yTop)
+    statsOptions.GeoM.Translate(float64(31), float64(6))
+    statsOptions.GeoM.Translate(float64(10), float64(50))
+
+    uiGroup.AddElements(unitview.CreateUnitInfoStatsElements(&imageCache, unit, 15, fonts.DescriptionFont, fonts.SmallFont, statsOptions, &getAlpha, 1))
 
     uiGroup.AddElements(unitview.MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, unit, fonts.MediumFont, 40, 124, &ui.Counter, 1, &getAlpha, false, 0, false))
 

--- a/game/magic/game/surveyor.go
+++ b/game/magic/game/surveyor.go
@@ -101,11 +101,7 @@ func (game *Game) doSurveyor(yield coroutine.YieldFunc) {
             options.GeoM.Translate(float64(240), float64(174))
             scale.DrawScaled(screen, cancelBackground, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
 
             player := game.Players[0]
 

--- a/game/magic/game/vault.go
+++ b/game/magic/game/vault.go
@@ -101,11 +101,7 @@ func (game *Game) showVaultScreen(createdArtifact *artifact.Artifact, player *pl
             fonts.ResourceFont.PrintOptions(screen, 190, 166, fontOptions, fmt.Sprintf("%v GP", player.Gold))
             fonts.ResourceFont.PrintOptions(screen, 233, 166, fontOptions, fmt.Sprintf("%v MP", player.Mana))
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/magicview/view.go
+++ b/game/magic/magicview/view.go
@@ -347,11 +347,7 @@ func (magic *MagicScreen) MakeUI(player *playerlib.Player, enemies []*playerlib.
             fonts.NormalFont.PrintOptions(screen, float64(103), float64(160), rightShadow, fmt.Sprintf("%v RP", research))
             fonts.NormalFont.PrintOptions(screen, float64(151), float64(160), rightShadow, fmt.Sprintf("%v SP", skill))
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/mainview/view.go
+++ b/game/magic/mainview/view.go
@@ -60,11 +60,7 @@ func (main *MainScreen) MakeUI() *uilib.UI {
                 scale.DrawScaled(screen, background, &options)
             }
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/setup/new-game.go
+++ b/game/magic/setup/new-game.go
@@ -269,9 +269,7 @@ func (newGameScreen *NewGameScreen) MakeUI() *uilib.UI {
             optionsImage, _ := newGameScreen.ImageCache.GetImage("newgame.lbx", 1, 0)
             scale.DrawScaled(screen, optionsImage, &options)
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                element.Draw(element, screen)
-            })
+            ui.StandardDraw(screen)
         },
         HandleKeys: func(keys []ebiten.Key){
             for _, key := range keys {

--- a/game/magic/setup/new-wizard.go
+++ b/game/magic/setup/new-wizard.go
@@ -602,9 +602,7 @@ func (screen *NewWizardScreen) MakeCustomPictureUI() *uilib.UI {
             customPictureBackground, _ := screen.ImageCache.GetImage("newgame.lbx", 39, 0)
             window.DrawImage(customPictureBackground, scale.ScaleOptions(options))
 
-            this.IterateElementsByLayer(func (element *uilib.UIElement){
-                element.Draw(element, window)
-            })
+            this.StandardDraw(window)
 
             portrait, _ := screen.ImageCache.GetImage("wizards.lbx", screen.CustomWizard.Portrait, 0)
             if portrait != nil {
@@ -736,9 +734,7 @@ func (screen *NewWizardScreen) MakeSelectWizardUI() *uilib.UI {
             window.DrawImage(background, scale.ScaleOptions(options))
             screen.SelectFont.PrintOptions(window, 245, 2, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, "Select Wizard")
 
-            this.IterateElementsByLayer(func (element *uilib.UIElement){
-                element.Draw(element, window)
-            })
+            this.StandardDraw(window)
 
             if screen.CurrentWizard >= 0 && screen.CurrentWizard < len(screen.WizardSlots) {
                 portraitX := 24
@@ -1369,11 +1365,7 @@ func (screen *NewWizardScreen) MakeCustomWizardBooksUI() *uilib.UI {
             options.GeoM.Translate(34, 135)
             draw.DrawBooks(window, options, &imageCache, screen.CustomWizard.Books, screen.BooksOrderRandom())
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, window)
-                }
-            })
+            ui.StandardDraw(window)
 
             screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
             screen.NameFontBright.PrintOptions(window, 223, 185, font.FontOptions{Justify: font.FontJustifyCenter, Scale: scale.ScaleAmount}, fmt.Sprintf("%v picks", picksLeft()))
@@ -1754,11 +1746,7 @@ func (screen *NewWizardScreen) MakeSelectSpellsUI() *uilib.UI {
                     showDescription(78, fmt.Sprintf("Rare: %v", spellInfo.RareMax), spellBackground2)
                 }
 
-                ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                    if element.Draw != nil {
-                        element.Draw(element, window)
-                    }
-                })
+                ui.StandardDraw(window)
             },
             HandleKeys: func(keys []ebiten.Key){
                 for _, key := range keys {
@@ -2013,12 +2001,7 @@ func (screen *NewWizardScreen) MakeSelectRaceUI() *uilib.UI {
 
             screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, window)
-                }
-            })
-
+            ui.StandardDraw(window)
         },
         HandleKeys: func(keys []ebiten.Key){
             for _, key := range keys {
@@ -2100,11 +2083,7 @@ func (screen *NewWizardScreen) MakeSelectBannerUI() *uilib.UI {
 
             screen.AbilityFontSelected.PrintOptions(window, 12, 180, font.FontOptions{Scale: scale.ScaleAmount}, JoinAbilities(screen.CustomWizard.Retorts))
 
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, window)
-                }
-            })
+            ui.StandardDraw(window)
         },
         HandleKeys: func(keys []ebiten.Key){
             for _, key := range keys {

--- a/game/magic/spellbook/spell.go
+++ b/game/magic/spellbook/spell.go
@@ -282,11 +282,7 @@ func ComputeSpellCost(wizard Wizard, spell Spell, overland bool, hasEvilOmens bo
 func ShowSpellBook(yield coroutine.YieldFunc, cache *lbx.LbxCache, allSpells Spells, knownSpells Spells, researchSpells Spells, researchingSpell Spell, researchProgress int, researchPoints float64, castingSkill int, learnedSpell Spell, pickResearchSpell bool, chosenSpell *Spell, caster SpellCaster, drawFunc *func(screen *ebiten.Image)) {
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-            ui.IterateElementsByLayer(func (element *uilib.UIElement){
-                if element.Draw != nil {
-                    element.Draw(element, screen)
-                }
-            })
+            ui.StandardDraw(screen)
         },
     }
 

--- a/game/magic/ui/ui.go
+++ b/game/magic/ui/ui.go
@@ -462,7 +462,7 @@ func (ui *UI) RenderTooltip(screen *ebiten.Image) {
                     options.ColorScale.ScaleAlpha(float32(alpha) / float32(alphaRange))
                 }
 
-                renderFont.PrintOptions(screen, float64(ui.TooltipPosition.X), float64(ui.TooltipPosition.Y), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, DropShadow: true}, tip)
+                renderFont.PrintOptions(screen, float64(ui.TooltipPosition.X), float64(ui.TooltipPosition.Y - renderFont.Height() - 1), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, DropShadow: true}, tip)
             }
         }
     }

--- a/game/magic/ui/ui.go
+++ b/game/magic/ui/ui.go
@@ -13,6 +13,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/scale"
     "github.com/kazzmir/master-of-magic/game/magic/inputmanager"
     "github.com/kazzmir/master-of-magic/lib/lbx"
+    "github.com/kazzmir/master-of-magic/lib/font"
 
     "github.com/hajimehoshi/ebiten/v2"
     "github.com/hajimehoshi/ebiten/v2/inpututil"
@@ -23,6 +24,7 @@ type UIInsideElementFunc func(element *UIElement, x int, y int)
 type UINotInsideElementFunc func(element *UIElement)
 type UIClickElementFunc func(element *UIElement)
 type UIDrawFunc func(element *UIElement, window *ebiten.Image)
+type UIToolTipFunc func(element *UIElement) (string, *font.Font)
 type UIKeyFunc func(key []ebiten.Key)
 type UIGainFocusFunc func(*UIElement)
 type UILoseFocusFunc func(*UIElement)
@@ -58,6 +60,10 @@ type UIElement struct {
     DoubleLeftClick UIClickElementFunc
     // fires when this element is right clicked
     RightClick UIClickElementFunc
+
+    // if not nil and doesn't return the empty string, the tooltip will be rendered on top of the ui when
+    // this element is hovered
+    Tooltip UIToolTipFunc
 
     // fires when this element is left clicked
     GainFocus UIGainFocusFunc
@@ -179,6 +185,10 @@ type UI struct {
     touchStartTime uint64
 
     textField textinput.Field
+
+    // the element that is currently being hovered over
+    TooltipElement *UIElement
+    TooltipPosition image.Point
 
     doubleClickCandidates []doubleClick
 
@@ -434,6 +444,28 @@ func (ui *UI) PlayStandardSound() {
     }
 }
 
+func (ui *UI) RenderTooltip(screen *ebiten.Image) {
+    if ui.TooltipElement != nil && ui.TooltipElement.Tooltip != nil {
+        tip, renderFont := ui.TooltipElement.Tooltip(ui.TooltipElement)
+        if tip != "" {
+            var options ebiten.DrawImageOptions
+            renderFont.PrintOptions(screen, float64(ui.TooltipPosition.X), float64(ui.TooltipPosition.Y), font.FontOptions{Options: &options, Scale: scale.ScaleAmount, DropShadow: true}, tip)
+        }
+    }
+}
+
+// iterates through the elements in the highest layer and draws them
+// then draws the tooltip on top
+func (ui *UI) StandardDraw(screen *ebiten.Image) {
+    ui.IterateElementsByLayer(func (element *UIElement){
+        if element.Draw != nil {
+            element.Draw(element, screen)
+        }
+    })
+
+    ui.RenderTooltip(screen)
+}
+
 func (ui *UI) StandardUpdate() {
     ui.Counter += 1
 
@@ -556,8 +588,13 @@ func (ui *UI) StandardUpdate() {
 
     mouseX, mouseY = scale.Unscale2(mouseX, mouseY)
 
+    ui.TooltipElement = nil
+
     for _, element := range slices.Backward(ui.GetHighestLayer()) {
         if image.Pt(mouseX, mouseY).In(element.Rect) {
+            ui.TooltipElement = element
+            ui.TooltipPosition = image.Pt(mouseX, mouseY)
+
             if element.Inside != nil {
                 element.Inside(element, mouseX - element.Rect.Min.X, mouseY - element.Rect.Min.Y)
             }

--- a/game/magic/unitview/ui.go
+++ b/game/magic/unitview/ui.go
@@ -152,6 +152,7 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
 
     uiGroup.AddElement(&uilib.UIElement{
         Layer: 1,
+        Order: -1,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
             var options ebiten.DrawImageOptions
@@ -179,10 +180,12 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
 
             RenderUnitInfoNormal(screen, &imageCache, unit, unit.GetTitle(), "", descriptionFont, smallFont, options)
 
+            /*
             options.GeoM.Reset()
             options.GeoM.Translate(31, 6)
             options.GeoM.Translate(10, 50)
             RenderUnitInfoStats(screen, &imageCache, unit, 15, descriptionFont, smallFont, options)
+            */
 
             /*
             options.GeoM.Translate(0, 60)
@@ -190,6 +193,12 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
             */
         },
     })
+
+    var defaultOptions ebiten.DrawImageOptions
+    defaultOptions.GeoM.Translate(31, 6)
+    defaultOptions.GeoM.Translate(10, 50)
+
+    uiGroup.AddElements(CreateUnitInfoStatsElements(&imageCache, unit, 15, descriptionFont, smallFont, defaultOptions, &getAlpha))
 
     uiGroup.AddElements(MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, unit, mediumFont, 40, 114, &ui.Counter, 1, &getAlpha, false, 0, true))
 

--- a/game/magic/unitview/ui.go
+++ b/game/magic/unitview/ui.go
@@ -198,7 +198,7 @@ func MakeGenericContextMenu(cache *lbx.LbxCache, ui *uilib.UI, unit UnitView, di
     defaultOptions.GeoM.Translate(31, 6)
     defaultOptions.GeoM.Translate(10, 50)
 
-    uiGroup.AddElements(CreateUnitInfoStatsElements(&imageCache, unit, 15, descriptionFont, smallFont, defaultOptions, &getAlpha))
+    uiGroup.AddElements(CreateUnitInfoStatsElements(&imageCache, unit, 15, descriptionFont, smallFont, defaultOptions, &getAlpha, 1))
 
     uiGroup.AddElements(MakeUnitAbilitiesElements(uiGroup, cache, &imageCache, unit, mediumFont, 40, 114, &ui.Counter, 1, &getAlpha, false, 0, true))
 

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -299,6 +299,7 @@ func RenderHitpointsStats(screen *ebiten.Image, imageCache *util.ImageCache, uni
     showNIcons(screen, healthIcon, unit.GetBaseHitPoints(), healthIconGold, unit.GetFullHitPoints() - unit.GetBaseHitPoints(), unit.GetHitPoints() - unit.GetFullHitPoints(), defaultOptions, x, y, width, maxIconsPerLine)
 }
 
+/*
 func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions) {
     width := descriptionFont.MeasureTextWidth("Armor", 1)
 
@@ -324,8 +325,9 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
 
     RenderHitpointsStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, defaultOptions, x, y, width)
 }
+*/
 
-func CreateUnitInfoStatsElements(imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, getAlpha *util.AlphaFadeFunc) []*uilib.UIElement {
+func CreateUnitInfoStatsElements(imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, getAlpha *util.AlphaFadeFunc, layer uilib.UILayer) []*uilib.UIElement {
     type statsRender struct {
         Render func(*ebiten.Image, *util.ImageCache, UnitStats, int, *font.Font, *font.Font, ebiten.DrawImageOptions, float64, float64, float64)
         Value func() int
@@ -349,7 +351,7 @@ func CreateUnitInfoStatsElements(imageCache *util.ImageCache, unit UnitStats, ma
         elementX, elementY := x, y
         elements = append(elements, &uilib.UIElement{
             Order: 1,
-            Layer: 1,
+            Layer: layer,
             Rect: image.Rect(int(elementX), int(elementY), int(elementX) + background.Bounds().Dx(), int(elementY) + descriptionFont.Height()),
             Tooltip: func (element *uilib.UIElement) (string, *font.Font) {
                 return strconv.Itoa(render.Value()), smallFont

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -182,58 +182,53 @@ func RenderUnitInfoBuild(screen *ebiten.Image, imageCache *util.ImageCache, unit
     smallFont.PrintOptions(screen, x, y + float64(27), font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}, fmt.Sprintf("Cost %v(%v)", discountedCost, cost))
 }
 
-func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions) {
-    width := descriptionFont.MeasureTextWidth("Armor", 1)
+// show rows of icons. the second row is offset a bit to the right and down
+func showNIcons(screen *ebiten.Image, icon *ebiten.Image, count int, icon2 *ebiten.Image, count2 int, negativeCount int, options ebiten.DrawImageOptions, x, y float64, width float64, maxIconsPerLine int) {
+    // var options ebiten.DrawImageOptions
+    // options = defaultOptions
+    options.GeoM.Reset()
+    options.GeoM.Translate(x, y)
+    options.GeoM.Translate(width + 1, 0)
+    saveGeoM := options.GeoM
 
-    x, y := defaultOptions.GeoM.Apply(0, 0)
-
-    fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
-
-    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Melee")
-
-    // show rows of icons. the second row is offset a bit to the right and down
-    showNIcons := func(icon *ebiten.Image, count int, icon2 *ebiten.Image, count2 int, negativeCount int, x, y float64) {
-        var options ebiten.DrawImageOptions
-        options = defaultOptions
-        options.GeoM.Reset()
-        options.GeoM.Translate(x, y)
-        options.GeoM.Translate(width + 1, 0)
-        saveGeoM := options.GeoM
-
-        draw := func (index int, icon *ebiten.Image) {
-            if index > 0 && index % 5 == 0 {
-                options.GeoM.Translate(3, 0)
-            }
-
-            if index > 0 && index % maxIconsPerLine == 0 {
-                options.GeoM = saveGeoM
-                options.GeoM.Translate(float64(3 * index/maxIconsPerLine), 2 * float64(index/maxIconsPerLine))
-            }
-
-            screen.DrawImage(icon, scale.ScaleOptions(options))
-            // FIXME: if a stat is given due to an ability/spell then render the icon in gold
-            options.GeoM.Translate(float64(icon.Bounds().Dx() + 1), 0)
+    draw := func (index int, icon *ebiten.Image) {
+        if index > 0 && index % 5 == 0 {
+            options.GeoM.Translate(3, 0)
         }
 
-        index := 0
-        for index < count {
-            if index == count + count2 + negativeCount {
-                options.ColorScale.ScaleWithColor(color.RGBA{R: 128, G: 128, B: 128, A: 255})
-            }
-
-            draw(index, icon)
-            index += 1
+        if index > 0 && index % maxIconsPerLine == 0 {
+            options.GeoM = saveGeoM
+            options.GeoM.Translate(float64(3 * index/maxIconsPerLine), 2 * float64(index/maxIconsPerLine))
         }
 
-        for index < (count + count2) {
-            if index == count + count2 + negativeCount {
-                options.ColorScale.ScaleWithColor(color.RGBA{R: 128, G: 128, B: 128, A: 255})
-            }
-
-            draw(index, icon2)
-            index += 1
-        }
+        screen.DrawImage(icon, scale.ScaleOptions(options))
+        // FIXME: if a stat is given due to an ability/spell then render the icon in gold
+        options.GeoM.Translate(float64(icon.Bounds().Dx() + 1), 0)
     }
+
+    index := 0
+    for index < count {
+        if index == count + count2 + negativeCount {
+            options.ColorScale.ScaleWithColor(color.RGBA{R: 128, G: 128, B: 128, A: 255})
+        }
+
+        draw(index, icon)
+        index += 1
+    }
+
+    for index < (count + count2) {
+        if index == count + count2 + negativeCount {
+            options.ColorScale.ScaleWithColor(color.RGBA{R: 128, G: 128, B: 128, A: 255})
+        }
+
+        draw(index, icon2)
+        index += 1
+    }
+}
+
+func RenderMeleeStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, x float64, y float64, width float64) {
+    fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
+    descriptionFont.PrintOptions(screen, x, y, fontOptions, "Melee")
 
     // change the melee type depending on the unit attributes (hero uses magic sword), but
     // mythril or admantanium is also possible
@@ -252,9 +247,11 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
             weaponGold, _ = imageCache.GetImage("unitview.lbx", 39, 0)
     }
 
-    showNIcons(weaponIcon, unit.GetBaseMeleeAttackPower(), weaponGold, unit.GetMeleeAttackPower() - unit.GetBaseMeleeAttackPower(), 0, x, y)
+    showNIcons(screen, weaponIcon, unit.GetBaseMeleeAttackPower(), weaponGold, unit.GetMeleeAttackPower() - unit.GetBaseMeleeAttackPower(), 0, defaultOptions, x, y, width, maxIconsPerLine)
+}
 
-    y += float64(descriptionFont.Height())
+func RenderRangedStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, x float64, y float64, width float64) {
+    fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
     descriptionFont.PrintOptions(screen, x, y, fontOptions, "Range")
 
     var rangeIcon *ebiten.Image
@@ -273,29 +270,58 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
     }
 
     if rangeIcon != nil && rangeIconGold != nil {
-        showNIcons(rangeIcon, unit.GetBaseRangedAttackPower(), rangeIconGold, unit.GetRangedAttackPower() - unit.GetBaseRangedAttackPower(), 0, x, y)
+        showNIcons(screen, rangeIcon, unit.GetBaseRangedAttackPower(), rangeIconGold, unit.GetRangedAttackPower() - unit.GetBaseRangedAttackPower(), 0, defaultOptions, x, y, width, maxIconsPerLine)
     }
+}
 
-    y += float64(descriptionFont.Height())
+func RenderArmorStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, x float64, y float64, width float64) {
+    fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
     descriptionFont.PrintOptions(screen, x, y, fontOptions, "Armor")
-
     armorIcon, _ := imageCache.GetImage("unitview.lbx", 22, 0)
     armorGold, _ := imageCache.GetImage("unitview.lbx", 44, 0)
-    showNIcons(armorIcon, unit.GetBaseDefense(), armorGold, unit.GetDefense() - unit.GetBaseDefense(), 0, x, y)
+    showNIcons(screen, armorIcon, unit.GetBaseDefense(), armorGold, unit.GetDefense() - unit.GetBaseDefense(), 0, defaultOptions, x, y, width, maxIconsPerLine)
+}
 
-    y += float64(descriptionFont.Height())
+func RenderResistanceStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, x float64, y float64, width float64) {
+    fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
     descriptionFont.PrintOptions(screen, x, y, fontOptions, "Resist")
-
     resistIcon, _ := imageCache.GetImage("unitview.lbx", 27, 0)
     resistGold, _ := imageCache.GetImage("unitview.lbx", 49, 0)
-    showNIcons(resistIcon, unit.GetBaseResistance(), resistGold, unit.GetResistance() - unit.GetBaseResistance(), 0, x, y)
+    showNIcons(screen, resistIcon, unit.GetBaseResistance(), resistGold, unit.GetResistance() - unit.GetBaseResistance(), 0, defaultOptions, x, y, width, maxIconsPerLine)
+}
 
-    y += float64(descriptionFont.Height())
+func RenderHitpointsStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, x float64, y float64, width float64) {
+    fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
     descriptionFont.PrintOptions(screen, x, y, fontOptions, "Hits")
-
     healthIcon, _ := imageCache.GetImage("unitview.lbx", 23, 0)
     healthIconGold, _ := imageCache.GetImage("unitview.lbx", 45, 0)
-    showNIcons(healthIcon, unit.GetBaseHitPoints(), healthIconGold, unit.GetFullHitPoints() - unit.GetBaseHitPoints(), unit.GetHitPoints() - unit.GetFullHitPoints(), x, y)
+    showNIcons(screen, healthIcon, unit.GetBaseHitPoints(), healthIconGold, unit.GetFullHitPoints() - unit.GetBaseHitPoints(), unit.GetHitPoints() - unit.GetFullHitPoints(), defaultOptions, x, y, width, maxIconsPerLine)
+}
+
+func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions) {
+    width := descriptionFont.MeasureTextWidth("Armor", 1)
+
+    x, y := defaultOptions.GeoM.Apply(0, 0)
+
+    // fontOptions := font.FontOptions{DropShadow: true, Options: &defaultOptions, Scale: scale.ScaleAmount}
+
+    RenderMeleeStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, defaultOptions, x, y, width)
+
+    y += float64(descriptionFont.Height())
+
+    RenderRangedStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, defaultOptions, x, y, width)
+
+    y += float64(descriptionFont.Height())
+
+    RenderArmorStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, defaultOptions, x, y, width)
+
+    y += float64(descriptionFont.Height())
+
+    RenderArmorStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, defaultOptions, x, y, width)
+
+    y += float64(descriptionFont.Height())
+
+    RenderHitpointsStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, defaultOptions, x, y, width)
 }
 
 func RenderExperienceBadge(screen *ebiten.Image, imageCache *util.ImageCache, unit UnitExperience, showFont *font.Font, defaultOptions ebiten.DrawImageOptions, showExperience bool) (float64) {

--- a/game/magic/unitview/unit.go
+++ b/game/magic/unitview/unit.go
@@ -326,8 +326,6 @@ func RenderUnitInfoStats(screen *ebiten.Image, imageCache *util.ImageCache, unit
 }
 
 func CreateUnitInfoStatsElements(imageCache *util.ImageCache, unit UnitStats, maxIconsPerLine int, descriptionFont *font.Font, smallFont *font.Font, defaultOptions ebiten.DrawImageOptions, getAlpha *util.AlphaFadeFunc) []*uilib.UIElement {
-    var elements []*uilib.UIElement
-
     type statsRender struct {
         Render func(*ebiten.Image, *util.ImageCache, UnitStats, int, *font.Font, *font.Font, ebiten.DrawImageOptions, float64, float64, float64)
         Value func() int
@@ -344,6 +342,8 @@ func CreateUnitInfoStatsElements(imageCache *util.ImageCache, unit UnitStats, ma
     background, _ := imageCache.GetImage("unitview.lbx", 1, 0)
     width := descriptionFont.MeasureTextWidth("Armor", 1)
     x, y := defaultOptions.GeoM.Apply(0, 0)
+
+    var elements []*uilib.UIElement
 
     for _, render := range renders {
         elementX, elementY := x, y
@@ -362,41 +362,6 @@ func CreateUnitInfoStatsElements(imageCache *util.ImageCache, unit UnitStats, ma
         })
         y += float64(descriptionFont.Height())
     }
-
-    /*
-    meleeX, meleeY := x, y
-    elements = append(elements, &uilib.UIElement{
-        Order: 1,
-        Layer: 1,
-        Rect: image.Rect(int(meleeX), int(meleeY), int(meleeX) + background.Bounds().Dx(), int(meleeY) + descriptionFont.Height()),
-        Tooltip: func (element *uilib.UIElement) (string, *font.Font) {
-            return strconv.Itoa(unit.GetMeleeAttackPower()), smallFont
-        },
-        Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
-            options := defaultOptions
-            options.ColorScale.ScaleAlpha((*getAlpha)())
-            RenderMeleeStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, options, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), width)
-        },
-    })
-
-    y += float64(descriptionFont.Height())
-
-    defenseX, defenseY := x, y
-
-    elements = append(elements, &uilib.UIElement{
-        Order: 1,
-        Layer: 1,
-        Rect: image.Rect(int(defenseX), int(defenseY), int(defenseX) + background.Bounds().Dx(), int(defenseY) + descriptionFont.Height()),
-        Tooltip: func (element *uilib.UIElement) (string, *font.Font) {
-            return strconv.Itoa(unit.GetDefense()), smallFont
-        },
-        Draw: func(element *uilib.UIElement, screen *ebiten.Image) {
-            options := defaultOptions
-            options.ColorScale.ScaleAlpha((*getAlpha)())
-            RenderArmorStats(screen, imageCache, unit, maxIconsPerLine, descriptionFont, smallFont, options, float64(element.Rect.Min.X), float64(element.Rect.Min.Y), width)
-        },
-    })
-    */
 
     return elements
 }

--- a/test/hire-hero/main.go
+++ b/test/hire-hero/main.go
@@ -28,13 +28,7 @@ func NewEngine(scenario int) (*Engine, error) {
 
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-
-        ui.IterateElementsByLayer(func (element *uilib.UIElement){
-            if element.Draw != nil {
-                element.Draw(element, screen)
-            }
-        })
-
+            ui.StandardDraw(screen)
         },
     }
     ui.SetElementsFromArray(nil)

--- a/test/hire-mercenaries/main.go
+++ b/test/hire-mercenaries/main.go
@@ -27,13 +27,7 @@ func NewEngine(scenario int) (*Engine, error) {
 
     ui := &uilib.UI{
         Draw: func(ui *uilib.UI, screen *ebiten.Image){
-
-        ui.IterateElementsByLayer(func (element *uilib.UIElement){
-            if element.Draw != nil {
-                element.Draw(element, screen)
-            }
-        })
-
+            ui.StandardDraw(screen)
         },
     }
     ui.SetElementsFromArray(nil)


### PR DESCRIPTION
Show a tooltip for some ui elements, so far just the unit stats.

![image](https://github.com/user-attachments/assets/7bc1f350-50dc-4c69-85d7-fa8187076e58)

since counting the icons is annoying