### PR TITLE
Fix infinite disband-warning loop with auto next turn

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2181,6 +2181,7 @@ func (game *Game) doNextTurn(yield coroutine.YieldFunc) {
 
         no := func(){
             quit = true
+            player.SuppressAutoNextTurn = true
             game.HudUI.RemoveGroup(group)
         }
 
@@ -3867,7 +3868,7 @@ func (game *Game) Update(yield coroutine.YieldFunc) GameState {
 
                         // if the player has disabled 'end of turn wait', automatically end the turn
                         // once there is nothing left to do: no stack selected and no stack with moves left
-                        if !game.Settings.EndOfTurnWait && player.MovedStacksThisTurn > 0 && player.SelectedStack == nil && player.AllStacksOutOfMoves() {
+                        if !game.Settings.EndOfTurnWait && !player.SuppressAutoNextTurn && player.MovedStacksThisTurn > 0 && player.SelectedStack == nil && player.AllStacksOutOfMoves() {
                             select {
                                 case game.Events <- &GameEventNextTurn{}:
                                 default:
@@ -7030,6 +7031,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
     }
 
     player.MovedStacksThisTurn = 0
+    player.SuppressAutoNextTurn = false
 
     disbandedMessages := game.DisbandUnits(player)
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -353,6 +353,10 @@ type Player struct {
 
     SelectedStack *UnitStack
     MovedStacksThisTurn int
+    // set when the player declines the end-of-turn disband warning, so the
+    // 'end of turn wait' auto-advance check doesn't just re-trigger the same
+    // warning again on the very next frame. Cleared at the start of each turn.
+    SuppressAutoNextTurn bool
 
     // track how much road work has been done per tile
     RoadWorkArcanus map[image.Point]float64


### PR DESCRIPTION
## Summary
- With "end of turn wait" disabled, the auto-advance check in `Update()` (game.go) fires `GameEventNextTurn` every frame once the human player has no stack selected and no stacks with moves left.
- `doNextTurn`'s food/gold/mana disband confirmation doesn't change any of that state when the player clicks "No" - so on the very next frame the auto-check's condition was still true and it immediately re-fired `GameEventNextTurn`, reshowing the same dialog. From the player's perspective, clicking "No" appeared to do nothing.
- Found via manual playtesting after the "end of turn wait" / keybindings work in #724 landed.

## Fix
- Adds `Player.SuppressAutoNextTurn`, set `true` when the disband warning is declined.
- The auto-advance condition additionally requires `!player.SuppressAutoNextTurn`.
- Reset back to `false` in `StartPlayerTurn`, alongside the existing `MovedStacksThisTurn` reset, so it only suppresses for the remainder of the current turn.

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Verified on the native build: with End Of Turn Wait disabled, reached a turn with a food shortage, clicked "No" on the warning - now correctly returns control to the map instead of immediately reshowing the same dialog