### PR TITLE
hero: include equipment to-hit bonuses in melee to-hit

### DIFF
--- a/game/magic/hero/hero.go
+++ b/game/magic/hero/hero.go
@@ -679,8 +679,13 @@ func (hero *Hero) GetKnownSpells() []string {
 }
 
 func (hero *Hero) GetToHitMelee() int {
-    // FIXME: add in equipment tohit bonuses
     base := 30
+
+    for _, item := range hero.GetArtifacts() {
+        if item != nil {
+            base += item.ToHitBonus()
+        }
+    }
 
     level := hero.GetHeroExperienceLevel()
     switch level {

--- a/game/magic/hero/hero_test.go
+++ b/game/magic/hero/hero_test.go
@@ -5,6 +5,7 @@ import (
     "math"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/artifact"
 )
 
 func floatEqual(a, b float32) bool {
@@ -110,5 +111,21 @@ func TestHeroProgression(test *testing.T) {
     // zaldron starts with 7.5, at champion level, caster should be 37
     if int(zaldron.GetAbilityValue(data.AbilityCaster)) != 37 {
         test.Errorf("Expected caster level to be 37 but was %v", zaldron.GetAbilityValue(data.AbilityCaster))
+    }
+}
+
+func TestHeroToHitMeleeEquipment(test *testing.T) {
+    brax := MakeHeroSimple(HeroBrax)
+
+    base := brax.GetToHitMelee()
+
+    brax.Equipment[0] = &artifact.Artifact{
+        Powers: []artifact.Power{
+            {Type: artifact.PowerTypeToHit, Amount: 15},
+        },
+    }
+
+    if brax.GetToHitMelee() != base + 15 {
+        test.Errorf("Expected to-hit melee to include the equipped item's to-hit bonus: base=%v with-item=%v", base, brax.GetToHitMelee())
     }
 }


### PR DESCRIPTION
## Summary
- `Hero.GetToHitMelee()` had `// FIXME: add in equipment tohit bonuses` - it summed experience level, Lucky, and Holy Weapon, but never looked at equipped items.
- `Artifact.ToHitBonus()` and `Hero.GetArtifacts()` already existed as the building blocks (used elsewhere for other stats), so this just sums the bonus across all equipped items, skipping empty (nil) slots.

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Added `TestHeroToHitMeleeEquipment`: equips an item with a `PowerTypeToHit` power on a test hero and asserts `GetToHitMelee()` increases by exactly that amount