### PR TITLE
Add 'Strategic Combat Only' setting

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -620,6 +620,10 @@ func MakeGameWithModel(lbxCache *lbx.LbxCache, music_ *music.Music, makeModel fu
     // game.Model = MakeGameModel(terrainData, settings, data.PlaneArcanus, game.Events, heroNames, game.AllSpells(), createArtifactPool(lbxCache), buildingInfo)
     game.Model = makeModel(lbxCache, game.Events)
 
+    if len(game.Model.Players) > 0 {
+        game.Model.GetHumanPlayer().StrategicCombat = game.Music.GetStrategicCombatOnly()
+    }
+
     game.HudUI = game.MakeHudUI()
     game.PushDrawer(func(screen *ebiten.Image){
         game.DrawGame(screen)
@@ -1662,7 +1666,17 @@ type SettingsUI struct {
 }
 
 func (settings *SettingsUI) RunSettingsUI() {
-    group, quit := settingslib.MakeSettingsUI(settings.Game.Cache, &settings.Game.ImageCache, settings.Game.Music)
+    game := settings.Game
+    group, quit := settingslib.MakeSettingsUI(game.Cache, &game.ImageCache, game.Music,
+        game.Music.GetStrategicCombatOnly,
+        func(value bool){
+            game.Music.SetStrategicCombatOnly(value)
+            // apply immediately to the current game, not just future games
+            if len(game.Model.Players) > 0 {
+                game.Model.GetHumanPlayer().StrategicCombat = value
+            }
+        },
+    )
     settings.Game.doRunUI(settings.Yield, group, quit)
 }
 
@@ -4605,6 +4619,9 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
 
     // do graphic combat only if a human is involved
     useHuman := attacker.IsHuman() || defender.IsHuman()
+    // skip the battle screen entirely and auto-resolve if the human has enabled 'Strategic Combat Only'
+    // (the non-human side always has StrategicCombat set, so this only depends on the human's own preference)
+    useStrategicCombat := useHuman && !game.WatchMode && attacker.StrategicCombat && defender.StrategicCombat
 
     createArmy := func (player *playerlib.Player, stack *playerlib.UnitStack) *combat.Army {
         army := combat.Army{
@@ -4639,8 +4656,6 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
     var recalledAttackers []units.StackUnit
     var recalledDefenders []units.StackUnit
 
-    // strategicCombat := attacker.StrategicCombat && defender.StrategicCombat
-
     events := make(chan combat.CombatEvent, 1000)
 
     combatModel := combat.MakeCombatModel(game.AllSpells(), defendingArmy, attackingArmy, landscape, defenderStack.Plane(), zone, game.GetInfluenceMagic(attackerStack.X(), attackerStack.Y(), attackerStack.Plane()), attackerStack.X(), attackerStack.Y(), events)
@@ -4663,7 +4678,9 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
 
     popCombatScreen := false
 
-    if useHuman || game.WatchMode {
+    if useStrategicCombat {
+        state, defeatedAttackers, defeatedDefenders = combat.DoStrategicCombat(attackingArmy, defendingArmy)
+    } else if useHuman || game.WatchMode {
         defer mouse.Mouse.SetImage(game.MouseData.Normal)
 
         controllingPlayer := optional.Of[combat.ArmyPlayer](game.Model.GetHumanPlayer())
@@ -4695,8 +4712,10 @@ func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player
         state = combat.Run(combatModel)
     }
 
-    defeatedDefenders = combatModel.DefeatedDefenders
-    defeatedAttackers = combatModel.DefeatedAttackers
+    if !useStrategicCombat {
+        defeatedDefenders = combatModel.DefeatedDefenders
+        defeatedAttackers = combatModel.DefeatedAttackers
+    }
 
     // FIXME: resolve the attacker/defender stack at the end of combat?
     for _, unit := range combatModel.AttackingArmy.RecalledUnits {

--- a/game/magic/mainview/view.go
+++ b/game/magic/mainview/view.go
@@ -329,7 +329,7 @@ type SettingsUI struct {
 }
 
 func (settings *SettingsUI) RunSettingsUI() {
-    group, done := settingslib.MakeSettingsUI(settings.main.Cache, &settings.main.ImageCache, settings.main.Music)
+    group, done := settingslib.MakeSettingsUI(settings.main.Cache, &settings.main.ImageCache, settings.main.Music, settings.main.Music.GetStrategicCombatOnly, settings.main.Music.SetStrategicCombatOnly)
 
     settings.ui.AddGroup(group)
     defer settings.ui.RemoveGroup(group)

--- a/game/magic/music/music.go
+++ b/game/magic/music/music.go
@@ -187,6 +187,11 @@ type Music struct {
 
     // queue of songs being played. a new song can be pushed on top, or popped off
     songQueue []Songs
+
+    // Music is the one object shared between the main menu and an in-progress game,
+    // so it doubles as the holder for cross-screen user preferences like this one
+    // (mirrors the original game's 'Strategic Combat Only' option).
+    strategicCombatOnly bool
 }
 
 func MakeMusic(cache *lbx.LbxCache) *Music {
@@ -207,6 +212,14 @@ func randomChoose[T any](choices... T) T {
 
 func (music *Music) GetVolume() float64 {
     return music.volume
+}
+
+func (music *Music) GetStrategicCombatOnly() bool {
+    return music.strategicCombatOnly
+}
+
+func (music *Music) SetStrategicCombatOnly(value bool) {
+    music.strategicCombatOnly = value
 }
 
 func (music *Music) SetVolume(volume float64) {

--- a/game/magic/settings/settings.go
+++ b/game/magic/settings/settings.go
@@ -18,7 +18,7 @@ import (
     "github.com/hajimehoshi/ebiten/v2/vector"
 )
 
-func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *musiclib.Music) (*uilib.UIElementGroup, context.Context) {
+func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *musiclib.Music, getStrategicCombatOnly func() bool, setStrategicCombatOnly func(bool)) (*uilib.UIElementGroup, context.Context) {
     fonts := fontslib.MakeSettingsFonts(cache)
 
     group := uilib.MakeGroup()
@@ -100,6 +100,36 @@ func MakeSettingsUI(cache *lbx.LbxCache, imageCache *util.ImageCache, music *mus
             scale.DrawScaled(screen, slider, &options)
 
             // util.DrawRect(screen, scale.ScaleRect(element.Rect), color.RGBA{R: 255, A: 255})
+        },
+    })
+
+    checkboxRect := image.Rect(30, 84, 30 + 12, 84 + 12)
+
+    group.AddElement(&uilib.UIElement{
+        Layer: settingsLayer,
+        Rect: checkboxRect,
+        LeftClick: func(element *uilib.UIElement){
+            setStrategicCombatOnly(!getStrategicCombatOnly())
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            rect := element.Rect
+
+            vector.FillRect(screen, float32(scale.Scale(rect.Min.X)), float32(scale.Scale(rect.Min.Y)), float32(scale.Scale(rect.Dx())), float32(scale.Scale(rect.Dy())), color.NRGBA{R: 32, G: 32, B: 32, A: uint8(200 * getAlpha())}, false)
+            util.DrawRect(screen, scale.ScaleRect(rect), color.NRGBA{R: 255, G: 255, B: 255, A: uint8(200 * getAlpha())})
+
+            if getStrategicCombatOnly() {
+                inner := image.Rect(rect.Min.X + 3, rect.Min.Y + 3, rect.Max.X - 3, rect.Max.Y - 3)
+                vector.FillRect(screen, float32(scale.Scale(inner.Min.X)), float32(scale.Scale(inner.Min.Y)), float32(scale.Scale(inner.Dx())), float32(scale.Scale(inner.Dy())), color.NRGBA{R: 255, G: 255, B: 255, A: uint8(220 * getAlpha())}, false)
+            }
+        },
+    })
+
+    group.AddElement(&uilib.UIElement{
+        Layer: settingsLayer,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(getAlpha())
+            fonts.OptionFont.PrintOptions(screen, float64(checkboxRect.Max.X + 6), float64(checkboxRect.Min.Y - 2), font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, "Strategic Combat Only")
         },
     })
 


### PR DESCRIPTION
## Summary
- Adds the original game's "Strategic Combat Only" toggle to the settings screen (title screen and in-game).
- When enabled, the human player's own battles are auto-resolved via the existing `combat.DoStrategicCombat` instead of playing out on the battle screen.
- Defaults to disabled (current always-show-battle-screen behavior for the human), so this is non-breaking.

## Implementation notes
- `Player.StrategicCombat` and `combat.DoStrategicCombat` already existed and were already used for AI-vs-AI encounters (always strategic) and wild-monster encounters, but were never reachable by the human player - this setting is what was missing to wire it up.
- `doCombat` (game/game.go) now checks `attacker.StrategicCombat && defender.StrategicCombat` (only meaningful when a human is involved and not in watch mode) and skips straight to `DoStrategicCombat`, taking its returned state/casualty counts directly instead of reading them from the unused `combatModel`. Existing AI-vs-AI behavior via `combat.Run` is untouched - that path is only reached when no human is involved, so it can't be affected by this human-facing preference.
- Same pattern as End Of Turn Wait (#720): the setting lives on `Music` since it's shared between the main menu and an in-progress game. Toggling it in-game also applies immediately to the current human player (not just future games), via `RunSettingsUI`'s setter.

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Verified on the native build: checkbox renders/toggles correctly, and with it enabled a real battle (spearmen vs. stronger opposition) was auto-resolved and lost as expected instead of opening the battle screen