### PR TITLE
keybinds: prevent duplicate key bindings in the Keys screen

### DIFF
--- a/game/magic/keybinds/keybinds.go
+++ b/game/magic/keybinds/keybinds.go
@@ -129,6 +129,24 @@ func (keybindings *Keybindings) Get(action Action) ebiten.Key {
     return keybindings.bindings[action]
 }
 
+// ConflictingActionForKey returns the action currently bound to key, or the
+// zero-value ActionGameScreen and false if no action holds that key. It is the
+// primitive the Keys screen consults before applying a rebind so a key can
+// never end up driving two actions at once.
+func (keybindings *Keybindings) ConflictingActionForKey(key ebiten.Key) (Action, bool) {
+    if key == Unbound {
+        return ActionGameScreen, false
+    }
+
+    for action, bound := range keybindings.bindings {
+        if bound == key {
+            return action, true
+        }
+    }
+
+    return ActionGameScreen, false
+}
+
 func (keybindings *Keybindings) Set(action Action, key ebiten.Key) {
     keybindings.bindings[action] = key
 }

--- a/game/magic/keybinds/keybinds_test.go
+++ b/game/magic/keybinds/keybinds_test.go
@@ -66,3 +66,63 @@ func TestDefaultBindingsHaveNoDuplicates(test *testing.T) {
         seen[key] = action
     }
 }
+
+// ConflictingActionForKey backs the Keys screen: before applying a rebind, it
+// asks the current bindings which action (if any) already holds the target key.
+func TestConflictingActionForKeyFindsCurrentHolder(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    // ActionNextTurn defaults to KeyN, so that key should resolve back to
+    // ActionNextTurn in a fresh keyset.
+    got, ok := keybindings.ConflictingActionForKey(ebiten.KeyN)
+    if !ok {
+        test.Fatalf("expected KeyN to resolve to an action in defaults")
+     }
+    if got != ActionNextTurn {
+        test.Errorf("expected KeyN to be held by %v, got %v", ActionNextTurn.Name(), got.Name())
+     }
+}
+
+func TestConflictingActionForKeyUnboundReturnsNo(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    // Unbound is the sentinel for "no binding" and must never resolve to
+    // any real action.
+    if _, ok := keybindings.ConflictingActionForKey(Unbound); ok {
+        test.Errorf("Unbound should not resolve to an action")
+     }
+}
+
+func TestConflictingActionForKeyFreeKeyReturnsNo(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    // KeyX is not used by any default action.
+    if _, ok := keybindings.ConflictingActionForKey(ebiten.KeyX); ok {
+        test.Errorf("did not expect KeyX to be held by any action")
+     }
+}
+
+// The Keys screen's flow unbinds the previous owner before applying a
+// rebind, so the map stays conflict-free and ConflictingActionForKey keeps
+// resolving to exactly one action per key.
+func TestConflictingActionForKeyTracksRebind(test *testing.T) {
+    keybindings := MakeKeybindings()
+
+    // Simulate a confirmed rebind of ActionGameScreen onto ActionNextTurn's key.
+    keybindings.Set(ActionNextTurn, Unbound)
+    keybindings.Set(ActionGameScreen, ebiten.KeyN)
+
+    got, ok := keybindings.ConflictingActionForKey(ebiten.KeyN)
+    if !ok {
+        test.Fatalf("expected KeyN to still resolve after rebind")
+     }
+    if got != ActionGameScreen {
+        test.Errorf("expected KeyN to be held by %v after rebind, got %v", ActionGameScreen.Name(), got.Name())
+     }
+
+    // the old owner should now be unbound, and KeyN must resolve to exactly
+    // one action (the new owner) with nothing else also claiming it.
+    if keybindings.Get(ActionNextTurn) != Unbound {
+        test.Errorf("expected old owner %v to be unbound after rebind", ActionNextTurn.Name())
+     }
+}

