### PR TITLE
Add 'End Of Turn Wait' setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,23 @@
 # macOS system files
 .DS_Store
 
+# Personal Claude Code settings (not team-shared)
+.claude/settings.local.json
+
 # Visual Studio Code editor settings
 .vscode/
 
 # Data files
 data/data/*.zip
 data/data/*.LBX
+/data/mom/
 
 # Executables
 /lbxdump
 /lbxviewer
 /magic
 /mapeditor
+*.wasm
 
 # Memory and CPU profiles
 profile.cpu.*

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -1662,7 +1662,8 @@ type SettingsUI struct {
 }
 
 func (settings *SettingsUI) RunSettingsUI() {
-    group, quit := settingslib.MakeSettingsUI(settings.Game.Cache, &settings.Game.ImageCache, settings.Game.Music)
+    game := settings.Game
+    group, quit := settingslib.MakeSettingsUI(game.Cache, &game.ImageCache, game.Music, game.Music.GetEndOfTurnWait, game.Music.SetEndOfTurnWait)
     settings.Game.doRunUI(settings.Yield, group, quit)
 }
 
@@ -3852,6 +3853,15 @@ func (game *Game) Update(yield coroutine.YieldFunc) GameState {
                 if player.IsHuman() {
                     if game.HudUI.GetHighestLayerValue() == 0 {
                         game.doPlayerUpdate(yield, player)
+
+                        // if the player has disabled 'end of turn wait', automatically end the turn
+                        // once there is nothing left to do: no stack selected and no stack with moves left
+                        if !game.Music.GetEndOfTurnWait() && player.SelectedStack == nil && player.AllStacksOutOfMoves() {
+                            select {
+                                case game.Events <- &GameEventNextTurn{}:
+                                default:
+                            }
+                        }
                     }
                 } else {
                     game.doAiUpdate(yield, player)

--- a/game/magic/mainview/view.go
+++ b/game/magic/mainview/view.go
@@ -329,7 +329,7 @@ type SettingsUI struct {
 }
 
 func (settings *SettingsUI) RunSettingsUI() {
-    group, done := settingslib.MakeSettingsUI(settings.main.Cache, &settings.main.ImageCache, settings.main.Music)
+    group, done := settingslib.MakeSettingsUI(settings.main.Cache, &settings.main.ImageCache, settings.main.Music, settings.main.Music.GetEndOfTurnWait, settings.main.Music.SetEndOfTurnWait)
 
     settings.ui.AddGroup(group)
     defer settings.ui.RemoveGroup(group)

--- a/game/magic/music/music.go
+++ b/game/magic/music/music.go
@@ -187,6 +187,11 @@ type Music struct {
 
     // queue of songs being played. a new song can be pushed on top, or popped off
     songQueue []Songs
+
+    // Music is the one object shared between the main menu and an in-progress game,
+    // so it doubles as the holder for cross-screen user preferences like this one
+    // (mirrors the original game's 'End Of Turn Wait' option).
+    endOfTurnWait bool
 }
 
 func MakeMusic(cache *lbx.LbxCache) *Music {
@@ -198,6 +203,7 @@ func MakeMusic(cache *lbx.LbxCache) *Music {
         XmiCache: make(map[Song]*smf.SMF),
         Enabled: true,
         volume: 1.0,
+        endOfTurnWait: true,
     }
 }
 
@@ -207,6 +213,14 @@ func randomChoose[T any](choices... T) T {
 
 func (music *Music) GetVolume() float64 {
     return music.volume
+}
+
+func (music *Music) GetEndOfTurnWait() bool {
+    return music.endOfTurnWait
+}
+
+func (music *Music) SetEndOfTurnWait(value bool) {
+    music.endOfTurnWait = value
 }
 
 func (music *Music) SetVolume(volume float64) {

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -1211,6 +1211,17 @@ func (player *Player) OwnsStack(stack *UnitStack) bool {
     })
 }
 
+// true if none of the player's stacks have any moves left, meaning there is nothing left for the player to do this turn
+func (player *Player) AllStacksOutOfMoves() bool {
+    for _, stack := range player.Stacks {
+        if !stack.OutOfMoves() {
+            return false
+        }
+    }
+
+    return true
+}
+
 func (player *Player) OwnsCity(city *citylib.City) bool {
     for _, ownedCity := range player.Cities {
         if ownedCity == city {

--- a/game/magic/settings/settings.go
+++ b/game/magic/settings/settings.go
@@ -103,7 +103,7 @@ func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *mus
         },
     })
 
-    checkboxRect := image.Rect(30, 84, 30 + 12, 84 + 12)
+    checkboxRect := image.Rect(29, 84, 29 + 12, 84 + 12)
 
     group.AddElement(&uilib.UIElement{
         Layer: settingsLayer,
@@ -129,7 +129,8 @@ func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *mus
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            fonts.OptionFont.PrintOptions(screen, float64(checkboxRect.Max.X + 6), float64(checkboxRect.Min.Y - 2), font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, "End Of Turn Wait")
+            textY := checkboxRect.Min.Y + (checkboxRect.Dy() - fonts.OptionFont.Height()) / 2
+            fonts.OptionFont.PrintOptions(screen, float64(checkboxRect.Max.X + 6), float64(textY), font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, "End Of Turn Wait")
         },
     })
 

--- a/game/magic/settings/settings.go
+++ b/game/magic/settings/settings.go
@@ -18,7 +18,7 @@ import (
     "github.com/hajimehoshi/ebiten/v2/vector"
 )
 
-func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *musiclib.Music) (*uilib.UIElementGroup, context.Context) {
+func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *musiclib.Music, getEndOfTurnWait func() bool, setEndOfTurnWait func(bool)) (*uilib.UIElementGroup, context.Context) {
     fonts := fontslib.MakeSettingsFonts(cache)
 
     group := uilib.MakeGroup()
@@ -100,6 +100,36 @@ func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *mus
             scale.DrawScaled(screen, slider, &options)
 
             // util.DrawRect(screen, scale.ScaleRect(element.Rect), color.RGBA{R: 255, A: 255})
+        },
+    })
+
+    checkboxRect := image.Rect(30, 84, 30 + 12, 84 + 12)
+
+    group.AddElement(&uilib.UIElement{
+        Layer: settingsLayer,
+        Rect: checkboxRect,
+        LeftClick: func(element *uilib.UIElement){
+            setEndOfTurnWait(!getEndOfTurnWait())
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            rect := element.Rect
+
+            vector.FillRect(screen, float32(scale.Scale(rect.Min.X)), float32(scale.Scale(rect.Min.Y)), float32(scale.Scale(rect.Dx())), float32(scale.Scale(rect.Dy())), color.NRGBA{R: 32, G: 32, B: 32, A: uint8(200 * getAlpha())}, false)
+            util.DrawRect(screen, scale.ScaleRect(rect), color.NRGBA{R: 255, G: 255, B: 255, A: uint8(200 * getAlpha())})
+
+            if getEndOfTurnWait() {
+                inner := image.Rect(rect.Min.X + 3, rect.Min.Y + 3, rect.Max.X - 3, rect.Max.Y - 3)
+                vector.FillRect(screen, float32(scale.Scale(inner.Min.X)), float32(scale.Scale(inner.Min.Y)), float32(scale.Scale(inner.Dx())), float32(scale.Scale(inner.Dy())), color.NRGBA{R: 255, G: 255, B: 255, A: uint8(220 * getAlpha())}, false)
+            }
+        },
+    })
+
+    group.AddElement(&uilib.UIElement{
+        Layer: settingsLayer,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(getAlpha())
+            fonts.OptionFont.PrintOptions(screen, float64(checkboxRect.Max.X + 6), float64(checkboxRect.Min.Y - 2), font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, "End Of Turn Wait")
         },
     })
 

--- a/game/magic/settings/settings.go
+++ b/game/magic/settings/settings.go
@@ -129,7 +129,9 @@ func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *mus
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            textY := checkboxRect.Min.Y + (checkboxRect.Dy() - fonts.OptionFont.Height()) / 2
+            // +2: this string has no descenders, but the font's glyph cell reserves space for
+            // them, so centering on the full cell height alone reads as visually too high
+            textY := checkboxRect.Min.Y + (checkboxRect.Dy() - fonts.OptionFont.Height()) / 2 + 2
             fonts.OptionFont.PrintOptions(screen, float64(checkboxRect.Max.X + 6), float64(textY), font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, "End Of Turn Wait")
         },
     })


### PR DESCRIPTION
## Summary
- Adds the original game's "End Of Turn Wait" toggle to the settings screen (title screen and in-game).
- When disabled, the human player's turn automatically ends once every stack is out of moves and nothing is selected — no need to click Next Turn manually.
- Defaults to enabled (current wait-for-click behavior), so this is non-breaking.

## Implementation notes
- `Player.AllStacksOutOfMoves()` (player/player.go) — new helper, reuses the existing `UnitStack.OutOfMoves()` per-stack check (which already correctly excludes patrolling/busy units).
- The setting itself lives on `Music` rather than `Game`, since `Music` is the one object already shared between the main menu and an in-progress game — same reasoning as why volume lives there. Mirrors the existing `GetVolume`/`SetVolume` pattern with `GetEndOfTurnWait`/`SetEndOfTurnWait`.
- The auto-advance check is added inside `Game.Update()`, gated behind the same "no UI modal open" condition that already gates player input, so it can't fire while a dialog (e.g. the disband-confirmation prompt) is open.
- Settings UI checkbox is hand-drawn (vector.FillRect/DrawRect) since there was no existing checkbox component in `uilib` to reuse.

## Test plan
- [x] `go build` (native) and `go vet` clean
- [x] `go test ./...` passes
- [x] Native build: verified the checkbox renders checked by default, toggles on click, and unchecking it causes turns to auto-advance once all stacks are out of moves
- [x] WASM build: verified the settings screen (including the new checkbox) renders correctly in-browser