### PR TITLE
Add baseline test coverage for keybinds, data, and artifact packages

### DIFF
--- a/game/magic/artifact/item_test.go
+++ b/game/magic/artifact/item_test.go
@@ -1,0 +1,231 @@
+package artifact
+
+import (
+    "testing"
+
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+)
+
+func TestArtifactTypeName(test *testing.T) {
+    if ArtifactTypeSword.Name() != "Sword" {
+        test.Errorf("expected Sword but got %v", ArtifactTypeSword.Name())
+    }
+
+    if ArtifactTypeNone.Name() != "" {
+        test.Errorf("expected empty name for ArtifactTypeNone but got %v", ArtifactTypeNone.Name())
+    }
+}
+
+func TestArtifactSlotCompatibleWith(test *testing.T) {
+    cases := []struct {
+        slot ArtifactSlot
+        kind ArtifactType
+        compatible bool
+    }{
+        {ArtifactSlotMeleeWeapon, ArtifactTypeSword, true},
+        {ArtifactSlotMeleeWeapon, ArtifactTypeBow, false},
+        {ArtifactSlotRangedWeapon, ArtifactTypeBow, true},
+        {ArtifactSlotMagicWeapon, ArtifactTypeStaff, true},
+        {ArtifactSlotMagicWeapon, ArtifactTypeSword, false},
+        {ArtifactSlotArmor, ArtifactTypePlate, true},
+        {ArtifactSlotJewelry, ArtifactTypeMisc, true},
+        {ArtifactSlotJewelry, ArtifactTypeShield, false},
+    }
+
+    for _, testCase := range cases {
+        if got := testCase.slot.CompatibleWith(testCase.kind); got != testCase.compatible {
+            test.Errorf("slot %v CompatibleWith(%v) = %v, want %v", testCase.slot, testCase.kind.Name(), got, testCase.compatible)
+        }
+    }
+}
+
+func makeAbilityPower(ability data.ItemAbility) Power {
+    return Power{Type: PowerTypeAbility1, Ability: ability}
+}
+
+func TestFirstAndLastAbility(test *testing.T) {
+    empty := &Artifact{}
+    if empty.FirstAbility() != data.ItemAbilityNone {
+        test.Errorf("expected ItemAbilityNone on an artifact with no powers")
+    }
+
+    item := &Artifact{
+        Powers: []Power{
+            makeAbilityPower(data.ItemAbilityHaste),
+            {Type: PowerTypeAttack, Amount: 5},
+            makeAbilityPower(data.ItemAbilityFlaming),
+        },
+    }
+
+    if item.FirstAbility() != data.ItemAbilityHaste {
+        test.Errorf("expected FirstAbility to be Haste but got %v", item.FirstAbility())
+    }
+
+    if item.LastAbility() != data.ItemAbilityFlaming {
+        test.Errorf("expected LastAbility to be Flaming but got %v", item.LastAbility())
+    }
+
+    if !item.HasItemAbility(data.ItemAbilityHaste) {
+        test.Errorf("expected item to have the Haste ability")
+    }
+
+    if item.HasItemAbility(data.ItemAbilityBless) {
+        test.Errorf("expected item not to have the Bless ability")
+    }
+
+    if !item.HasAbilities() {
+        test.Errorf("expected HasAbilities to be true")
+    }
+
+    if empty.HasAbilities() {
+        test.Errorf("expected HasAbilities to be false on an artifact with no powers")
+    }
+}
+
+func TestHasAbilityLargeShieldSpecialCase(test *testing.T) {
+    shield := &Artifact{Type: ArtifactTypeShield}
+    if !shield.HasAbility(data.AbilityLargeShield) {
+        test.Errorf("a shield-type artifact should always have AbilityLargeShield")
+    }
+
+    sword := &Artifact{Type: ArtifactTypeSword}
+    if sword.HasAbility(data.AbilityLargeShield) {
+        test.Errorf("a sword-type artifact should not have AbilityLargeShield")
+    }
+}
+
+func TestHasAbilityViaItemAbilityMapping(test *testing.T) {
+    item := &Artifact{
+        Powers: []Power{makeAbilityPower(data.ItemAbilityCloakOfFear)},
+    }
+
+    if !item.HasAbility(data.AbilityCauseFear) {
+        test.Errorf("expected Cloak Of Fear power to confer AbilityCauseFear")
+    }
+
+    if item.HasAbility(data.AbilityLucky) {
+        test.Errorf("did not expect Cloak Of Fear power to confer AbilityLucky")
+    }
+}
+
+func TestHasEnchantmentAndGetEnchantments(test *testing.T) {
+    item := &Artifact{
+        Powers: []Power{
+            makeAbilityPower(data.ItemAbilityBless),
+            {Type: PowerTypeAttack, Amount: 3},
+        },
+    }
+
+    if !item.HasEnchantment(data.UnitEnchantmentBless) {
+        test.Errorf("expected item to confer the Bless enchantment")
+    }
+
+    enchantments := item.GetEnchantments()
+    if len(enchantments) != 1 || enchantments[0] != data.UnitEnchantmentBless {
+        test.Errorf("expected exactly one Bless enchantment but got %v", enchantments)
+    }
+}
+
+func TestAddAndRemovePower(test *testing.T) {
+    item := &Artifact{}
+
+    power := Power{Type: PowerTypeAttack, Amount: 5, Index: 1}
+    item.AddPower(power)
+
+    if len(item.Powers) != 1 {
+        test.Fatalf("expected 1 power after AddPower but got %v", len(item.Powers))
+    }
+
+    item.RemovePower(power)
+
+    if len(item.Powers) != 0 {
+        test.Errorf("expected 0 powers after RemovePower but got %v", len(item.Powers))
+    }
+}
+
+func TestDamageBonusesRespectArtifactType(test *testing.T) {
+    attackPower := Power{Type: PowerTypeAttack, Amount: 10}
+
+    sword := &Artifact{Type: ArtifactTypeSword, Powers: []Power{attackPower}}
+    if sword.MeleeBonus() != 10 {
+        test.Errorf("expected sword MeleeBonus to be 10 but was %v", sword.MeleeBonus())
+    }
+    if sword.RangedAttackBonus() != 0 {
+        test.Errorf("expected sword RangedAttackBonus to be 0 but was %v", sword.RangedAttackBonus())
+    }
+
+    bow := &Artifact{Type: ArtifactTypeBow, Powers: []Power{attackPower}}
+    if bow.RangedAttackBonus() != 10 {
+        test.Errorf("expected bow RangedAttackBonus to be 10 but was %v", bow.RangedAttackBonus())
+    }
+    if bow.MeleeBonus() != 0 {
+        test.Errorf("expected bow MeleeBonus to be 0 but was %v", bow.MeleeBonus())
+    }
+
+    wand := &Artifact{Type: ArtifactTypeWand, Powers: []Power{attackPower}}
+    if wand.MagicAttackBonus() != 10 {
+        test.Errorf("expected wand MagicAttackBonus to be 10 but was %v", wand.MagicAttackBonus())
+    }
+
+    // misc items can carry any of the three attack bonus types
+    misc := &Artifact{Type: ArtifactTypeMisc, Powers: []Power{attackPower}}
+    if misc.MeleeBonus() != 10 || misc.RangedAttackBonus() != 10 || misc.MagicAttackBonus() != 10 {
+        test.Errorf("expected a misc item to apply its attack power to all three bonus types")
+    }
+}
+
+func TestDefenseBonusIncludesArmorTypeBase(test *testing.T) {
+    defensePower := Power{Type: PowerTypeDefense, Amount: 3}
+
+    chain := &Artifact{Type: ArtifactTypeChain, Powers: []Power{defensePower}}
+    if chain.DefenseBonus() != 4 {
+        test.Errorf("expected chain DefenseBonus to be 3+1=4 but was %v", chain.DefenseBonus())
+    }
+
+    plate := &Artifact{Type: ArtifactTypePlate, Powers: []Power{defensePower}}
+    if plate.DefenseBonus() != 5 {
+        test.Errorf("expected plate DefenseBonus to be 3+2=5 but was %v", plate.DefenseBonus())
+    }
+
+    misc := &Artifact{Type: ArtifactTypeMisc, Powers: []Power{defensePower}}
+    if misc.DefenseBonus() != 3 {
+        test.Errorf("expected misc DefenseBonus to be just the power amount, 3, but was %v", misc.DefenseBonus())
+    }
+}
+
+func TestSimplePowerBonuses(test *testing.T) {
+    item := &Artifact{
+        Powers: []Power{
+            {Type: PowerTypeToHit, Amount: 15},
+            {Type: PowerTypeSpellSkill, Amount: 5},
+            {Type: PowerTypeSpellSave, Amount: 2},
+            {Type: PowerTypeResistance, Amount: 4},
+            {Type: PowerTypeMovement, Amount: 1},
+        },
+    }
+
+    if !item.HasToHitPower() || item.ToHitBonus() != 15 {
+        test.Errorf("expected ToHitBonus 15 but got %v", item.ToHitBonus())
+    }
+
+    if !item.HasSpellSkillPower() || item.SpellSkillBonus() != 5 {
+        test.Errorf("expected SpellSkillBonus 5 but got %v", item.SpellSkillBonus())
+    }
+
+    if !item.HasSpellSavePower() || item.SpellSaveBonus() != 2 {
+        test.Errorf("expected SpellSaveBonus 2 but got %v", item.SpellSaveBonus())
+    }
+
+    if !item.HasResistancePower() || item.ResistanceBonus() != 4 {
+        test.Errorf("expected ResistanceBonus 4 but got %v", item.ResistanceBonus())
+    }
+
+    if !item.HasMovementPower() || item.MovementBonus() != 1 {
+        test.Errorf("expected MovementBonus 1 but got %v", item.MovementBonus())
+    }
+
+    empty := &Artifact{}
+    if empty.HasToHitPower() || empty.HasSpellSkillPower() || empty.HasSpellSavePower() || empty.HasResistancePower() || empty.HasMovementPower() || empty.HasDefensePower() || empty.HasAbilityPower() {
+        test.Errorf("an artifact with no powers should report false for every Has*Power check")
+    }
+}

