### PR TITLE
Speed up selected stack blink rate

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -7843,7 +7843,7 @@ func (overworld *Overworld) DrawOverworld(screen *ebiten.Image, geom ebiten.GeoM
         location := image.Point{stack.X(), stack.Y()}
         _, hasCity := cityPositions[location]
 
-        if stack == overworld.SelectedStack && (overworld.ShowAnimation || overworld.Counter / 55 % 2 == 0) {
+        if stack == overworld.SelectedStack && (overworld.ShowAnimation || overworld.Counter / 15 % 2 == 0) {
             doDraw = true
         } else if stack == overworld.MovingStack {
             doDraw = true


### PR DESCRIPTION
## Summary
- The selected unit stack's visibility toggle (`Overworld.DrawOverworld`, game/game.go) ran on a 55-frame half-cycle (~1.8s full cycle at 60fps), making it hard to tell which stack currently has focus right after selecting it — noticeably slower than the original game.
- Speeds it up to a 15-frame half-cycle, closer to the game's other UI blink cadence (e.g. the text-input cursor blink at 30 frames in `setup/new-wizard.go`).

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Verified on the native build that the selected stack now blinks noticeably faster and is easy to spot immediately after selection