### PR TITLE
ci: generate and upload a test coverage report

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,7 +31,24 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: xvfb-run go test ./lib/... ./game/...
+        run: xvfb-run go test -coverprofile=coverage.out -covermode=atomic ./lib/... ./game/...
+
+      - name: Coverage summary
+        if: always()
+        run: go tool cover -func=coverage.out
+
+      - name: Coverage HTML report
+        if: always()
+        run: go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage.html
 
       - name: Build
         run: go build ./game/magic

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |


### PR DESCRIPTION
## Summary
No coverage tooling exists anywhere in the project today - no Makefile target, no CI step, nothing checked in. This adds coverage generation to the existing Linux amd64 build job:

- `go test` gains `-coverprofile=coverage.out -covermode=atomic` on its existing `./lib/... ./game/...` scope (unchanged otherwise).
- A "Coverage summary" step prints the per-package breakdown to the job log via `go tool cover -func`.
- An HTML report is generated (`go tool cover -html`) and both files are uploaded as a `coverage-report` build artifact, so coverage is inspectable from any CI run without signing up for an external service (Codecov etc.) - that's a reasonable follow-up if wanted, but this keeps the first step dependency-free.
- Left the arm64 job as build+test only (no coverage step) to avoid a duplicate, presumably-identical report.
- Used `if: always()` on the summary/report/upload steps so a report is still produced even if some tests fail, which is useful for seeing what was actually exercised in a failing run.

## Current numbers (for context, not part of the diff)
Ran the exact commands this workflow now runs locally: total coverage across `./lib/... ./game/...` is **9.1%**. Breakdown ranges from `shaders`/`coroutine` at 100% down to most UI-facing packages (`settings`, `keybinds`, `mainview`, `ui`, `artifact`, etc.) at 0% (no test files at all). Happy to follow up with actual coverage improvements in separate PRs now that this is visible.

## Test plan
- [x] Validated the YAML (`ruby -ryaml`)
- [x] Ran the exact commands the new steps use locally: `go test -coverprofile=... -covermode=atomic ./lib/... ./game/...` (passes, exit 0), `go tool cover -func=coverage.out` (prints summary), `go tool cover -html=coverage.out -o coverage.html` (generates a valid 4.6MB HTML report)
- [ ] Actual CI run - draft PR, will confirm the workflow runs green and the artifact appears once pushed