--- a/game/magic/data/data_test.go
+++ b/game/magic/data/data_test.go
@@ -1,0 +1,111 @@
+package data
+
+import "testing"
+
+func TestRomanNumeral(test *testing.T) {
+    cases := map[int]string{
+        1: "I",
+        4: "IV",
+        9: "IX",
+        10: "X",
+        11: "11", // falls back to plain digits above the known range
+    }
+
+    for value, expected := range cases {
+        if got := romanNumeral(value); got != expected {
+            test.Errorf("romanNumeral(%v) = %q, want %q", value, got, expected)
+        }
+    }
+}
+
+func TestAllAbilitiesHaveNames(test *testing.T) {
+    seen := make(map[string]bool)
+
+    for _, abilityType := range AllAbilities() {
+        ability := MakeAbility(abilityType)
+        name := ability.Name()
+
+        if name == "" {
+            test.Errorf("ability %v has an empty Name()", int(abilityType))
+        }
+
+        if seen[name] {
+            test.Errorf("ability name %q is used by more than one AbilityType", name)
+        }
+        seen[name] = true
+    }
+}
+
+func TestIsHeroAbility(test *testing.T) {
+    if !MakeAbility(AbilityLucky).IsHeroAbility() {
+        test.Errorf("Lucky should be a hero ability")
+    }
+
+    if MakeAbility(AbilityFireBreath).IsHeroAbility() {
+        test.Errorf("Fire Breath should not be a hero ability")
+    }
+}
+
+func TestAbilityValueRoundTrip(test *testing.T) {
+    ability := MakeAbilityValue(AbilityCaster, 2.5)
+
+    if ability.Ability != AbilityCaster {
+        test.Errorf("expected Ability to be AbilityCaster")
+    }
+
+    if ability.Value != 2.5 {
+        test.Errorf("expected Value to be 2.5 but was %v", ability.Value)
+    }
+}
+
+func TestItemAbilityMagicType(test *testing.T) {
+    // spot-check a few representative item abilities rather than every one -
+    // this is meant as baseline coverage of the mapping logic, not exhaustive
+    cases := map[ItemAbility]MagicType{
+        ItemAbilityHaste: SorceryMagic,
+        ItemAbilityFlaming: ChaosMagic,
+        ItemAbilityBless: LifeMagic,
+    }
+
+    for item, expected := range cases {
+        if got := item.MagicType(); got != expected {
+            test.Errorf("%v.MagicType() = %v, want %v", item.Name(), got, expected)
+        }
+    }
+}
+
+func TestItemAbilityAbilityType(test *testing.T) {
+    if got := ItemAbilityCloakOfFear.AbilityType(); got != AbilityCauseFear {
+        test.Errorf("ItemAbilityCloakOfFear.AbilityType() = %v, want AbilityCauseFear", got)
+    }
+
+    // documents the current (buggy) behavior noted in a FIXME above this
+    // case in abilities.go: Stoning should carry a value (AbilityValue(
+    // AbilityStoningTouch, 1)) but currently returns the bare ability type
+    // with no value attached. If this is fixed, update this test rather
+    // than deleting it.
+    if got := ItemAbilityStoning.AbilityType(); got != AbilityStoningTouch {
+        test.Errorf("ItemAbilityStoning.AbilityType() = %v, want AbilityStoningTouch", got)
+    }
+
+    // an item ability with no explicit case should fall back to AbilityNone
+    if got := ItemAbilityHaste.AbilityType(); got != AbilityNone {
+        test.Errorf("ItemAbilityHaste.AbilityType() = %v, want AbilityNone (no explicit mapping)", got)
+    }
+}
+
+func TestItemAbilityEnchantment(test *testing.T) {
+    if got := ItemAbilityBless.Enchantment(); got != UnitEnchantmentBless {
+        test.Errorf("ItemAbilityBless.Enchantment() = %v, want UnitEnchantmentBless", got)
+    }
+}
+
+func TestItemAbilityName(test *testing.T) {
+    if ItemAbilityStoning.Name() == "" {
+        test.Errorf("ItemAbilityStoning should have a non-empty Name()")
+    }
+
+    if ItemAbilityNone.Name() == ItemAbilityStoning.Name() {
+        test.Errorf("ItemAbilityNone and ItemAbilityStoning should not share a name")
+    }
+}

