### PR TITLE
Add 'Background Music' setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,14 @@
 # Data files
 data/data/*.zip
 data/data/*.LBX
+/data/mom/
 
 # Executables
 /lbxdump
 /lbxviewer
 /magic
 /mapeditor
+*.wasm
 
 # Memory and CPU profiles
 profile.cpu.*

--- a/game/magic/music/music.go
+++ b/game/magic/music/music.go
@@ -220,6 +220,22 @@ func (music *Music) SetVolume(volume float64) {
     }
 }
 
+func (music *Music) IsMusicEnabled() bool {
+    return music.Enabled
+}
+
+func (music *Music) SetMusicEnabled(enabled bool) {
+    music.Enabled = enabled
+
+    if !enabled {
+        music.Stop()
+    } else if len(music.songQueue) > 0 {
+        // resume whatever song context is currently active, rather than waiting
+        // for the next natural PlaySong/PushSong call somewhere else in the game
+        music.PlaySong(music.songQueue[len(music.songQueue) - 1].Choose())
+    }
+}
+
 func (music *Music) PushSongs(songs... Song) {
     music.songQueue = append(music.songQueue, Songs{Songs: songs})
     music.PlaySong(music.songQueue[len(music.songQueue)-1].Choose())

--- a/game/magic/settings/settings.go
+++ b/game/magic/settings/settings.go
@@ -54,12 +54,14 @@ func addCheckbox(group *uilib.UIElementGroup, fonts *fontslib.SettingsFonts, get
     })
 }
 
-type VolumeSettings interface {
+type MusicSettings interface {
     GetVolume() float64
     SetVolume(float64)
+    IsMusicEnabled() bool
+    SetMusicEnabled(bool)
 }
 
-func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, settings *Settings, volumeSettings VolumeSettings) (*uilib.UIElementGroup, context.Context) {
+func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, settings *Settings, musicSettings MusicSettings) (*uilib.UIElementGroup, context.Context) {
     fonts := fontslib.MakeSettingsFonts(cache)
 
     group := uilib.MakeGroup()
@@ -121,7 +123,7 @@ func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.Lb
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            fonts.OptionFont.PrintOptions(screen, 30, 40, font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, fmt.Sprintf("Volume: %02d%%", int(volumeSettings.GetVolume() * 100)))
+            fonts.OptionFont.PrintOptions(screen, 30, 40, font.FontOptions{Scale: scale.ScaleAmount, DropShadow: true, Options: &options}, fmt.Sprintf("Volume: %02d%%", int(musicSettings.GetVolume() * 100)))
         },
     })
 
@@ -133,7 +135,7 @@ func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.Lb
         Rect: image.Rect(30, 50, 30 + 80, 50 + slider.Bounds().Dy()),
         Inside: func(this *uilib.UIElement, x int, y int){
             if volumeClicked {
-                volumeSettings.SetVolume(min(1, float64(x) / float64(this.Rect.Dx() - 1)))
+                musicSettings.SetVolume(min(1, float64(x) / float64(this.Rect.Dx() - 1)))
             }
         },
         LeftClick: func(element *uilib.UIElement){
@@ -153,7 +155,7 @@ func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.Lb
 
             var options ebiten.DrawImageOptions
             options.ColorScale.ScaleAlpha(getAlpha())
-            options.GeoM.Translate(float64(element.Rect.Min.X) + float64(element.Rect.Dx()) * volumeSettings.GetVolume(), float64(element.Rect.Min.Y))
+            options.GeoM.Translate(float64(element.Rect.Min.X) + float64(element.Rect.Dx()) * musicSettings.GetVolume(), float64(element.Rect.Min.Y))
             options.GeoM.Translate(float64(-slider.Bounds().Dx()/2), 0)
             scale.DrawScaled(screen, slider, &options)
 
@@ -169,6 +171,14 @@ func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.Lb
     addCheckbox(group, fonts, &getAlpha, 30, 106, "Strategic Combat Only",
         func() bool { return settings.StrategicCombatOnly },
         func(value bool) { settings.StrategicCombatOnly = value },
+    )
+
+    // maps to the single existing music on/off flag - the original game's separate
+    // "Event Music" checkbox would need songs classified into background vs. event
+    // categories, which doesn't exist yet, so it's left as a future addition.
+    addCheckbox(group, fonts, &getAlpha, 30, 128, "Background Music",
+        musicSettings.IsMusicEnabled,
+        musicSettings.SetMusicEnabled,
     )
 
     return group, quit


### PR DESCRIPTION
## Summary
- Wires the existing `Music.Enabled` flag up to a settings screen checkbox. `PlaySong` already checks it live (`music/music.go`), it was previously only settable via the `-music` CLI flag at startup.
- Renamed the `settings` package's `VolumeSettings` interface to `MusicSettings` and added `IsMusicEnabled`/`SetMusicEnabled` to `Music`, keeping `settings.go` decoupled from the `music` package (same pattern as the existing `GetVolume`/`SetVolume`).
- Toggling off calls `Stop()` immediately. Toggling back on resumes whatever song context is on top of the existing song-queue stack, rather than staying silent until some unrelated part of the game happens to call `PlaySong` next.

## Scope note
This maps to the single existing on/off flag - i.e. all music. The original game's separate "Event Music" checkbox would need songs classified into background vs. event categories, which doesn't exist in this codebase yet, so it's left as a separate future addition rather than attempted here.

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Verified on the native build: checkbox defaults checked, unchecking stops music immediately, rechecking resumes music immediately (caught and fixed a bug during testing where re-enabling only flipped the flag without resuming playback)