### PR TITLE
artifact: add in-game Default Item Editor

### DIFF
--- a/game/magic/artifact/catalog.go
+++ b/game/magic/artifact/catalog.go
@@ -144,8 +144,8 @@ func (catalog *Catalog) Replace(index int, item *Artifact) {
     slot.Image = item.Image
     slot.Name = item.Name
     slot.Cost = item.Cost
-    slot.Powers = append([]Power{}, item.Powers...)
-    slot.Requirements = append([]Requirement{}, item.Requirements...)
+    slot.Powers = slices.Clone(item.Powers)
+    slot.Requirements = slices.Clone(item.Requirements)
     slot.CatalogIndex = index
 }
 
@@ -212,7 +212,7 @@ func (catalog *Catalog) AvailableMask() []bool {
         return nil
     }
 
-    return append([]bool{}, catalog.available...)
+    return slices.Clone(catalog.available)
 }
 
 func ReconstructCatalog(items []SerializedArtifact, available []bool, allSpells spellbook.Spells) *Catalog {
@@ -243,8 +243,8 @@ func CloneArtifact(src *Artifact) *Artifact {
     }
 
     clone := *src
-    clone.Powers = append([]Power{}, src.Powers...)
-    clone.Requirements = append([]Requirement{}, src.Requirements...)
+    clone.Powers = slices.Clone(src.Powers)
+    clone.Requirements = slices.Clone(src.Requirements)
     return &clone
 }
 

--- a/game/magic/artifact/catalog.go
+++ b/game/magic/artifact/catalog.go
@@ -1,0 +1,387 @@
+package artifact
+
+import (
+    "slices"
+
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
+    "github.com/kazzmir/master-of-magic/lib/set"
+)
+
+// NotPremade is CatalogIndex for an item that is not one of the 250
+// ITEMDATA slots (Enchant Item / Create Artifact output).
+const NotPremade = -1
+
+// Catalog is the 250-slot premade item list plus which slots have not
+// yet been awarded this campaign. Identity is the slot index, matching
+// ITEMMAKE's "Item #N".
+type Catalog struct {
+    Slots []*Artifact
+    available []bool
+}
+
+func MakeCatalog(items []Artifact) *Catalog {
+    catalog := &Catalog{
+        Slots: make([]*Artifact, len(items)),
+        available: make([]bool, len(items)),
+    }
+
+    for i, item := range items {
+        clone := CloneArtifact(&item)
+        clone.CatalogIndex = i
+        catalog.Slots[i] = clone
+        catalog.available[i] = true
+    }
+
+    return catalog
+}
+
+func (catalog *Catalog) Len() int {
+    if catalog == nil {
+        return 0
+    }
+
+    return len(catalog.Slots)
+}
+
+func (catalog *Catalog) IsAvailable(index int) bool {
+    if catalog == nil || index < 0 || index >= len(catalog.available) {
+        return false
+    }
+
+    return catalog.available[index]
+}
+
+// AvailableArtifacts returns the slots that have not been awarded yet,
+// in catalog order. Callers must not assume the slice is a live view.
+func (catalog *Catalog) AvailableArtifacts() []*Artifact {
+    if catalog == nil {
+        return nil
+    }
+
+    var out []*Artifact
+    for i, slot := range catalog.Slots {
+        if catalog.available[i] {
+            out = append(out, slot)
+        }
+    }
+
+    return out
+}
+
+func (catalog *Catalog) AvailableNames() []string {
+    var names []string
+    for _, item := range catalog.AvailableArtifacts() {
+        names = append(names, item.Name)
+    }
+
+    return names
+}
+
+func (catalog *Catalog) FindByName(name string) *Artifact {
+    if catalog == nil {
+        return nil
+    }
+
+    for _, slot := range catalog.Slots {
+        if slot != nil && slot.Name == name {
+            return slot
+        }
+    }
+
+    return nil
+}
+
+// Award marks the premade slot that item came from as used. Crafted items
+// (or anything that does not match a slot) are ignored, matching the old
+// delete-from-name-map no-op.
+func (catalog *Catalog) Award(item *Artifact) {
+    if catalog == nil || item == nil {
+        return
+    }
+
+    for i, slot := range catalog.Slots {
+        if slot == item {
+            catalog.available[i] = false
+            return
+        }
+    }
+
+    catalog.AwardByName(item.Name)
+}
+
+func (catalog *Catalog) AwardByName(name string) {
+    if catalog == nil || name == "" {
+        return
+    }
+
+    for i, slot := range catalog.Slots {
+        if catalog.available[i] && slot != nil && slot.Name == name {
+            catalog.available[i] = false
+            return
+        }
+    }
+}
+
+// Replace writes item into slot index without changing availability.
+// Used by the Default Item Editor: already-awarded slots stay awarded.
+func (catalog *Catalog) Replace(index int, item *Artifact) {
+    if catalog == nil || item == nil || index < 0 || index >= len(catalog.Slots) {
+        return
+    }
+
+    clone := CloneArtifact(item)
+    clone.CatalogIndex = index
+    catalog.Slots[index] = clone
+}
+
+// ApplyAvailabilityBitmap applies the 250-byte DOS save mask (1 = still
+// available). Shorter or empty slices are ignored so a missing field does
+// not wipe the catalog.
+func (catalog *Catalog) ApplyAvailabilityBitmap(bits []byte) {
+    if catalog == nil || len(bits) == 0 {
+        return
+    }
+
+    for i := 0; i < len(catalog.Slots) && i < len(bits); i++ {
+        catalog.available[i] = bits[i] != 0
+    }
+}
+
+// WithAvailableNames returns a copy of the catalog whose availability is
+// the set of names still remaining. Used to load old saves that only
+// stored remaining item names.
+func (catalog *Catalog) WithAvailableNames(names []string) *Catalog {
+    if catalog == nil {
+        return MakeCatalog(nil)
+    }
+
+    remaining := make(map[string]bool, len(names))
+    for _, name := range names {
+        remaining[name] = true
+    }
+
+    out := &Catalog{
+        Slots: make([]*Artifact, len(catalog.Slots)),
+        available: make([]bool, len(catalog.Slots)),
+    }
+
+    for i, slot := range catalog.Slots {
+        out.Slots[i] = CloneArtifact(slot)
+        if slot != nil {
+            out.available[i] = remaining[slot.Name]
+        }
+    }
+
+    return out
+}
+
+func (catalog *Catalog) Serialize() []SerializedArtifact {
+    if catalog == nil {
+        return nil
+    }
+
+    out := make([]SerializedArtifact, 0, len(catalog.Slots))
+    for _, slot := range catalog.Slots {
+        if slot == nil {
+            out = append(out, SerializedArtifact{})
+            continue
+        }
+        out = append(out, SerializeArtifact(slot))
+    }
+
+    return out
+}
+
+func (catalog *Catalog) AvailableMask() []bool {
+    if catalog == nil {
+        return nil
+    }
+
+    return append([]bool{}, catalog.available...)
+}
+
+func ReconstructCatalog(items []SerializedArtifact, available []bool, allSpells spellbook.Spells) *Catalog {
+    catalog := &Catalog{
+        Slots: make([]*Artifact, len(items)),
+        available: make([]bool, len(items)),
+    }
+
+    for i, serialized := range items {
+        art := ReconstructArtifact(&serialized, allSpells)
+        if art != nil {
+            art.CatalogIndex = i
+        }
+        catalog.Slots[i] = art
+        if i < len(available) {
+            catalog.available[i] = available[i]
+        } else {
+            catalog.available[i] = true
+        }
+    }
+
+    return catalog
+}
+
+func CloneArtifact(src *Artifact) *Artifact {
+    if src == nil {
+        return nil
+    }
+
+    clone := *src
+    clone.Powers = append([]Power{}, src.Powers...)
+    clone.Requirements = append([]Requirement{}, src.Requirements...)
+    return &clone
+}
+
+func isAbilityPowerType(powerType PowerType) bool {
+    return powerType == PowerTypeAbility1 || powerType == PowerTypeAbility2 || powerType == PowerTypeAbility3
+}
+
+// samePower reports whether two powers are the same pick in the item editor
+// (stat amount, ability, or spell-charge pair). Ability1/2/3 are treated as
+// the same kind so a catalog record that stored every ability as Ability1
+// still matches the itempow grouping.
+func samePower(a Power, b Power) bool {
+    if isAbilityPowerType(a.Type) && isAbilityPowerType(b.Type) {
+        return a.Ability == b.Ability
+    }
+
+    if a.Type != b.Type {
+        return false
+    }
+
+    if a.Type == PowerTypeSpellCharges {
+        return a.Spell.Name == b.Spell.Name && a.Amount == b.Amount
+    }
+
+    return a.Amount == b.Amount
+}
+
+func (artifact *Artifact) ContainsPower(power Power) bool {
+    if artifact == nil {
+        return false
+    }
+
+    for _, existing := range artifact.Powers {
+        if samePower(existing, power) {
+            return true
+        }
+    }
+
+    return false
+}
+
+// NormalizePowers replaces catalog-style powers with the matching itempow
+// entries so the create-artifact UI can highlight and toggle them. Spell
+// charges are kept as-is (they are not in itempow).
+func NormalizePowers(item *Artifact, powerEntries []Power) {
+    if item == nil {
+        return
+    }
+
+    var normalized []Power
+    for _, have := range item.Powers {
+        matched := false
+        for _, entry := range powerEntries {
+            if samePower(have, entry) {
+                normalized = append(normalized, entry)
+                matched = true
+                break
+            }
+        }
+
+        if !matched {
+            normalized = append(normalized, have)
+        }
+    }
+
+    item.Powers = normalized
+}
+
+// RequirementsFromPowers builds the realm book requirements Insecticide
+// writes: each realm's amount is the highest book cost among powers of
+// that realm. Attribute bonuses do not contribute. This is the opposite
+// of official ITEMMAKE, which wrote book counts in power-slot order.
+func RequirementsFromPowers(powers []Power) []Requirement {
+    amounts := make(map[data.MagicType]int)
+
+    for _, power := range powers {
+        if !isAbilityPowerType(power.Type) {
+            continue
+        }
+
+        if power.Magic == data.MagicNone || power.Amount <= 0 {
+            continue
+        }
+
+        if power.Amount > amounts[power.Magic] {
+            amounts[power.Magic] = power.Amount
+        }
+    }
+
+    order := []data.MagicType{
+        data.NatureMagic,
+        data.SorceryMagic,
+        data.ChaosMagic,
+        data.LifeMagic,
+        data.DeathMagic,
+    }
+
+    var out []Requirement
+    for _, magic := range order {
+        if amounts[magic] > 0 {
+            out = append(out, Requirement{MagicType: magic, Amount: amounts[magic]})
+        }
+    }
+
+    return out
+}
+
+func FilterPowersForType(item *Artifact, artifactType ArtifactType, compatibilities map[Power]set.Set[ArtifactType]) {
+    if item == nil {
+        return
+    }
+
+    item.Type = artifactType
+    item.Powers = slices.DeleteFunc(item.Powers, func (power Power) bool {
+        if power.Type == PowerTypeSpellCharges {
+            return artifactType != ArtifactTypeWand && artifactType != ArtifactTypeStaff
+        }
+
+        allowed, ok := compatibilities[power]
+        if !ok {
+            return false
+        }
+
+        return !allowed.Contains(artifactType)
+    })
+}
+
+func ImageRange(kind ArtifactType) (int, int) {
+    switch kind {
+        case ArtifactTypeSword: return 0, 8
+        case ArtifactTypeMace: return 9, 19
+        case ArtifactTypeAxe: return 20, 28
+        case ArtifactTypeBow: return 29, 37
+        case ArtifactTypeStaff: return 38, 46
+        case ArtifactTypeChain: return 47, 54
+        case ArtifactTypePlate: return 55, 61
+        case ArtifactTypeShield: return 62, 71
+        case ArtifactTypeMisc: return 72, 106
+        case ArtifactTypeWand: return 107, 115
+    }
+
+    return 0, 0
+}
+
+func ClampImageToType(item *Artifact) {
+    if item == nil {
+        return
+    }
+
+    low, high := ImageRange(item.Type)
+    if item.Image < low || item.Image > high {
+        item.Image = low
+    }
+}