--- a/game/magic/keybinds/keybinds_test.go
+++ b/game/magic/keybinds/keybinds_test.go
@@ -1,0 +1,68 @@
+package keybinds
+
+import (
+    "testing"
+
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestAllActionsHaveANonEmptyName(test *testing.T) {
+    for _, action := range AllActions {
+        if action.Name() == "" || action.Name() == "Unknown" {
+            test.Errorf("action %v has no Name() case", int(action))
+        }
+    }
+}
+
+func TestMakeKeybindingsSeedsDefaults(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    for _, action := range AllActions {
+        if keybindings.Get(action) != action.Default() {
+            test.Errorf("expected %v to default to %v but got %v", action.Name(), action.Default(), keybindings.Get(action))
+        }
+    }
+}
+
+func TestSetOverridesBinding(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    keybindings.Set(ActionNextTurn, ebiten.KeySpace)
+
+    if keybindings.Get(ActionNextTurn) != ebiten.KeySpace {
+        test.Errorf("expected Next Turn to be rebound to Space but got %v", keybindings.Get(ActionNextTurn))
+    }
+
+    // rebinding one action should not disturb another
+    if keybindings.Get(ActionSurveyor) != ActionSurveyor.Default() {
+        test.Errorf("expected Surveyor to remain at its default after rebinding a different action")
+    }
+}
+
+func TestSetToUnbound(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    keybindings.Set(ActionNextTurn, Unbound)
+
+    if keybindings.Get(ActionNextTurn) != Unbound {
+        test.Errorf("expected Next Turn to be unbound but got %v", keybindings.Get(ActionNextTurn))
+    }
+}
+
+// the original game's default bindings should be conflict-free - if two
+// actions defaulted to the same key, only one would ever fire
+func TestDefaultBindingsHaveNoDuplicates(test *testing.T) {
+    seen := make(map[ebiten.Key]Action)
+
+    for _, action := range AllActions {
+        key := action.Default()
+        if key == Unbound {
+            continue
+        }
+
+        if other, ok := seen[key]; ok {
+            test.Errorf("%v and %v both default to key %v", action.Name(), other.Name(), key)
+        }
+        seen[key] = action
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #731 (CI coverage reporting) - now that coverage is visible, starting to fill in the biggest zero-coverage gaps. First three:

- `game/magic/keybinds`: 0% -> 95.5%
- `game/magic/data`: 0.2% -> 9.0%
- `game/magic/artifact`: 0% -> 8.4%

Overall repo coverage (`./lib/... ./game/...`) goes from 9.1% to 9.6%.

All added tests exercise pure logic only - no `lbx.LbxCache` or Ebiten graphics context needed - matching `DEVELOPMENT.md`'s stated goal of keeping core functionality testable without those dependencies. That's also why these three specifically: they're the packages with real non-trivial logic reachable without touching LBX/rendering.

One test worth calling out: `TestItemAbilityAbilityType` in `data/data_test.go` documents the current behavior of `ItemAbilityStoning.AbilityType()` (drops its value, per the existing FIXME comment above that case) rather than asserting the "correct" behavior - so it fails loudly and needs an explicit update if that's ever fixed, instead of silently continuing to pass.

## Test plan
- [x] `go build`, `go vet`, `go test ./...` clean
- [x] Tested locally before opening this PR