### PR TITLE
Resource fonts shadows

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6471,9 +6471,9 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     negative.ColorScale = negativeScale
 
                     negativeOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &negative, Scale: scale.ScaleAmount,
-						DropShadow: true, ShadowColor: color.RGBA{128, 0, 0, 255}, ShadowDistance: 0.6}
+						DropShadow: true, ShadowColor: color.RGBA{128, 0, 0, 255}, ShadowDistance: 0.55}
                     normalOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount, 
-						DropShadow: true, ShadowColor: color.RGBA{96, 32, 0, 255}, ShadowDistance: 0.6}
+						DropShadow: true, ShadowColor: color.RGBA{80, 30, 0, 255}, ShadowDistance: 0.55}
 
                     if goldPerTurn < 0 {
                         game.Fonts.InfoFontRed.PrintOptions(screen, 278, 103, negativeOptions, fmt.Sprintf("%v Gold", goldPerTurn))

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -6470,8 +6470,10 @@ func (game *Game) MakeHudUI() *uilib.UI {
                     negative := options
                     negative.ColorScale = negativeScale
 
-                    negativeOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &negative, Scale: scale.ScaleAmount}
-                    normalOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount}
+                    negativeOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &negative, Scale: scale.ScaleAmount,
+						DropShadow: true, ShadowColor: color.RGBA{128, 0, 0, 255}, ShadowDistance: 0.6}
+                    normalOptions := font.FontOptions{Justify: font.FontJustifyCenter, Options: &options, Scale: scale.ScaleAmount, 
+						DropShadow: true, ShadowColor: color.RGBA{96, 32, 0, 255}, ShadowDistance: 0.6}
 
                     if goldPerTurn < 0 {
                         game.Fonts.InfoFontRed.PrintOptions(screen, 278, 103, negativeOptions, fmt.Sprintf("%v Gold", goldPerTurn))

--- a/lib/font/font.go
+++ b/lib/font/font.go
@@ -27,6 +27,8 @@ type FontOptions struct {
     DropShadow bool
     // if DropShadow is true, this is the color of the shadow, which defaults to black
     ShadowColor color.Color
+    // if DropShadow is true, this is the offset of the shadow, which defaults to 0.75
+	ShadowDistance float64
     // if nil then the default options are used (no scaling, no color scaling)
     Options *ebiten.DrawImageOptions
     Scale float64
@@ -186,15 +188,12 @@ func (font *Font) PrintOutline(destination *ebiten.Image, edgeShader *ebiten.Sha
     }
 }
 
-func (font *Font) doPrint(destination *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, dropShadow bool, shadowColor color.Color, text string) {
+func (font *Font) doPrint(destination *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, dropShadow bool, shadowColor color.Color, shadowDistance float64, text string) {
     useX := x
 
     if shadowColor == nil {
         shadowColor = color.Black
     }
-
-    // TODO: this shadow distance could be a parameter
-    distance := 3.0/4
 
     for _, c := range text {
         if c == '\n' {
@@ -217,13 +216,13 @@ func (font *Font) doPrint(destination *ebiten.Image, x float64, y float64, scale
 
         options.GeoM.Translate(useX, y)
         if dropShadow {
-            options.GeoM.Translate(scale*distance, scale*distance)
+            options.GeoM.Translate(scale*shadowDistance, scale*shadowDistance)
             options.ColorScale = colorScale
             options.ColorScale.ScaleWithColor(shadowColor)
             destination.DrawImage(glyphImage, &options)
 
             // then draw the normal glyph on top
-            options.GeoM.Translate(-scale*distance, -scale*distance)
+            options.GeoM.Translate(-scale*shadowDistance, -scale*shadowDistance)
         }
 
         options.ColorScale = colorScale
@@ -234,7 +233,7 @@ func (font *Font) doPrint(destination *ebiten.Image, x float64, y float64, scale
 }
 
 func (font *Font) PrintDropShadow(destination *ebiten.Image, x float64, y float64, scale float64, colorScale ebiten.ColorScale, text string) {
-    font.doPrint(destination, x, y, scale, colorScale, true, color.Black, text)
+    font.doPrint(destination, x, y, scale, colorScale, true, color.Black, 0.75, text)
 }
 
 // print the text with no border/outline
@@ -338,9 +337,13 @@ func (font *Font) PrintOptions(image *ebiten.Image, x float64, y float64, option
     }
 
     if options.DropShadow {
-        font.doPrint(image, useX, useY, scale, useOptions.ColorScale, true, options.ShadowColor, text)
+		var shadowDistance float64 = options.ShadowDistance
+		if shadowDistance == 0.0 {
+			shadowDistance = 0.75
+		}
+        font.doPrint(image, useX, useY, scale, useOptions.ColorScale, true, options.ShadowColor, shadowDistance, text)
     } else {
-        font.doPrint(image, useX, useY, scale, useOptions.ColorScale, false, options.ShadowColor, text)
+        font.doPrint(image, useX, useY, scale, useOptions.ColorScale, false, options.ShadowColor, options.ShadowDistance, text)
     }
 }
 


### PR DESCRIPTION
Added shadows to resources income UI on overland screen. I'm not sure why, but it's still not looking that beautiful.
To do this, made shadow distance configurable (there was a TODO for that).