--- a/game/magic/artifact/catalog.go
+++ b/game/magic/artifact/catalog.go
@@ -123,16 +123,30 @@ func (catalog *Catalog) AwardByName(name string) {
     }
 }
 
-// Replace writes item into slot index without changing availability.
-// Used by the Default Item Editor: already-awarded slots stay awarded.
+// Replace copies item into slot index without changing availability and
+// without replacing the slot pointer. Awarded copies (hero equipment,
+// vault) share that pointer, so an in-game edit updates items already
+// in play. Used by the Default Item Editor.
 func (catalog *Catalog) Replace(index int, item *Artifact) {
     if catalog == nil || item == nil || index < 0 || index >= len(catalog.Slots) {
         return
     }
 
-    clone := CloneArtifact(item)
-    clone.CatalogIndex = index
-    catalog.Slots[index] = clone
+    slot := catalog.Slots[index]
+    if slot == nil {
+        slot = CloneArtifact(item)
+        slot.CatalogIndex = index
+        catalog.Slots[index] = slot
+        return
+    }
+
+    slot.Type = item.Type
+    slot.Image = item.Image
+    slot.Name = item.Name
+    slot.Cost = item.Cost
+    slot.Powers = append([]Power{}, item.Powers...)
+    slot.Requirements = append([]Requirement{}, item.Requirements...)
+    slot.CatalogIndex = index
 }
 
 // ApplyAvailabilityBitmap applies the 250-byte DOS save mask (1 = still

--- a/game/magic/artifact/catalog_test.go
+++ b/game/magic/artifact/catalog_test.go
@@ -90,6 +90,27 @@ func TestReplaceDoesNotResurrectAwardedSlot(test *testing.T) {
     }
 }
 