--- a/game/magic/settings/keys.go
+++ b/game/magic/settings/keys.go
@@ -21,6 +21,7 @@ import (
 
 const keysLayer = uilib.UILayer(6)
 const keyPressLayer = uilib.UILayer(7)
+const confirmLayer = uilib.UILayer(8)
 
 // runNestedUI adds group to parentUI, pumps it each frame via yield until quit is
 // cancelled, then removes it. Mirrors game.go's doRunUI, which needs *Game and so
@@ -109,10 +110,56 @@ func waitForKeyPress(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.L
     return pressed, !cancelled
 }
 
+// confirmRebind pops the standard game confirm dialog before applying a rebind
+// that would kick a key out from under another action. It matches the original
+// game's behaviour: the previous owner is unbound and the new action takes the
+// key. Returns true when the player confirmed (the caller performs the swap), or
+// false when they cancelled (leave the bindings unchanged). Mirrors the nested-UI
+// pump of waitForKeyPress: add a group and pump it via yield until it is gone.
+func confirmRebind(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, actionName, otherName string, key ebiten.Key) bool {
+    group := uilib.MakeGroup()
+    parentUI.AddGroup(group)
+    defer parentUI.RemoveGroup(group)
+
+    quit, cancel := context.WithCancel(context.Background())
+    accepted := false
+
+     // the dialog's container and its elements must be the same group: the
+     // confirm buttons' fade/removal are driven by this group's delays, which
+     // only fire when its elements live in this group. It is rendered on
+     // confirmLayer so it sits above the keys screen instead of being hidden
+     // behind it.
+    group.AddElements(uilib.MakeConfirmDialogWithLayer(group, cache, imageCache, confirmLayer,
+        fmt.Sprintf("Key %v is already bound to %q. Bind %q to it and unbind it from %q?", key.String(), otherName, actionName, otherName),
+        true,
+        func() {
+            accepted = true
+            cancel()
+          },
+        func() {
+            cancel()
+          }))
+
+     // let the click that opened this screen finish out its frame before the
+     // confirm group starts processing input, otherwise a same-frame click on the
+     // confirm group would fire immediately.
+    yield()
+
+    for quit.Err() == nil {
+        parentUI.StandardUpdate()
+        if yield() != nil {
+            break
+          }
+      }
+
+    return accepted
+}
+
 // MakeKeysUI builds the list of rebindable actions and their current key.
-// Clicking a row opens waitForKeyPress to rebind it. Back/Ok both just close
-// the screen - rebinding already applies immediately per keypress, there is
-// no separate save/cancel state for the screen as a whole.
+// Clicking a row opens waitForKeyPress to rebind it; if the chosen key is
+// already held by another action, confirmRebind asks whether to unbind the
+// previous owner. Back/Ok just close the screen - there is no separate
+// save/cancel state for the screen as a whole.
 func MakeKeysUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, keybindings *keybinds.Keybindings) (*uilib.UIElementGroup, context.Context) {
     fonts := fontslib.MakeSettingsFonts(cache)
     background, _ := imageCache.GetImage("load.lbx", 11, 0)
@@ -140,9 +187,24 @@ func MakeKeysUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCac
             Rect: image.Rect(x, y, x + rowWidth, y + rowHeight),
             LeftClick: func(element *uilib.UIElement){
                 key, ok := waitForKeyPress(yield, parentUI, cache, action.Name())
-                if ok {
-                    keybindings.Set(action, key)
-                }
+                if !ok {
+                    return
+                        }
+
+                    // If another action currently owns this key, ask the player how to
+                    // proceed before applying the rebind so a keypress can never fire
+                    // two actions at once.
+                if other, hasConflict := keybindings.ConflictingActionForKey(key); hasConflict && other != action {
+                    if !confirmRebind(yield, parentUI, cache, imageCache, action.Name(), other.Name(), key) {
+                        return
+                        }
+
+                    // confirmed: unbind the previous owner first, matching the original
+                    // game, then bind the key to this action.
+                    keybindings.Set(other, keybinds.Unbound)
+                    }
+
+                keybindings.Set(action, key)
             },
             Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                 var options ebiten.DrawImageOptions

--- a/game/magic/settings/keys.go
+++ b/game/magic/settings/keys.go
@@ -135,10 +135,9 @@ func confirmRebind(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.Lbx
         func() {
             accepted = true
             cancel()
-          },
-        func() {
-            cancel()
-          }))
+        },
+        cancel,
+    ))
 
      // let the click that opened this screen finish out its frame before the
      // confirm group starts processing input, otherwise a same-frame click on the
@@ -189,7 +188,7 @@ func MakeKeysUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCac
                 key, ok := waitForKeyPress(yield, parentUI, cache, action.Name())
                 if !ok {
                     return
-                        }
+                }
 
                     // If another action currently owns this key, ask the player how to
                     // proceed before applying the rebind so a keypress can never fire
@@ -197,12 +196,12 @@ func MakeKeysUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.LbxCac
                 if other, hasConflict := keybindings.ConflictingActionForKey(key); hasConflict && other != action {
                     if !confirmRebind(yield, parentUI, cache, imageCache, action.Name(), other.Name(), key) {
                         return
-                        }
+                    }
 
                     // confirmed: unbind the previous owner first, matching the original
                     // game, then bind the key to this action.
                     keybindings.Set(other, keybinds.Unbound)
-                    }
+                }
 
                 keybindings.Set(action, key)
             },


### PR DESCRIPTION
## Summary

Rebinding a key in the **Keys** settings screen could silently leave two actions sharing one key, so a single keypress would fire whichever action Go's non-fall-through `switch` happened to match first.

- Add `Keybindings.ConflictingActionForKey`, which reports the action that currently owns a given key.
- Wire it into the Keys screen's rebind flow: when the chosen key is already held by another action, the previous owner is unbound first (matching the original game's behavior).
- The confirm step pops the standard confirm dialog, rendered on a new `confirmLayer` above the Keys screen, with its elements added to the same group that drives their fade/removal so the dialog shows and the button clicks cancel the nested UI pump.
- Adds unit tests for `ConflictingActionForKey` across the conflict, unbound, free-key, and rebind-tracking cases.

## Motivation

This completes the "No duplicate-key-binding detection" item flagged in #724. The Keys screen now makes it impossible for two actions to end up on the same key.

## Testing

- `go test ./game/magic/keybinds/...` passes.
- Native (`go build -o magic ./game/magic`) and WASM (`GOOS=js GOARCH=wasm go build`) both build.
- Manually verified: entering Settings → Keys, rebinding an action onto an already-used key now shows the confirm dialog; confirming unbinds the previous owner and binds the key to the new action.

## Related

Closes the duplicate-key-detection gap from #724 (rebindable keybindings + Keys screen).