### PR TITLE
Fix issues about SetRoad

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5457,6 +5457,26 @@ func (game *Game) CreateOutpost(settlers units.StackUnit, player *playerlib.Play
     newCity.ProducingBuilding = buildinglib.BuildingHousing
     newCity.ProducingUnit = units.UnitNone
 
+    //City default has road
+    x, y := settlers.GetX(), settlers.GetY()
+    plane := settlers.GetPlane()
+    m := game.GetMap(plane)
+    pt := image.Pt(x, y)
+
+    // Check if road exits
+    hasRoad := false
+    if extras, ok := m.ExtraMap[pt]; ok {
+        if _, roadExists := extras[maplib.ExtraKindRoad]; roadExists {
+            hasRoad = true
+        }
+    }
+
+    // if no, build road
+    if !hasRoad {
+        isEnchanted := (plane == data.PlaneMyrror)
+        m.SetRoad(x, y, isEnchanted)
+    }
+
     player.RemoveUnit(settlers)
     player.SelectedStack = nil
     game.RefreshUI()
@@ -6656,6 +6676,11 @@ func (game *Game) MaybeBuildRoads(stack *playerlib.UnitStack, player *playerlib.
                 i += 1
 
                 // log.Printf("Unit stack %v is building road along path %v. Current %v, %v hasRoad=%v", stack, roadPath, stack.X(), stack.Y(), hasRoad)
+            }
+
+            //Prevent boundry case, else system hang if build road across city
+            if i >= len(roadPath) {
+                  i = len(roadPath) - 1
             }
 
             stack.CurrentPath = roadPath[:i+1]

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -1285,6 +1285,13 @@ func getExtra[T any](extras map[ExtraKind]ExtraTile, kind ExtraKind) T {
 }
 
 func (mapObject *Map) SetRoad(x int, y int, enchanted bool) {
+	if mapObject.ExtraMap == nil {
+        mapObject.ExtraMap = make(map[image.Point]map[ExtraKind]ExtraTile)
+    }
+    pt := image.Pt(x, y)
+    if mapObject.ExtraMap[pt] == nil {
+        mapObject.ExtraMap[pt] = make(map[ExtraKind]ExtraTile)
+    }
     mapObject.ExtraMap[image.Pt(x, y)][ExtraKindRoad] = &ExtraRoad{Map: mapObject, X: x, Y: y, Enchanted: enchanted}
 }
 


### PR DESCRIPTION
1. Fix crash when SetRoad: Initial map first
2. SetRoad when create outpost: Cities should have roads by default.
3. Fix crash in MaybeBuildRoads: Fix crash if try to build road in a city