+func TestReplaceMutatesAwardedPointer(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+    })
+
+    held := catalog.Slots[0]
+    catalog.Award(held)
+
+    edited := sampleSword("Ultimate Defense", 3)
+    catalog.Replace(0, &edited)
+
+    if held != catalog.Slots[0] {
+        test.Errorf("Replace must keep the awarded pointer so equipped copies update")
+    }
+
+    if held.Name != "Ultimate Defense" || held.Powers[0].Amount != 3 {
+        test.Errorf("awarded item should show the edit, got %+v", held)
+    }
+}
+
 func TestReplaceUpdatesUnusedSlotForLaterAward(test *testing.T) {
     catalog := MakeCatalog([]Artifact{
         sampleSword("First", 1),

--- a/game/magic/artifact/catalog_test.go
+++ b/game/magic/artifact/catalog_test.go
@@ -1,0 +1,250 @@
+package artifact
+
+import (
+    "testing"
+
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
+    "github.com/kazzmir/master-of-magic/lib/set"
+)
+
+func sampleSword(name string, attack int) Artifact {
+    return Artifact{
+        Type: ArtifactTypeSword,
+        Name: name,
+        Image: 0,
+        Cost: 150,
+        Powers: []Power{
+            {Type: PowerTypeAttack, Amount: attack, Name: "+1 Attack"},
+        },
+    }
+}
+
+func TestMakeCatalogIndexesEverySlot(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+    })
+
+    if catalog.Len() != 2 {
+        test.Fatalf("expected 2 slots, got %v", catalog.Len())
+    }
+
+    if catalog.Slots[0].CatalogIndex != 0 || catalog.Slots[0].Name != "First" {
+        test.Errorf("slot 0 = %+v", catalog.Slots[0])
+    }
+
+    if catalog.Slots[1].CatalogIndex != 1 || catalog.Slots[1].Name != "Second" {
+        test.Errorf("slot 1 = %+v", catalog.Slots[1])
+    }
+
+    if !catalog.IsAvailable(0) || !catalog.IsAvailable(1) {
+        test.Errorf("fresh catalog slots should all be available")
+    }
+}
+
+func TestAwardLeavesSlotUnavailable(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+    })
+
+    first := catalog.Slots[0]
+    catalog.Award(first)
+
+    if catalog.IsAvailable(0) {
+        test.Errorf("awarding slot 0 should mark it unavailable")
+    }
+
+    if !catalog.IsAvailable(1) {
+        test.Errorf("awarding slot 0 should not touch slot 1")
+    }
+
+    available := catalog.AvailableArtifacts()
+    if len(available) != 1 || available[0].Name != "Second" {
+        test.Errorf("expected only Second to remain available, got %v", available)
+    }
+}
+
+func TestReplaceDoesNotResurrectAwardedSlot(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+    })
+
+    catalog.Award(catalog.Slots[0])
+
+    edited := sampleSword("Ultimate Defense", 3)
+    catalog.Replace(0, &edited)
+
+    if catalog.IsAvailable(0) {
+        test.Errorf("editing an awarded slot must not make it available again")
+    }
+
+    if catalog.Slots[0].Name != "Ultimate Defense" {
+        test.Errorf("expected slot 0 name to update, got %v", catalog.Slots[0].Name)
+    }
+
+    if catalog.Slots[0].CatalogIndex != 0 {
+        test.Errorf("Replace should keep the slot index, got %v", catalog.Slots[0].CatalogIndex)
+    }
+}
+
+func TestReplaceUpdatesUnusedSlotForLaterAward(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+    })
+
+    edited := sampleSword("Ultimate Defense", 3)
+    catalog.Replace(1, &edited)
+
+    remaining := catalog.AvailableArtifacts()
+    if len(remaining) != 2 {
+        test.Fatalf("editing an unused slot should leave it available, got %v items", len(remaining))
+    }
+
+    found := catalog.FindByName("Ultimate Defense")
+    if found == nil || found != catalog.Slots[1] {
+        test.Fatalf("edited slot should be findable by its new name")
+    }
+
+    catalog.Award(found)
+
+    if catalog.IsAvailable(1) {
+        test.Errorf("awarding the edited slot should mark it used")
+    }
+
+    if catalog.Slots[1].Powers[0].Amount != 3 {
+        test.Errorf("awarded item should still carry the edited powers")
+    }
+}
+
+func TestAwardByNameOnlyConsumesAvailableSlot(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("Shared", 1),
+        sampleSword("Other", 2),
+    })
+
+    catalog.AwardByName("Shared")
+
+    if catalog.IsAvailable(0) {
+        test.Errorf("AwardByName should consume the named available slot")
+    }
+
+    catalog.AwardByName("Shared")
+    if !catalog.IsAvailable(1) {
+        test.Errorf("AwardByName must not consume a different slot")
+    }
+}
+
+func TestWithAvailableNamesRestoresOldSaveList(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+        sampleSword("Third", 3),
+    })
+
+    restored := catalog.WithAvailableNames([]string{"Second", "Third"})
+
+    if restored.IsAvailable(0) {
+        test.Errorf("First was not in the remaining-name list")
+    }
+
+    if !restored.IsAvailable(1) || !restored.IsAvailable(2) {
+        test.Errorf("Second and Third should still be available")
+    }
+}
+
+func TestSerializeRoundTripPreservesEdits(test *testing.T) {
+    catalog := MakeCatalog([]Artifact{
+        sampleSword("First", 1),
+        sampleSword("Second", 2),
+    })
+
+    edited := sampleSword("Ultimate Defense", 3)
+    catalog.Replace(1, &edited)
+    catalog.Award(catalog.Slots[0])
+
+    loaded := ReconstructCatalog(catalog.Serialize(), catalog.AvailableMask(), spellbook.Spells{})
+
+    if loaded.Len() != 2 {
+        test.Fatalf("expected 2 slots after round trip, got %v", loaded.Len())
+    }
+
+    if loaded.IsAvailable(0) {
+        test.Errorf("awarded slot 0 should stay unavailable")
+    }
+
+    if !loaded.IsAvailable(1) {
+        test.Errorf("unused slot 1 should stay available")
+    }
+
+    if loaded.Slots[1].Name != "Ultimate Defense" || loaded.Slots[1].Powers[0].Amount != 3 {
+        test.Errorf("edited slot did not survive the round trip: %+v", loaded.Slots[1])
+    }
+}
+
+func TestRequirementsFromPowersUsesRealmNotSlotOrder(test *testing.T) {
+    // official ITEMMAKE would have written Nature=1, Sorcery=4 because
+    // +1 Attack (no books) is skipped and Elemental Armor is the "second"
+    // property. Correct behavior is Nature=4 from the armor's own realm.
+    powers := []Power{
+        {Type: PowerTypeAttack, Amount: 1, Name: "+1 Attack"},
+        {Type: PowerTypeAbility1, Amount: 4, Magic: data.NatureMagic, Ability: data.ItemAbilityElementalArmor},
+        {Type: PowerTypeAbility2, Amount: 2, Magic: data.LifeMagic, Ability: data.ItemAbilityHolyAvenger},
+    }
+
+    got := RequirementsFromPowers(powers)
+
+    if len(got) != 2 {
+        test.Fatalf("expected Nature + Life requirements, got %+v", got)
+    }
+
+    if got[0].MagicType != data.NatureMagic || got[0].Amount != 4 {
+        test.Errorf("expected Nature 4 first, got %+v", got[0])
+    }
+
+    if got[1].MagicType != data.LifeMagic || got[1].Amount != 2 {
+        test.Errorf("expected Life 2 second, got %+v", got[1])
+    }
+}
+
+func TestSamePowerMatchesCatalogAbilityStoredAsAbility1(test *testing.T) {
+    catalogPower := Power{Type: PowerTypeAbility1, Ability: data.ItemAbilityFlaming}
+    itempowPower := Power{Type: PowerTypeAbility2, Ability: data.ItemAbilityFlaming}
+
+    if !samePower(catalogPower, itempowPower) {
+        test.Errorf("Flaming stored as Ability1 should match the itempow Ability2 entry")
+    }
+
+    if samePower(catalogPower, Power{Type: PowerTypeAbility1, Ability: data.ItemAbilityBless}) {
+        test.Errorf("different abilities should not match")
+    }
+}
+
+func TestFilterPowersForTypeDropsIncompatible(test *testing.T) {
+    flaming := Power{Type: PowerTypeAbility1, Ability: data.ItemAbilityFlaming, Name: "Flaming"}
+    item := &Artifact{
+        Type: ArtifactTypeSword,
+        Powers: []Power{
+            {Type: PowerTypeAttack, Amount: 3, Name: "+3 Attack"},
+            flaming,
+            {Type: PowerTypeSpellCharges, Amount: 2, Name: "Fireball x2"},
+        },
+    }
+
+    compat := map[Power]set.Set[ArtifactType]{
+        flaming: *set.NewSet(ArtifactTypeSword, ArtifactTypeAxe),
+    }
+
+    FilterPowersForType(item, ArtifactTypeShield, compat)
+
+    if item.Type != ArtifactTypeShield {
+        test.Errorf("expected type to change to shield")
+    }
+
+    if len(item.Powers) != 1 || item.Powers[0].Type != PowerTypeAttack {
+        test.Errorf("expected only the attack bonus to remain, got %+v", item.Powers)
+    }
+}

