### PR TITLE
Implement Spell of Mastery win condition

### DIFF
--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -424,9 +424,17 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
 
         /*
             INSTANT SPELLS
-                TODO:
-                Spell of Mastery
         */
+        case "Spell of Mastery":
+            // the casting-started announcement already played when the player chose to
+            // start casting this spell (see game.go). completion of casting is the win
+            // condition, so queue an event rather than run the victory screens directly -
+            // this function does not have a yield to drive them (and it can be invoked
+            // from the non-yielding per-turn casting-progress code path).
+            select {
+                case game.Events <- &GameEventSpellOfMasteryComplete{Player: player}:
+                default:
+            }
         case "Spell of Return":
             selected := func (yield coroutine.YieldFunc, tileX int, tileY int){
                 city := player.FindCity(tileX, tileY, game.Model.Plane)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -115,6 +115,10 @@ type GameEventCartographer struct {
 type GameEventNextTurn struct {
 }
 
+type GameEventSpellOfMasteryComplete struct {
+    Player *playerlib.Player
+}
+
 type GameEventCityListView struct {
 }
 
@@ -2421,6 +2425,9 @@ func (game *Game) ProcessEvents(yield coroutine.YieldFunc) {
 
                     case *GameEventNextTurn:
                         game.doNextTurn(yield)
+                    case *GameEventSpellOfMasteryComplete:
+                        masteryEvent := event.(*GameEventSpellOfMasteryComplete)
+                        game.doSpellOfMasteryVictory(yield, masteryEvent.Player)
                     case *GameEventSurveyor:
                         game.doSurveyor(yield)
                     case *GameEventCartographer:
@@ -5426,6 +5433,47 @@ func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerl
             }
         }
     }))
+}
+
+// called when a player's casting of the Spell of Mastery completes. shows the vortex
+// banishing all other wizards, then the victory screen, then returns to the main menu -
+// the spell of mastery is the game's win condition, so the game ends here for everyone,
+// whether the winner is the human player or an ai.
+func (game *Game) doSpellOfMasteryVictory(yield coroutine.YieldFunc, player *playerlib.Player) {
+    var losers []data.WizardBase
+    for _, other := range game.Model.Players {
+        if other != player && !other.Defeated {
+            losers = append(losers, other.Wizard.Base)
+        }
+    }
+
+    game.Music.PushSong(music.SongSpellOfMastery)
+    vortexLogic, vortexDraw := mastery.LabVortexScreen(game.Cache, player.Wizard.Base, losers)
+    game.PushDrawer(vortexDraw)
+    vortexLogic(yield)
+    game.PopDrawer()
+    game.Music.PopSong()
+
+    game.Music.PushSong(music.SongYouWin)
+    endLogic, endDraw := mastery.SpellOfMasteryEndScreen(game.Cache, player.Wizard.Base)
+    game.PushDrawer(endDraw)
+    endLogic(yield)
+    game.PopDrawer()
+    game.Music.PopSong()
+
+    game.State = GameStateQuit
+
+    // the same StartPlayerTurn call that finished this cast may have queued other
+    // events (e.g. a research-spell prompt) before or after this one - the game is
+    // over, so drain them rather than let ProcessEvents act on them after we return.
+    draining := true
+    for draining {
+        select {
+            case <-game.Events:
+            default:
+                draining = false
+        }
+    }
 }
 
 func (game *Game) CityGoldBonus(x int, y int, plane data.Plane) int {


### PR DESCRIPTION
## Summary

Casting Spell of Mastery to completion currently falls through to `doCastSpell`'s `default:` case ("Warning: casting unhandled spell") - there's no win condition anywhere in the codebase. This wires it up.

The `mastery` package already had everything needed for the presentation - `LabVortexScreen` (banishes the other wizards) and `SpellOfMasteryEndScreen` (the "Master of Magic" victory screen, using `win.lbx`) - but neither was ever called from anywhere. Only `ShowSpellOfMasteryScreen` (the "X has started casting" announcement, shown when casting *begins*) was wired up.

## Implementation

- `doCastSpell` (cast.go) gets a `case "Spell of Mastery"`. It can't run the victory screens directly - it has no `yield` (it's called from `StartPlayerTurn`'s non-yielding per-turn casting-progress code, among other places) - so it queues a new `GameEventSpellOfMasteryComplete` event instead.
- `ProcessEvents` (game.go) handles that event by calling the new `doSpellOfMasteryVictory(yield, player)`, which runs the vortex screen then the end screen (reusing the existing `PushDrawer`/coroutine pattern already used for the casting-announcement screen), then sets `GameStateQuit` to return to the main menu - no new `GameState` needed, this reuses the existing quit-to-menu path.
- Any other events queued during the same `StartPlayerTurn` pass (e.g. a research-spell prompt, since research and casting progress are both processed there) are drained right after, otherwise `ProcessEvents`'s drain loop keeps handling them regardless of the state change and the player ends up back in a live turn instead of at the menu. Caught via manual testing, see below.
- Applies uniformly whether the human or an AI wizard completes the cast, matching the original game (the human sees the winning wizard's own face/portrait either way).

## Test plan

- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Manual playtest via a save-game fixture (built with a temporary local dev flag, not part of this diff) with the human player one mana point from completing Spell of Mastery: advancing one turn triggers the win, both screens play, and it lands cleanly back at the main menu with no leftover UI prompts (this last part needed the event-draining fix above - without it, a queued research-spell prompt would still get shown after the win screens, and only dismissing that returned you to the menu)