### PR TITLE
Add 'Quit Without Saving' as a rebindable action

### DIFF
--- a/game/magic/keybinds/keybinds.go
+++ b/game/magic/keybinds/keybinds.go
@@ -29,6 +29,7 @@ const (
     ActionGrandVizier
     ActionMirror
     ActionNextTurn
+    ActionQuitWithoutSaving
 )
 
 // AllActions lists every rebindable action, in the order they should be
@@ -51,6 +52,7 @@ var AllActions = []Action{
     ActionGrandVizier,
     ActionMirror,
     ActionNextTurn,
+    ActionQuitWithoutSaving,
 }
 
 func (action Action) Name() string {
@@ -72,6 +74,7 @@ func (action Action) Name() string {
         case ActionGrandVizier: return "Grand Vizier"
         case ActionMirror: return "Mirror"
         case ActionNextTurn: return "Next Turn"
+        case ActionQuitWithoutSaving: return "Quit Without Saving"
     }
 
     return "Unknown"
@@ -98,6 +101,7 @@ func (action Action) Default() ebiten.Key {
         case ActionGrandVizier: return ebiten.KeyF8
         case ActionMirror: return ebiten.KeyF9
         case ActionNextTurn: return ebiten.KeyN
+        case ActionQuitWithoutSaving: return Unbound
     }
 
     return Unbound

--- a/game/magic/mainview/view.go
+++ b/game/magic/mainview/view.go
@@ -15,6 +15,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/gamemenu"
     settingslib "github.com/kazzmir/master-of-magic/game/magic/settings"
     musiclib "github.com/kazzmir/master-of-magic/game/magic/music"
+    "github.com/kazzmir/master-of-magic/game/magic/keybinds"
     fontslib "github.com/kazzmir/master-of-magic/game/magic/fonts"
     uilib "github.com/kazzmir/master-of-magic/game/magic/ui"
     helplib "github.com/kazzmir/master-of-magic/game/magic/help"
@@ -100,6 +101,13 @@ func (main *MainScreen) MakeUI() *uilib.UI {
             }
 
             ui.StandardDraw(screen)
+        },
+        HandleKeys: func(keys []ebiten.Key){
+            for _, key := range keys {
+                if key == main.Settings.Keybindings.Get(keybinds.ActionQuitWithoutSaving) {
+                    main.State = MainScreenStateQuit
+                }
+            }
         },
     }
 

--- a/game/magic/settings/keys.go
+++ b/game/magic/settings/keys.go
@@ -60,7 +60,7 @@ func waitForKeyPress(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.L
     cancelled := false
     var pressed ebiten.Key
 
-    boxRect := image.Rect(60, 85, 260, 118)
+    boxRect := image.Rect(50, 85, 270, 118)
 
     element := &uilib.UIElement{
         Layer: keyPressLayer,


### PR DESCRIPTION
## Summary
- Adds `ActionQuitWithoutSaving` to the Keys screen, matching the original game's entry of the same name.
- Wired to the title screen's key handling, triggering the same `MainScreenStateQuit` transition as the existing "Quit to Dos" button - confirmed via `main.go:743` that this is a real app exit (`ebiten.Termination`), not a no-op.
- Unbound by default (`---`), matching the original: verified by hand that `Q` (my first guess) is actually bound to a unit action in the original game, and there's no default key for this action at all there - only reachable via the Settings button or manually binding it.

## Context
Started as an investigation into whether "Quit Without Saving" was a broken/missing feature (see discussion on #726/#727) - traced through and found both existing quit paths (in-game Game Menu quit, title screen's own "Quit to Dos") already work correctly and match the original. The only real gap was this action not being reachable as a keybinding at all, which is what this PR adds.

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Verified on the native build: Keys screen shows "Quit Without Saving" as unbound by default; binding it to a key and pressing that key at the title screen exits the app