### PR TITLE
game: do not path a stack onto land if it contains a ship

### DIFF
--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -221,8 +221,12 @@ func (model *GameModel) FindPath(oldX int, oldY int, newX int, newY int, player 
         tileTo := useMap.GetTile(newX, newY)
         tileFrom := useMap.GetTile(oldX, oldY)
 
-        // if this is a water unit that cannot walk on land then just return nil immediately since the move is impossible
-        if tileTo.Tile.IsLand() && !stack.CanMoveOnLand(true) {
+        // if this stack contains a water-bound unit (a ship) that cannot walk on
+        // land then the move onto land is impossible. Check ALL units, not just
+        // the active ones: AI movement does not split inactive units off the
+        // stack (see doAiMoveUnit), so an inactive ship must not be dragged
+        // ashore when the active land units walk inland.
+        if tileTo.Tile.IsLand() && !stack.CanMoveOnLand(false) {
             return nil, false
         }
 
@@ -495,9 +499,11 @@ func (model *GameModel) ComputeTerrainCost(stack playerlib.PathStack, sourceX in
         return false
     }
 
-    // sailing units cannot move onto land
+    // sailing units cannot move onto land. Check ALL units (not just active
+    // ones) so an inactive ship in the stack is never dragged ashore when the
+    // active land units walk onto land.
     if tileTo.Tile.IsLand() {
-        if !stack.CanMoveOnLand(true) {
+        if !stack.CanMoveOnLand(false) {
             return fraction.Zero(), false
         }
     }

--- a/game/magic/game/path_test.go
+++ b/game/magic/game/path_test.go
@@ -199,4 +199,41 @@ func TestPathBasic(test *testing.T) {
     if !checkValidPathUnexplored(2, 1, units.HighMenSwordsmen) {
         test.Errorf("Land walker should be able to path to unexplored water tile")
     }
+
+    // an inactive ship sharing a stack with active land units must not be
+    // dragged onto land. AI movement does not split inactive units off first
+    // (human movement does), so pathfinding has to reject the move.
+    func() {
+        player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
+
+        warship := player1.AddUnit(units.MakeOverworldUnit(units.Warship, 1, 0, data.PlaneArcanus))
+        swordsmen := player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 1, 0, data.PlaneArcanus))
+
+        stack := player1.FindStack(1, 0, data.PlaneArcanus)
+        stack.SetActive(warship, false)
+        stack.SetActive(swordsmen, true)
+
+        path, ok := model.FindPath(1, 0, 2, 0, player1, stack, fog)
+        if ok && len(path) > 0 {
+            test.Errorf("stack with an inactive ship must not path from water onto land")
+        }
+    }()
+
+    // same rule once the mixed stack is already on the coast: active land
+    // units must not walk further inland while the ship is still in the stack
+    func() {
+        player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
+
+        warship := player1.AddUnit(units.MakeOverworldUnit(units.Warship, 2, 0, data.PlaneArcanus))
+        swordsmen := player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 2, 0, data.PlaneArcanus))
+
+        stack := player1.FindStack(2, 0, data.PlaneArcanus)
+        stack.SetActive(warship, false)
+        stack.SetActive(swordsmen, true)
+
+        path, ok := model.FindPath(2, 0, 3, 0, player1, stack, fog)
+        if ok && len(path) > 0 {
+            test.Errorf("stack with an inactive ship must not path further inland")
+        }
+    }()
 }

--- a/game/magic/game/path_test.go
+++ b/game/magic/game/path_test.go
@@ -201,8 +201,10 @@ func TestPathBasic(test *testing.T) {
     }
 
     // an inactive ship sharing a stack with active land units must not be
-    // dragged onto land. AI movement does not split inactive units off first
-    // (human movement does), so pathfinding has to reject the move.
+    // dragged onto land. Ships only occupy ocean/shore (both !IsLand), so
+    // the case that matters is water -> land. AI movement does not split
+    // inactive units off first (human movement does), so pathfinding has
+    // to reject the move.
     func() {
         player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
 
@@ -216,24 +218,6 @@ func TestPathBasic(test *testing.T) {
         path, ok := model.FindPath(1, 0, 2, 0, player1, stack, fog)
         if ok && len(path) > 0 {
             test.Errorf("stack with an inactive ship must not path from water onto land")
-        }
-    }()
-
-    // same rule once the mixed stack is already on the coast: active land
-    // units must not walk further inland while the ship is still in the stack
-    func() {
-        player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
-
-        warship := player1.AddUnit(units.MakeOverworldUnit(units.Warship, 2, 0, data.PlaneArcanus))
-        swordsmen := player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 2, 0, data.PlaneArcanus))
-
-        stack := player1.FindStack(2, 0, data.PlaneArcanus)
-        stack.SetActive(warship, false)
-        stack.SetActive(swordsmen, true)
-
-        path, ok := model.FindPath(2, 0, 3, 0, player1, stack, fog)
-        if ok && len(path) > 0 {
-            test.Errorf("stack with an inactive ship must not path further inland")
         }
     }()
 }


### PR DESCRIPTION
## Summary
Split out of [#716](https://github.com/kazzmir/master-of-magic/pull/716) as requested in review.

AI movement (`doAiMoveUnit`) does not split inactive units off the stack
before pathing (there is a FIXME). `CanMoveOnLand(true)` only looks at
active units, so an inactive warship rides inland with the swordsmen —
the ship-on-land screenshot on #716.

`FindPath` and `ComputeTerrainCost` now call `CanMoveOnLand(false)` for
land destinations so **any** ship in the stack blocks a land move.

Human movement is unchanged: it already splits inactive units off before
`FindPath`.

## Tests
`path_test.go`:
- water tile, inactive Warship + active Swordsmen → no path onto land
- coast tile, same mix → no path further inland

`go test ./game/magic/game/ -run TestPathBasic` passes.