### PR TITLE
combat: fix multi-unit attack rolls

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -633,7 +633,7 @@ func (combat *CombatScreen) CreateIceBoltProjectile(target *ArmyUnit, strength i
     explodeImages := images[3:]
 
     damage := func(unit *ArmyUnit) {
-        hurt, lost := ApplyDamage(unit, unit.ReduceInvulnerability(ComputeRoll(strength, 30)), units.DamageCold, DamageSourceSpell, DamageModifiers{Magic: data.NatureMagic})
+        hurt, lost := ApplyDamage(unit, []int{ComputeRoll(strength, 30)}, units.DamageCold, DamageSourceSpell, DamageModifiers{Magic: data.NatureMagic})
         combat.MakeGibs(unit, lost)
         combat.AddDamageIndicator(unit, hurt)
         if unit.GetHealth() <= 0 {
@@ -650,7 +650,7 @@ func (combat *CombatScreen) CreateFireBoltProjectile(target *ArmyUnit, strength 
     explodeImages := images[3:]
 
     damage := func(unit *ArmyUnit) {
-        fireDamage, lost := ApplyDamage(unit, unit.ReduceInvulnerability(ComputeRoll(strength, 30)), units.DamageFire, DamageSourceSpell, DamageModifiers{Magic: data.ChaosMagic})
+        fireDamage, lost := ApplyDamage(unit, []int{ComputeRoll(strength, 30)}, units.DamageFire, DamageSourceSpell, DamageModifiers{Magic: data.ChaosMagic})
         combat.AddDamageIndicator(unit, fireDamage)
         combat.MakeGibs(unit, lost)
 
@@ -686,7 +686,7 @@ func (combat *CombatScreen) CreateStarFiresProjectile(target *ArmyUnit) *Project
     explodeImages := images
 
     damage := func (unit *ArmyUnit) {
-        hurt, lost := ApplyDamage(unit, unit.ReduceInvulnerability(15), units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{})
+        hurt, lost := ApplyDamage(unit, []int{15}, units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{})
         combat.AddDamageIndicator(unit, hurt)
         combat.MakeGibs(unit, lost)
         if unit.GetHealth() <= 0 {
@@ -734,7 +734,7 @@ func (combat *CombatScreen) CreatePsionicBlastProjectile(target *ArmyUnit, stren
     explodeImages := images
 
     damage := func (unit *ArmyUnit) {
-        hurt, lost := ApplyDamage(unit, unit.ReduceInvulnerability(ComputeRoll(15, 30)), units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{Magic: data.SorceryMagic})
+        hurt, lost := ApplyDamage(unit, []int{ComputeRoll(15, 30)}, units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{Magic: data.SorceryMagic})
         combat.AddDamageIndicator(unit, hurt)
         combat.MakeGibs(unit, lost)
         if unit.GetHealth() <= 0 {
@@ -784,7 +784,7 @@ func (combat *CombatScreen) CreateLightningBoltProjectile(target *ArmyUnit, stre
         Explode: util.MakeRepeatAnimation(explodeImages, 2),
         Exploding: true,
         Effect: func(unit *ArmyUnit) {
-            hurt, lost := ApplyDamage(unit, unit.ReduceInvulnerability(ComputeRoll(strength, 30)), units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{ArmorPiercing: true, Magic: data.ChaosMagic})
+            hurt, lost := ApplyDamage(unit, []int{ComputeRoll(strength, 30)}, units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{ArmorPiercing: true, Magic: data.ChaosMagic})
             combat.AddDamageIndicator(unit, hurt)
             combat.MakeGibs(unit, lost)
             if unit.GetHealth() <= 0 {
@@ -825,7 +825,7 @@ func (combat *CombatScreen) CreateWarpLightningProjectile(target *ArmyUnit) *Pro
             damage := 0
             // 10 separate attacks are different than a single 55-point attack due to defense
             for strength := range 10 {
-                hurt, more := ApplyDamage(unit, unit.ReduceInvulnerability(ComputeRoll(strength + 1, 30)), units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{ArmorPiercing: true, Magic: data.ChaosMagic})
+                hurt, more := ApplyDamage(unit, []int{ComputeRoll(strength + 1, 30)}, units.DamageRangedMagical, DamageSourceSpell, DamageModifiers{ArmorPiercing: true, Magic: data.ChaosMagic})
                 lost += more
                 damage += hurt
             }
@@ -2582,7 +2582,7 @@ func (combat *CombatScreen) createRangeAttack(attacker *ArmyUnit, defender *Army
         damage := attacker.ComputeRangeDamage(target, tileDistance)
 
         // FIXME: for magical damage, set the Magic damage modifier for the proper realm
-        appliedDamage, lost := ApplyDamage(target, damage, attacker.GetRangedAttackDamageType(), attacker.GetDamageSource(), DamageModifiers{WallDefense: combat.Model.ComputeWallDefense(attacker, defender)})
+        appliedDamage, lost := ApplyDamage(target, []int{damage}, attacker.GetRangedAttackDamageType(), attacker.GetDamageSource(), DamageModifiers{WallDefense: combat.Model.ComputeWallDefense(attacker, defender)})
         combat.MakeGibs(target, lost)
 
         totalDamage := appliedDamage

--- a/game/magic/combat/combat_test.go
+++ b/game/magic/combat/combat_test.go
@@ -96,7 +96,7 @@ func TestUnitHealth(test *testing.T) {
 }
 
 type TestObserver struct {
-    Melee func(attacker *ArmyUnit, defender *ArmyUnit, damageRoll int)
+    Melee func(attacker *ArmyUnit, defender *ArmyUnit, damageRoll []int)
     Throw func(attacker *ArmyUnit, defender *ArmyUnit, defenderDamage int)
     PoisonTouch func(attacker *ArmyUnit, defender *ArmyUnit, damage int)
     Fear func(attacker *ArmyUnit, defender *ArmyUnit, fear int)
@@ -147,7 +147,7 @@ func (observer *TestObserver) LightningBreathAttack(attacker *ArmyUnit, defender
 func (observer *TestObserver) ImmolationAttack(attacker *ArmyUnit, defender *ArmyUnit, damage int){
 }
 
-func (observer *TestObserver) MeleeAttack(attacker *ArmyUnit, defender *ArmyUnit, damageRoll int){
+func (observer *TestObserver) MeleeAttack(attacker *ArmyUnit, defender *ArmyUnit, damageRoll []int){
     if observer.Melee != nil {
         observer.Melee(attacker, defender, damageRoll)
     }
@@ -194,7 +194,7 @@ func TestBasicMelee(test *testing.T){
     defenderMelee := false
 
     observer := &TestObserver{
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee = true
             } else if defendingArmy.units[0] == meleeAttacker {
@@ -243,7 +243,7 @@ func TestAttackerHaste(test *testing.T){
     defenderMelee := 0
 
     observer := &TestObserver{
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
             } else if defendingArmy.units[0] == meleeAttacker {
@@ -300,7 +300,7 @@ func TestFirstStrike(test *testing.T){
     defenderMelee := 0
 
     observer := &TestObserver{
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
             } else if defendingArmy.units[0] == meleeAttacker {
@@ -360,7 +360,7 @@ func TestFirstStrikeNegate(test *testing.T){
     defenderMelee := 0
 
     observer := &TestObserver{
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
             } else if defendingArmy.units[0] == meleeAttacker {
@@ -423,7 +423,7 @@ func TestThrowAttack(test *testing.T){
                 attackerThrow += 1
             }
         },
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
             } else if defendingArmy.units[0] == meleeAttacker {
@@ -500,7 +500,7 @@ func TestThrownTouchAttack(test *testing.T){
                 attackerPoison += 1
             }
         },
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
             } else if defendingArmy.units[0] == meleeAttacker {
@@ -566,7 +566,7 @@ func TestFear(test *testing.T){
     defenderMelee := 0
 
     observer := &TestObserver{
-        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll int){
+        Melee: func(meleeAttacker *ArmyUnit, meleeDefender *ArmyUnit, damageRoll []int){
             if attackingArmy.units[0] == meleeAttacker {
                 attackerMelee += 1
             } else if defendingArmy.units[0] == meleeAttacker {

--- a/game/magic/combat/model.go
+++ b/game/magic/combat/model.go
@@ -1774,10 +1774,6 @@ func ApplyDamage(unit UnitDamage, damageRolls []int, damageType units.Damage, so
     taken := 0
     lost := 0
     for _, damage := range damageRolls {
-        if unit.GetHealth() <= 0 {
-            break
-        }
-
         damage = unit.ReduceInvulnerability(damage)
 
         for damage > 0 && unit.GetHealth() > 0 {

--- a/game/magic/combat/observer.go
+++ b/game/magic/combat/observer.go
@@ -18,7 +18,7 @@ type CombatObserver interface {
     FireBreathAttack(attacker *ArmyUnit, defender *ArmyUnit, damage int)
     LightningBreathAttack(attacker *ArmyUnit, defender *ArmyUnit, damage int)
     ImmolationAttack(attacker *ArmyUnit, defender *ArmyUnit, damage int)
-    MeleeAttack(attacker *ArmyUnit, defender *ArmyUnit, damageRoll int)
+    MeleeAttack(attacker *ArmyUnit, defender *ArmyUnit, damageRoll []int)
     CauseFear(attacker *ArmyUnit, defender *ArmyUnit, fear int)
     WallOfFire(defender *ArmyUnit, damage int)
     UnitKilled(unit *ArmyUnit)
@@ -56,7 +56,7 @@ func (observer *CombatObservers) ThrowAttack(attacker *ArmyUnit, defender *ArmyU
     }
 }
 
-func (observer *CombatObservers) MeleeAttack(attacker *ArmyUnit, defender *ArmyUnit, damageRoll int) {
+func (observer *CombatObservers) MeleeAttack(attacker *ArmyUnit, defender *ArmyUnit, damageRoll []int) {
     for _, notify := range observer.Observers {
         notify.MeleeAttack(attacker, defender, damageRoll)
     }

--- a/game/magic/game/damage_test.go
+++ b/game/magic/game/damage_test.go
@@ -43,7 +43,7 @@ func TestDamageNormal(test *testing.T) {
 
     strength := 4
 
-    damage, _ := combat.ApplyDamage(&wrapper, strength, units.DamageRangedMagical, combat.DamageSourceSpell, combat.DamageModifiers{Magic: data.ChaosMagic})
+    damage, _ := combat.ApplyDamage(&wrapper, []int{strength}, units.DamageRangedMagical, combat.DamageSourceSpell, combat.DamageModifiers{Magic: data.ChaosMagic})
     if damage != strength {
         test.Errorf("expected %v damage, got %d", strength, damage)
     }
@@ -78,7 +78,7 @@ func TestDamageHero(test *testing.T) {
 
     strength := 4
 
-    damage, _ := combat.ApplyDamage(&wrapper, strength, units.DamageRangedMagical, combat.DamageSourceSpell, combat.DamageModifiers{Magic: data.ChaosMagic})
+    damage, _ := combat.ApplyDamage(&wrapper, []int{strength}, units.DamageRangedMagical, combat.DamageSourceSpell, combat.DamageModifiers{Magic: data.ChaosMagic})
     if damage != strength {
         test.Errorf("expected %v damage, got %d", strength, damage)
     }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -8447,7 +8447,7 @@ func (game *Game) doChaosRift() {
 
                     wrapper := &UnitDamageWrapper{StackUnit: choice}
 
-                    combat.ApplyDamage(wrapper, wrapper.ReduceInvulnerability(combat.ComputeRoll(8, 30)), units.DamageRangedMagical, combat.DamageSourceSpell, combat.DamageModifiers{ArmorPiercing: true, Magic: data.ChaosMagic})
+                    combat.ApplyDamage(wrapper, []int{combat.ComputeRoll(8, 30)}, units.DamageRangedMagical, combat.DamageSourceSpell, combat.DamageModifiers{ArmorPiercing: true, Magic: data.ChaosMagic})
                 }
 
                 // check for dead units


### PR DESCRIPTION
Each figure in an attacking unit does a separate attack roll that can individually be blocked.