### PR TITLE
combat: move towards tile

### DIFF
--- a/game/magic/combat/ai.go
+++ b/game/magic/combat/ai.go
@@ -260,7 +260,7 @@ func doAIMovementPathfinding(model *CombatModel, aiActions AIUnitActionsInterfac
             lastIndex := 0
             for lastIndex < len(path) {
                 lastIndex += 1
-                if !aiUnit.CanFollowPath(path[0:lastIndex]) {
+                if !aiUnit.CanFollowPath(path[0:lastIndex], false) {
                     lastIndex -= 1
                     break
                 }
@@ -279,7 +279,7 @@ func doAIMovementPathfinding(model *CombatModel, aiActions AIUnitActionsInterfac
         gateX, gateY := model.GetCityGateCoordinates()
         if gateX != -1 && gateY != -1 {
             path, ok := model.computePath(aiUnit.X, aiUnit.Y, gateX, gateY, aiUnit.CanTraverseWall(), aiUnit.IsFlying())
-            if ok && len(path) > 1 && aiUnit.CanFollowPath(path) {
+            if ok && len(path) > 1 && aiUnit.CanFollowPath(path, false) {
                 aiActions.MoveUnit(aiUnit, path[1:])
                 return true
             }

--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -4327,7 +4327,16 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image) {
             if ok {
                 var options ebiten.DrawImageOptions
                 options.ColorScale.ScaleAlpha(0.8)
-                for i := 0; i < len(path); i++ {
+
+                moves := combat.Model.SelectedUnit.MovesLeft
+
+                lastX := combat.Model.SelectedUnit.X
+                lastY := combat.Model.SelectedUnit.Y
+
+                movementImage, _ := combat.ImageCache.GetImage("compix.lbx", 72, 0)
+                showBad := false
+
+                for i := range path {
                     tileX, tileY := path[i].X, path[i].Y
 
                     tx, ty := tilePosition(float64(tileX), float64(tileY))
@@ -4335,14 +4344,21 @@ func (combat *CombatScreen) NormalDraw(screen *ebiten.Image) {
                     // ty += float64(tile0.Bounds().Dy())/2
 
                     // show boots
-                    movementImage, _ := combat.ImageCache.GetImage("compix.lbx", 72, 0)
                     tx -= float64(movementImage.Bounds().Dx())/2
                     ty -= float64(movementImage.Bounds().Dy())/2
 
                     options.GeoM.Reset()
                     options.GeoM.Scale(combat.CameraScale, combat.CameraScale)
                     options.GeoM.Translate(tx, ty)
+
+                    if !showBad && moves.LessThanEqual(fraction.FromInt(0)) {
+                        showBad = true
+                        options.ColorScale.Scale(0.1, 0.1, 0.1, 1)
+                    }
+
                     scale.DrawScaled(screen, movementImage, &options)
+
+                    moves = moves.Subtract(pathCost(image.Pt(lastX, lastY), image.Pt(tileX, tileY)))
                 }
             }
         }


### PR DESCRIPTION
Hold down CONTROL while selecting a tile to move towards in order to allow the unit to walk along a path to the tile even if the unit cannot move along the entire path in a single turn.