--- a/game/magic/artifact/create-artifact.go
+++ b/game/magic/artifact/create-artifact.go
@@ -323,8 +323,10 @@ func calculateCost(artifact *Artifact, costs map[Power]int) int {
 func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCache, fonts ArtifactFonts, picLow int, picHigh int, powerGroups [][]Power, costs map[Power]int, artifact *Artifact, customName *string, selectCount *int) []*uilib.UIElement {
     var elements []*uilib.UIElement
 
-    // image
-    artifact.Image = picLow
+    // image - keep a loaded catalog image if it is already in this type's range
+    if artifact.Image < picLow || artifact.Image > picHigh {
+        artifact.Image = picLow
+    }
 
     elements = append(elements, &uilib.UIElement{
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
@@ -487,6 +489,14 @@ func makePowersFull(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.ImageCac
         groupRight := printRight
 
         var lastPower *Power = nil
+        for i, power := range group {
+            if artifact.ContainsPower(power) {
+                groupSelect = i
+                last := power
+                lastPower = &last
+            }
+        }
+
         for i, power := range group {
             rect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth(power.Name, 1)), y + fonts.PowerFont.Height())
             if groupRight {
@@ -811,6 +821,15 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
         var lastPower *Power = nil
         selected := make([]bool, len(group))
         for i, power := range group {
+            if artifact.ContainsPower(power) {
+                groupSelect = i
+                last := power
+                lastPower = &last
+                selected[i] = true
+            }
+        }
+
+        for i, power := range group {
             artifactTypes := compatibilities[power]
             if artifactTypes.Contains(artifact.Type) && wizard.MagicLevel(power.Magic) >= power.Amount {
                 totalItems += 1
@@ -901,10 +920,19 @@ func makeAbilityElements(ui *uilib.UI, cache *lbx.LbxCache, imageCache *util.Ima
     // spell charges
     if len(availableSpells.Spells) > 0 && (artifact.Type == ArtifactTypeWand || artifact.Type == ArtifactTypeStaff) {
         xRect := image.Rect(x, y, x + int(fonts.PowerFont.MeasureTextWidth("Spell Charges", 1)), y + fonts.PowerFont.Height())
-        selected := false
+        selected := artifact.HasSpellCharges()
         totalItems += 1
 
         addedPower := Power{Type: PowerTypeNone}
+        if selected {
+            spell, charges := artifact.GetSpellCharge()
+            addedPower = Power{
+                Type: PowerTypeSpellCharges,
+                Spell: spell,
+                Amount: charges,
+                Name: fmt.Sprintf("%v x%v", spell.Name, charges),
+            }
+        }
 
         elements = append(elements, &uilib.UIElement{
             Rect: xRect,
@@ -1300,4 +1328,262 @@ func ShowCreateArtifactScreen(yield coroutine.YieldFunc, cache *lbx.LbxCache, cr
     ui.UnfocusElement()
 
     return currentArtifact, canceled
+}
+
+// unrestrictedWizard satisfies spellbook.Wizard with 11 books in every
+// realm so the Default Item Editor lists every compatible power, the way
+// ITEMMAKE does (it is a data editor, not a spell).
+type unrestrictedWizard struct {
+}
+
+func (unrestrictedWizard) MagicLevel(kind data.MagicType) int {
+    return 11
+}
+
+func (unrestrictedWizard) RetortEnabled(retort data.Retort) bool {
+    return false
+}
+
+// ShowDefaultItemEditor is the in-game ITEMMAKE replacement. It edits the
+// premade catalog in place (availability is unchanged) and returns when
+// the player clicks OK. draw is set each frame like ShowCreateArtifactScreen.
+func ShowDefaultItemEditor(yield coroutine.YieldFunc, cache *lbx.LbxCache, catalog *Catalog, availableSpells spellbook.Spells, draw *func(*ebiten.Image)) {
+    if catalog == nil || catalog.Len() == 0 {
+        return
+    }
+
+    fonts := makeFonts(cache)
+
+    imageCache := util.MakeImageCache(cache)
+
+    ui := &uilib.UI{
+        Cache: cache,
+        Draw: func(ui *uilib.UI, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            background, _ := imageCache.GetImage("spellscr.lbx", 13, 0)
+            scale.DrawScaled(screen, background, &options)
+
+            ui.StandardDraw(screen)
+        },
+    }
+
+    ui.SetElementsFromArray(nil)
+
+    powerEntries, costs, compatibilities, err := ReadPowers(cache)
+    if err != nil {
+        log.Printf("Unable to read item powers: %v", err)
+        return
+    }
+
+    wizard := unrestrictedWizard{}
+
+    currentIndex := 0
+    customName := ""
+    var currentArtifact *Artifact
+    var powerElements []*uilib.UIElement
+    var abilityElements []*uilib.UIElement
+    selectCount := 0
+
+    commitCurrent := func(){
+        if currentArtifact == nil {
+            return
+        }
+
+        currentArtifact.Name = getName(currentArtifact, customName)
+        currentArtifact.Cost = calculateCost(currentArtifact, costs)
+        currentArtifact.Requirements = RequirementsFromPowers(currentArtifact.Powers)
+        catalog.Replace(currentIndex, currentArtifact)
+    }
+
+    var selectedButton *uilib.UIElement
+    typeButtons := make(map[ArtifactType]*uilib.UIElement)
+
+    var refreshPowers func()
+    refreshPowers = func(){
+        ui.RemoveElements(powerElements)
+        ui.RemoveElements(abilityElements)
+
+        if currentArtifact == nil {
+            powerElements = nil
+            abilityElements = nil
+            return
+        }
+
+        picLow, picHigh := ImageRange(currentArtifact.Type)
+        ClampImageToType(currentArtifact)
+        groups := groupPowers(powerEntries, costs, compatibilities, currentArtifact.Type, CreationCreateArtifact)
+        selectCount = len(currentArtifact.Powers)
+        powerElements = makePowersFull(ui, cache, &imageCache, fonts, picLow, picHigh, groups, costs, currentArtifact, &customName, &selectCount)
+        abilityElements = makeAbilityElements(ui, cache, &imageCache, currentArtifact, &customName, fonts, powerEntries, compatibilities, costs, &selectCount, wizard, availableSpells)
+        ui.AddElements(powerElements)
+        ui.AddElements(abilityElements)
+    }
+
+    loadIndex := func(index int){
+        if catalog.Len() == 0 {
+            return
+        }
+
+        if index < 0 {
+            index = catalog.Len() - 1
+        }
+        if index >= catalog.Len() {
+            index = 0
+        }
+
+        currentIndex = index
+        currentArtifact = CloneArtifact(catalog.Slots[index])
+        if currentArtifact == nil {
+            currentArtifact = &Artifact{Type: ArtifactTypeSword, CatalogIndex: index}
+        }
+        NormalizePowers(currentArtifact, powerEntries)
+        customName = currentArtifact.Name
+        selectedButton = typeButtons[currentArtifact.Type]
+        refreshPowers()
+    }
+
+    makeButton := func(x int, y int, unselected int, selected int, item ArtifactType) *uilib.UIElement {
+        index := 0
+        imageRect, _ := imageCache.GetImage("spellscr.lbx", unselected, 0)
+        rect := util.ImageRect(x, y, imageRect)
+        return &uilib.UIElement{
+            Rect: rect,
+            PlaySoundLeftClick: true,
+            LeftClick: func(element *uilib.UIElement){
+                index = 1
+            },
+            LeftClickRelease: func(element *uilib.UIElement){
+                selectedButton = element
+                index = 0
+
+                if currentArtifact == nil {
+                    return
+                }
+
+                FilterPowersForType(currentArtifact, item, compatibilities)
+                ClampImageToType(currentArtifact)
+                currentArtifact.Name = getName(currentArtifact, customName)
+                refreshPowers()
+            },
+            Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+                var options ebiten.DrawImageOptions
+                options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
+                use := unselected
+                if selectedButton == element {
+                    use = selected
+                }
+                image, _ := imageCache.GetImage("spellscr.lbx", use, index)
+                scale.DrawScaled(screen, image, &options)
+            },
+        }
+    }
+
+    unselectedImageStart := 14
+    selectedImageStart := 25
+    tmpImage, _ := imageCache.GetImage("spellscr.lbx", unselectedImageStart, 0)
+
+    for i := 0; i < 10; i++ {
+        x := 156 + (i % 5) * (tmpImage.Bounds().Dx() + 2)
+        y := 3 + (i / 5) * (tmpImage.Bounds().Dy() + 2)
+
+        itemType := ArtifactType(i + 1)
+        button := makeButton(x, y, unselectedImageStart + i, selectedImageStart + i, itemType)
+        typeButtons[itemType] = button
+        ui.AddElement(button)
+    }
+
+    ui.AddElement(&uilib.UIElement{
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            cost := 0
+            if currentArtifact != nil {
+                cost = calculateCost(currentArtifact, costs)
+            }
+            fonts.PowerFontWhite.PrintOptions(screen, 198, 185, font.FontOptions{Scale: scale.ScaleAmount}, fmt.Sprintf("Cost: %v", cost))
+        },
+    })
+
+    leftImages, _ := imageCache.GetImages("spellscr.lbx", 35)
+    rightImages, _ := imageCache.GetImages("spellscr.lbx", 36)
+
+    itemLeftIndex := 0
+    itemLeftRect := util.ImageRect(40, 24, leftImages[0])
+    ui.AddElement(&uilib.UIElement{
+        Rect: itemLeftRect,
+        PlaySoundLeftClick: true,
+        LeftClick: func(element *uilib.UIElement){
+            itemLeftIndex = 1
+        },
+        LeftClickRelease: func(element *uilib.UIElement){
+            itemLeftIndex = 0
+            commitCurrent()
+            loadIndex(currentIndex - 1)
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(float64(itemLeftRect.Min.X), float64(itemLeftRect.Min.Y))
+            scale.DrawScaled(screen, leftImages[itemLeftIndex], &options)
+        },
+    })
+
+    itemRightIndex := 0
+    itemRightRect := util.ImageRect(118, 24, rightImages[0])
+    ui.AddElement(&uilib.UIElement{
+        Rect: itemRightRect,
+        PlaySoundLeftClick: true,
+        LeftClick: func(element *uilib.UIElement){
+            itemRightIndex = 1
+        },
+        LeftClickRelease: func(element *uilib.UIElement){
+            itemRightIndex = 0
+            commitCurrent()
+            loadIndex(currentIndex + 1)
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(float64(itemRightRect.Min.X), float64(itemRightRect.Min.Y))
+            scale.DrawScaled(screen, rightImages[itemRightIndex], &options)
+        },
+    })
+
+    ui.AddElement(&uilib.UIElement{
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            fonts.NameFont.PrintOptions(screen, 80, 25, font.FontOptions{Scale: scale.ScaleAmount, Justify: font.FontJustifyCenter}, fmt.Sprintf("Item #%v", currentIndex + 1))
+        },
+    })
+
+    quit := false
+
+    okButtons, _ := imageCache.GetImages("spellscr.lbx", 24)
+    okIndex := 0
+    okRect := util.ImageRect(281, 180, okButtons[0])
+    ui.AddElement(&uilib.UIElement{
+        Rect: okRect,
+        PlaySoundLeftClick: true,
+        LeftClick: func(element *uilib.UIElement){
+            okIndex = 1
+        },
+        LeftClickRelease: func(element *uilib.UIElement){
+            okIndex = 0
+            commitCurrent()
+            quit = true
+        },
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(float64(okRect.Min.X), float64(okRect.Min.Y))
+            scale.DrawScaled(screen, okButtons[okIndex], &options)
+        },
+    })
+
+    loadIndex(0)
+
+    *draw = func(screen *ebiten.Image) {
+        ui.Draw(ui, screen)
+    }
+
+    for !quit {
+        ui.StandardUpdate()
+        yield()
+    }
+
+    ui.UnfocusElement()
 }

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -156,6 +156,10 @@ type Artifact struct {
     Cost int
     Powers []Power
     Requirements []Requirement
+
+    // CatalogIndex is the ITEMDATA slot this artifact came from (0-249),
+    // or NotPremade if it was crafted in play.
+    CatalogIndex int
 }
 
 // if true then generally this artifact should be rendered with a glow around it

--- a/game/magic/artifact/serialize.go
+++ b/game/magic/artifact/serialize.go
@@ -12,6 +12,7 @@ type SerializedArtifact struct {
     Cost int `json:"cost"`
     Powers []SerializedPower `json:"powers"`
     Requirements []Requirement `json:"requirements"`
+    CatalogIndex int `json:"catalog-index"`
 }
 
 type SerializedPower struct {
@@ -75,6 +76,7 @@ func SerializeArtifact(artifact *Artifact) SerializedArtifact {
         Cost: artifact.Cost,
         Powers: serializePowers(artifact.Powers),
         Requirements: append(make([]Requirement, 0), artifact.Requirements...),
+        CatalogIndex: artifact.CatalogIndex,
     }
 }
 
@@ -86,5 +88,6 @@ func ReconstructArtifact(serialized *SerializedArtifact, allSpells spellbook.Spe
         Cost: serialized.Cost,
         Powers: reconstructPowers(serialized.Powers, allSpells),
         Requirements: serialized.Requirements,
+        CatalogIndex: serialized.CatalogIndex,
     }
 }

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -116,6 +116,9 @@ type GameEventCartographer struct {
 type GameEventNextTurn struct {
 }
 
+type GameEventDefaultItemEditor struct {
+}
+
 type GameEventSpellOfMasteryComplete struct {
     Player *playerlib.Player
 }
@@ -512,19 +515,14 @@ func (loader *DummyGameLoader) LoadNew(path string) error {
     return errors.New("cannot load")
 }
 
-func createArtifactPool(lbxCache *lbx.LbxCache) map[string]*artifact.Artifact {
+func createArtifactPool(lbxCache *lbx.LbxCache) *artifact.Catalog {
     artifacts, err := artifact.ReadArtifacts(lbxCache)
     if err != nil {
         log.Printf("Error reading artifacts")
-        return nil
+        return artifact.MakeCatalog(nil)
     }
 
-    pool := make(map[string]*artifact.Artifact)
-    for _, artifact := range artifacts {
-        pool[artifact.Name] = &artifact
-    }
-
-    return pool
+    return artifact.MakeCatalog(artifacts)
 }
 
 func MakeGame(lbxCache *lbx.LbxCache, music *musiclib.Music, gameSettings *settingslib.Settings, settings setup.NewGameSettings) *Game {
@@ -2052,9 +2050,9 @@ func (game *Game) maybeBuyFromMerchant(player *playerlib.Player) {
     }
 
     var artifactCandidates []*artifact.Artifact
-    for _, artifact := range game.Model.ArtifactPool {
+    for _, candidate := range game.Model.ArtifactPool.AvailableArtifacts() {
         requirementsMet := true
-        for _, requirement := range artifact.Requirements {
+        for _, requirement := range candidate.Requirements {
             if requirement.Amount > 12 {
                 requirementsMet = false
                 break
@@ -2064,7 +2062,7 @@ func (game *Game) maybeBuyFromMerchant(player *playerlib.Player) {
             continue
         }
 
-        artifactCandidates = append(artifactCandidates, artifact)
+        artifactCandidates = append(artifactCandidates, candidate)
     }
     if len(artifactCandidates) == 0 {
         return
@@ -2099,7 +2097,7 @@ func (game *Game) maybeBuyFromMerchant(player *playerlib.Player) {
     result := func(bought bool) {
         quit = true
         if bought {
-            delete(game.Model.ArtifactPool, artifact.Name)
+            game.Model.ArtifactPool.Award(artifact)
             player.Gold -= cost
             game.doVault(yield, artifact)
         }
@@ -2432,6 +2430,8 @@ func (game *Game) ProcessEvents(yield coroutine.YieldFunc) {
                     case *GameEventSpellOfMasteryComplete:
                         masteryEvent := event.(*GameEventSpellOfMasteryComplete)
                         game.doSpellOfMasteryVictory(yield, masteryEvent.Player)
+                    case *GameEventDefaultItemEditor:
+                        game.doDefaultItemEditor(yield)
                     case *GameEventSurveyor:
                         game.doSurveyor(yield)
                     case *GameEventCartographer:
@@ -4405,11 +4405,7 @@ func (game *Game) createTreasure(encounterType maplib.EncounterType, budget int,
         }
 
         makeArtifacts := func () []*artifact.Artifact {
-            var out []*artifact.Artifact
-            for _, artifact := range game.Model.ArtifactPool {
-                out = append(out, artifact)
-            }
-            return out
+            return game.Model.ArtifactPool.AvailableArtifacts()
         }
 
         // cannot find the last spell in treasure
@@ -4519,7 +4515,7 @@ func (game *Game) ApplyTreasure(yield coroutine.YieldFunc, player *playerlib.Pla
                     }
                 }
                 // if the treasure was one of the premade artifacts, then remove it from the pool
-                delete(game.Model.ArtifactPool, magicalItem.Artifact.Name)
+                game.Model.ArtifactPool.Award(magicalItem.Artifact)
             case *TreasurePrisonerHero:
                 hero := item.(*TreasurePrisonerHero)
                 if player.IsHuman() {
@@ -5399,6 +5395,16 @@ func (game *Game) MakeInfoUI(cornerX int, cornerY int) []*uilib.UIElement {
     return uilib.MakeSelectionUI(game.HudUI, game.Cache, &game.ImageCache, cornerX, cornerY, "Select An Advisor", advisors, true)
 }
 
+func (game *Game) doDefaultItemEditor(yield coroutine.YieldFunc) {
+    drawFunc := func(screen *ebiten.Image){}
+    game.PushDrawer(func(screen *ebiten.Image){
+        drawFunc(screen)
+    })
+    defer game.PopDrawer()
+
+    artifact.ShowDefaultItemEditor(yield, game.Cache, game.Model.ArtifactPool, game.AllSpells().CombatSpells(false), &drawFunc)
+}
+
 func (game *Game) ShowSpellBookCastUI(yield coroutine.YieldFunc, player *playerlib.Player){
     overlandSpells := player.KnownSpells.OverlandSpells()
     // don't show this spell in the spellbook, it will be cast automatically
@@ -5891,6 +5897,11 @@ func (game *Game) MakeHudUI() *uilib.UI {
                                 game.Model.SwitchPlane()
                                 game.doPlanarTraval()
                                 game.RefreshUI()
+                            case keybindings.Get(keybinds.ActionDefaultItemEditor):
+                                select {
+                                    case game.Events <- &GameEventDefaultItemEditor{}:
+                                    default:
+                                }
 
                             case ebiten.KeyTab:
                                 if !game.DebugMode {

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -32,7 +32,7 @@ type GameModel struct {
     Players []*playerlib.Player
     Plane data.Plane
 
-    ArtifactPool map[string]*artifact.Artifact
+    ArtifactPool *artifact.Catalog
 
     Settings setup.NewGameSettings
 
@@ -64,7 +64,7 @@ type GameModel struct {
 func MakeGameModel(terrainData *terrain.TerrainData, settings setup.NewGameSettings,
                    startingPlane data.Plane, events chan GameEvent,
                    heroNames map[int]map[herolib.HeroType]string, allSpells spellbook.Spells,
-                   artifactPool map[string]*artifact.Artifact,
+                   artifactPool *artifact.Catalog,
                    buildingInfo buildinglib.BuildingInfos,
                ) *GameModel {
 
@@ -1074,9 +1074,9 @@ func (model *GameModel) DoRandomEvents() {
                         return MakePiracyEvent(model.TurnNumber, gold, target), nil
                     case RandomEventGift:
                         var out []*artifact.Artifact
-                        for _, artifact := range model.ArtifactPool {
-                            if canUseArtifact(artifact, target.Wizard) {
-                                out = append(out, artifact)
+                        for _, candidate := range model.ArtifactPool.AvailableArtifacts() {
+                            if canUseArtifact(candidate, target.Wizard) {
+                                out = append(out, candidate)
                             }
                         }
 
@@ -1087,7 +1087,7 @@ func (model *GameModel) DoRandomEvents() {
 
                         use := out[rand.N(len(out))]
 
-                        delete(model.ArtifactPool, use.Name)
+                        model.ArtifactPool.Award(use)
 
                         // returning GameEventVault here is ugly but we need a way to have the vault event
                         // be added to game.Events after the random event

--- a/game/magic/game/serialize.go
+++ b/game/magic/game/serialize.go
@@ -2,8 +2,6 @@ package game
 
 import (
     "time"
-    "maps"
-    "slices"
     "log"
 
     "github.com/kazzmir/master-of-magic/game/magic/ai"
@@ -73,7 +71,11 @@ type SerializedGame struct {
     Arcanus maplib.SerializedMap `json:"arcanus"`
     Myrror maplib.SerializedMap `json:"myrror"`
     Plane data.Plane `json:"plane"`
-    ArtifactPool []string `json:"artifact-pool"`
+    // ArtifactPool is the old remaining-name list. New saves also write
+    // ArtifactCatalog + ArtifactAvailable; load prefers those when present.
+    ArtifactPool []string `json:"artifact-pool,omitempty"`
+    ArtifactCatalog []artifact.SerializedArtifact `json:"artifact-catalog,omitempty"`
+    ArtifactAvailable []bool `json:"artifact-available,omitempty"`
     Settings setup.NewGameSettings `json:"settings"`
     CurrentPlayer int `json:"current-player"`
     Turn uint64 `json:"turn"`
@@ -96,7 +98,9 @@ func SerializeModel(model *GameModel, saveName string) SerializedGame {
         },
         Arcanus: maplib.SerializeMap(model.ArcanusMap),
         Myrror: maplib.SerializeMap(model.MyrrorMap),
-        ArtifactPool: slices.Collect(maps.Keys(model.ArtifactPool)),
+        ArtifactPool: model.ArtifactPool.AvailableNames(),
+        ArtifactCatalog: model.ArtifactPool.Serialize(),
+        ArtifactAvailable: model.ArtifactPool.AvailableMask(),
         Plane:  model.Plane,
         Settings: model.Settings,
         CurrentPlayer: model.CurrentPlayer,
@@ -107,16 +111,12 @@ func SerializeModel(model *GameModel, saveName string) SerializedGame {
     }
 }
 
-func reconstructArtifactPool(items []string, artifactPool map[string]*artifact.Artifact) map[string]*artifact.Artifact {
-    out := make(map[string]*artifact.Artifact)
-
-    for _, itemName := range items {
-        if item, ok := artifactPool[itemName]; ok {
-            out[itemName] = item
-        }
+func reconstructArtifactPool(serializedGame *SerializedGame, vanilla *artifact.Catalog, allSpells spellbook.Spells) *artifact.Catalog {
+    if len(serializedGame.ArtifactCatalog) > 0 {
+        return artifact.ReconstructCatalog(serializedGame.ArtifactCatalog, serializedGame.ArtifactAvailable, allSpells)
     }
 
-    return out
+    return vanilla.WithAvailableNames(serializedGame.ArtifactPool)
 }
 
 func reconstructRandomEvents(serializedEvents []SerializedRandomEvent, model *GameModel) []*RandomEvent {
@@ -163,13 +163,13 @@ func MakeModelFromSerialized(
     serializedGame *SerializedGame, events chan GameEvent,
     heroNames map[int]map[herolib.HeroType]string,
     allSpells spellbook.Spells,
-    artifactPool map[string]*artifact.Artifact,
+    artifactPool *artifact.Catalog,
     buildingInfo buildinglib.BuildingInfos,
     terrainData *terrain.TerrainData,
 ) *GameModel {
     model := &GameModel{
         Plane: serializedGame.Plane,
-        ArtifactPool: reconstructArtifactPool(serializedGame.ArtifactPool, artifactPool),
+        ArtifactPool: reconstructArtifactPool(serializedGame, artifactPool, allSpells),
         Settings: serializedGame.Settings,
         heroNames: heroNames,
         allSpells: allSpells,

--- a/game/magic/keybinds/keybinds.go
+++ b/game/magic/keybinds/keybinds.go
@@ -105,7 +105,8 @@ func (action Action) Default() ebiten.Key {
         case ActionMirror: return ebiten.KeyF9
         case ActionNextTurn: return ebiten.KeyN
         case ActionQuitWithoutSaving: return Unbound
-        case ActionDefaultItemEditor: return Unbound
+        // remake default: original/CP left this unbound. E is free.
+        case ActionDefaultItemEditor: return ebiten.KeyE
     }
 
     return Unbound

--- a/game/magic/keybinds/keybinds.go
+++ b/game/magic/keybinds/keybinds.go
@@ -30,6 +30,7 @@ const (
     ActionMirror
     ActionNextTurn
     ActionQuitWithoutSaving
+    ActionDefaultItemEditor
 )
 
 // AllActions lists every rebindable action, in the order they should be
@@ -53,6 +54,7 @@ var AllActions = []Action{
     ActionMirror,
     ActionNextTurn,
     ActionQuitWithoutSaving,
+    ActionDefaultItemEditor,
 }
 
 func (action Action) Name() string {
@@ -75,6 +77,7 @@ func (action Action) Name() string {
         case ActionMirror: return "Mirror"
         case ActionNextTurn: return "Next Turn"
         case ActionQuitWithoutSaving: return "Quit Without Saving"
+        case ActionDefaultItemEditor: return "Default Item Editor"
     }
 
     return "Unknown"
@@ -102,6 +105,7 @@ func (action Action) Default() ebiten.Key {
         case ActionMirror: return ebiten.KeyF9
         case ActionNextTurn: return ebiten.KeyN
         case ActionQuitWithoutSaving: return Unbound
+        case ActionDefaultItemEditor: return Unbound
     }
 
     return Unbound

--- a/game/magic/load/convert.go
+++ b/game/magic/load/convert.go
@@ -1426,6 +1426,10 @@ func (saveGame *SaveGame) Convert(cache *lbx.LbxCache, music *musiclib.Music, se
     game.Model.TurnNumber = uint64(saveGame.Turn)
 
     artifacts := saveGame.convertArtifacts(game.AllSpells())
+    // DOS saves store a 250-byte mask of which ITEMDATA slots are still
+    // available; apply that first, then also award anything already in play
+    // (name match) so a missing/zero mask still drops found premade items.
+    game.Model.ArtifactPool.ApplyAvailabilityBitmap(saveGame.PremadeItems)
     // artifacts that are in the game are removed from the pool
     // because the ones in the pool are the ones not found yet.
     // an artifact that is not in the pool must have been created
@@ -1435,10 +1439,7 @@ func (saveGame *SaveGame) Convert(cache *lbx.LbxCache, music *musiclib.Music, se
             continue
         }
 
-        _, ok := game.Model.ArtifactPool[artifact.Name]
-        if ok {
-            delete(game.Model.ArtifactPool, artifact.Name)
-        }
+        game.Model.ArtifactPool.Award(artifact)
     }
 
     /*

--- a/test/artifact/main.go
+++ b/test/artifact/main.go
@@ -84,6 +84,32 @@ func (engine *Engine) ArtifactRoutine() func (coroutine.YieldFunc) error {
     }
 }
 
+func (engine *Engine) EditorRoutine() func (coroutine.YieldFunc) error {
+    spells, err := spellbook.ReadSpellsFromCache(engine.Cache)
+    if err != nil {
+        log.Printf("Unable to read spells: %v", err)
+    }
+
+    items, err := artifact.ReadArtifacts(engine.Cache)
+    if err != nil {
+        log.Printf("Unable to read artifacts: %v", err)
+        return func(yield coroutine.YieldFunc) error {
+            return nil
+        }
+    }
+
+    catalog := artifact.MakeCatalog(items)
+
+    return func(yield coroutine.YieldFunc) error {
+        artifact.ShowDefaultItemEditor(yield, engine.Cache, catalog, spells.CombatSpells(false), &engine.Drawer)
+        log.Printf("Default item editor closed, %v slots", catalog.Len())
+        if catalog.Len() > 0 {
+            log.Printf("Slot 0: %+v", catalog.Slots[0])
+        }
+        return nil
+    }
+}
+
 func (engine *Engine) Update() error {
     engine.Counter += 1
     inputmanager.Update()
@@ -103,6 +129,10 @@ func (engine *Engine) Update() error {
                 engine.ShowUpdate = 60
                 engine.Coroutine = coroutine.MakeCoroutine(engine.ArtifactRoutine())
                 log.Printf("Artificer %v Runemaster %v", engine.Books.Artificer, engine.Books.Runemaster)
+            case ebiten.KeyF3:
+                engine.ShowUpdate = 60
+                engine.Coroutine = coroutine.MakeCoroutine(engine.EditorRoutine())
+                log.Printf("Default item editor")
         }
     }
 

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -1666,7 +1666,7 @@ func createScenario17(cache *lbx.LbxCache) *gamelib.Game {
         Cost: 300,
     }
 
-    player.VaultEquipment[1] = game.Model.ArtifactPool["Pummel Mace"]
+    player.VaultEquipment[1] = game.Model.ArtifactPool.FindByName("Pummel Mace")
 
     testArtifact := artifact.Artifact{
         Name: "Sword",
@@ -2477,7 +2477,7 @@ func createScenario25(cache *lbx.LbxCache) *gamelib.Game {
     }, false)
     enemy.AddUnit(units.MakeOverworldUnitFromUnit(units.KlackonSpearmen, x + 1, y + 1, data.PlaneArcanus, enemy.Wizard.Banner, enemy.MakeExperienceInfo(), enemy.MakeUnitEnchantmentProvider()))
 
-    artifact := game.Model.ArtifactPool["Pummel Mace"]
+    artifact := game.Model.ArtifactPool.FindByName("Pummel Mace")
 
     game.Events <- &gamelib.GameEventMerchant{
         Player: player,


### PR DESCRIPTION
## Summary
Community-patch-style **Default Item Editor**: an in-game replacement for
ITEMMAKE.EXE. The overland action opens the Enchant Item / Create Artifact
UI plus **Item #N** arrows so you can browse and edit the 250-slot premade
catalog.

- `artifact.Catalog` is now the source of truth for premade items: a
  250-slot slice plus an availability mask (identity is the slot index,
  not the name). Treasure, merchants, gifts, and DOS-save import award by
  index; already-awarded slots stay awarded even if you rewrite them.
- `ShowDefaultItemEditor` reuses the create-artifact helpers. No wizard
  book filter, raw item cost (not spell cost), OK writes the current slot
  and closes. Browsing Item # commits the current slot first.
- Realm requirements are written by color (Insecticide), not official
  ITEMMAKE's power-slot order.
- `keybinds`: new `ActionDefaultItemEditor`, shown on the Keys screen,
  default **E** (unused by the original A/G/I/M/N/P/S + F1–F9 set; C left
  free for Cities, F10 left for a future Quick Save). The Community Patch
  left this action unbound; we bind E so the editor is discoverable.
- `test/artifact`: F3 opens the editor against a live catalog.

## Save format
New games still start from vanilla `itemdata.lbx`. Edits persist **in the
current campaign save only**.

Old saves stored remaining premade items as a name list:

```json
"artifact-pool": ["Pummel Mace", "..."]
```

On load those names were looked up in a fresh `ReadArtifacts()` from
`itemdata.lbx`, so an in-memory edit could not survive save/load.

New saves still write that name list (so older builds can load the file
and reconstruct availability from vanilla `itemdata.lbx`), and add:

```json
"artifact-catalog": [ { "name": "...", "type": ..., "powers": [...], ... } ],
"artifact-available": [true, false, ...]
```

Load prefers `artifact-catalog` + `artifact-available` when the catalog
array is non-empty. Old saves without those fields keep working via the
name list + vanilla `itemdata.lbx`.

`SerializedArtifact` also gains `catalog-index` so a slot keeps its
ITEMDATA index across the round trip.

## What this does not do
- **Does not write `itemdata.lbx`.** ITEMMAKE and the Community Patch
  in-game editor both wrote the data file, so the next *new* game would
  see the edited catalog. We have no LBX writer, WASM cannot usefully
  write the copyrighted data files, and this remake should not mutate
  `data/mom/*.LBX`. A sidecar override for cross-game persistence would
  be a follow-up.
- Does not change items already sitting on heroes or in the vault.
- Does not start Enchant Item / Create Artifact, and does not reproduce
  the official ITEMMAKE book-requirement bug.

## Notes
- Headless tests in `artifact/catalog_test.go` cover award vs replace,
  old-save name lists, serialize round-trip of an edited unused slot, and
  realm-correct requirements.
- Verified: `go test ./...`, native `go build ./game/magic`, and
  `GOOS=js GOARCH=wasm go build` all pass.

Open as draft for manual in-game review (bind is E; or `go run ./test/artifact` and press F3).