### PR TITLE
ai: rebase #716 goal planning and apply review notes

### DIFF
--- a/game/magic/ai/enemy2.go
+++ b/game/magic/ai/enemy2.go
@@ -13,11 +13,14 @@ package ai
  */
 
 import (
+    "fmt"
     "log"
     "slices"
     "cmp"
+    "math"
     "math/rand/v2"
     "image"
+    "strings"
 
     "github.com/kazzmir/master-of-magic/lib/functional"
     "github.com/kazzmir/master-of-magic/lib/set"
@@ -32,16 +35,175 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/maplib"
     "github.com/kazzmir/master-of-magic/game/magic/units"
-    // "github.com/kazzmir/master-of-magic/game/magic/spellbook"
+    "github.com/kazzmir/master-of-magic/game/magic/spellbook"
 )
 
 type Enemy2AI struct {
     // units that are currently moving towards an enemy
     Attacking map[*playerlib.UnitStack]bool
+
+    // a catalogue of every lair / encounter / magic node this wizard has
+    // discovered (explored the tile of). Persists across turns. Once a stack
+    // gets a look at the contents (the tile becomes visible) the entry is
+    // marked Scouted and its monster Strength is recorded so the AI can decide
+    // whether it can field an army strong enough to clear it.
+    KnownLairs map[LairKey]*LairInfo
+
+    // a memory of every enemy city this wizard has scouted (explored the tile
+    // of). Persists across turns so the AI can mount an offensive toward a city
+    // it discovered earlier even after losing sight of it. Entries are forgotten
+    // once we can see the tile and the enemy city is no longer there (razed or
+    // captured).
+    KnownEnemyCities map[CityKey]*EnemyCityInfo
+
+    // a snapshot of the goals/decisions computed on the most recent Update,
+    // used by the watch-mode debug overlay (press D). Not used for gameplay.
+    LastGoalDebug []GoalDebugInfo
+
+    // a human-readable description of what each stack was last told to do this
+    // turn (e.g. "attacking enemy stack", "scouting a lair", "settling a city").
+    // Rebuilt every Update; used only by the watch-mode inspector. Not gameplay.
+    StackActivity map[*playerlib.UnitStack]string
+
+    // cities that GoalBuildCities has reserved for settler production this turn.
+    // GoalDefendCities runs after GoalBuildCities and the engine applies
+    // AIProduceDecision with a last-wins override (game.go), so without this
+    // reservation a defender build would clobber the just-queued settler and the
+    // empire would never actually finish a settler. Rebuilt every Update.
+    reservedSettlerCities map[*citylib.City]bool
 }
 
 func MakeEnemy2AI() *Enemy2AI {
-    return &Enemy2AI{}
+    return &Enemy2AI{
+        KnownLairs: make(map[LairKey]*LairInfo),
+        KnownEnemyCities: make(map[CityKey]*EnemyCityInfo),
+        StackActivity: make(map[*playerlib.UnitStack]string),
+    }
+}
+
+// setActivity records what a stack is currently being directed to do, for the
+// watch-mode inspector. Purely informational.
+func (ai *Enemy2AI) setActivity(stack *playerlib.UnitStack, activity string) {
+    if ai.StackActivity == nil {
+        ai.StackActivity = make(map[*playerlib.UnitStack]string)
+    }
+    ai.StackActivity[stack] = activity
+}
+
+// StackActivityFor returns a human-readable description of what the given stack
+// is currently doing (as last decided by the AI this turn), or "" if unknown.
+func (ai *Enemy2AI) StackActivityFor(stack *playerlib.UnitStack) string {
+    if ai.StackActivity == nil {
+        return ""
+    }
+    return ai.StackActivity[stack]
+}
+
+// describeTravelIntent classifies why a stack is moving toward (destX,destY),
+// for the watch-mode inspector. When a stack is just resuming a path the goal
+// that originally set it isn't re-run, so we reconstruct the intent from what
+// the AI knows about the destination tile (remembered enemy cities, catalogued
+// lairs/nodes/towers, or unexplored fog). Purely informational.
+func (ai *Enemy2AI) describeTravelIntent(self *playerlib.Player, stack *playerlib.UnitStack, destX int, destY int) string {
+    plane := stack.Plane()
+
+    // heading for a city we remember belonging to an enemy?
+    if _, ok := ai.KnownEnemyCities[CityKey{X: destX, Y: destY, Plane: plane}]; ok {
+        return fmt.Sprintf("marching on enemy city at (%d,%d)", destX, destY)
+    }
+
+    // heading for a known lair / node / plane tower?
+    if lair, ok := ai.KnownLairs[LairKey{X: destX, Y: destY, Plane: plane}]; ok {
+        if lair.Type == maplib.EncounterTypePlaneTower {
+            return fmt.Sprintf("traveling to plane tower at (%d,%d)", destX, destY)
+        }
+        if lair.Scouted {
+            return fmt.Sprintf("moving to clear a lair at (%d,%d)", destX, destY)
+        }
+        return fmt.Sprintf("scouting a lair at (%d,%d)", destX, destY)
+    }
+
+    // heading into the fog to reveal new territory?
+    if !self.IsExplored(destX, destY, plane) {
+        return fmt.Sprintf("scouting unexplored territory near (%d,%d)", destX, destY)
+    }
+
+    return fmt.Sprintf("repositioning to (%d,%d)", destX, destY)
+}
+
+// LairKey uniquely identifies a discovered lair/encounter by location.
+type LairKey struct {
+    X, Y int
+    Plane data.Plane
+}
+
+// LairInfo is the AI's catalogued knowledge about one lair / encounter / node.
+type LairInfo struct {
+    X, Y int
+    Plane data.Plane
+    Type maplib.EncounterType
+    // Scouted is true once the AI has actually seen the contents (computed a
+    // Strength). Before that we only know a lair exists at this location.
+    Scouted bool
+    // Strength is the combat strength of the defending monsters, valid only
+    // when Scouted is true.
+    Strength int
+}
+
+// CityKey uniquely identifies a remembered enemy city by location.
+type CityKey struct {
+    X, Y int
+    Plane data.Plane
+}
+
+// EnemyCityInfo is the AI's remembered knowledge about an enemy city it has
+// scouted, so it can march on it later even after losing sight of the tile.
+type EnemyCityInfo struct {
+    X, Y int
+    Plane data.Plane
+}
+
+// margin by which a stack's combat strength must exceed a lair's defenders
+// before the AI commits to attacking it. The strength estimate ignores some
+// factors (combat spells, terrain, exact ability matchups) so we keep a safety
+// buffer rather than attacking on a razor-thin advantage. Raised from 1.25 by a
+// further 20% because the AI was losing raids too easily.
+const lairAttackMargin = 1.5
+
+// requiredLairMargin scales the combat-strength surplus the AI demands before
+// committing to a lair/node, based on how strong the defenders are. Weak lairs
+// can be cleared opportunistically on a modest advantage, but strong lairs are
+// only worth attacking when the AI has "plenty of spare army" — a big surplus —
+// because losing an elite stack to a tough lair is far costlier than skipping
+// it. Because a lair's recorded strength is recomputed from its current
+// defenders whenever the AI can see it, partially-cleared lairs naturally fall
+// into a lower band over time and become attractive targets again.
+func requiredLairMargin(lairStrength int) float32 {
+    switch {
+    case lairStrength <= 0:
+        return lairAttackMargin
+    case lairStrength < 150:
+        return 1.25
+    case lairStrength < 400:
+        return 1.5
+    case lairStrength < 800:
+        return 2.0
+    default:
+        return 2.5
+    }
+}
+
+// GoalDebugInfo is a read-only snapshot of one goal node (and its subgoals)
+// produced during a single Update, for display in the watch-mode debug menu.
+type GoalDebugInfo struct {
+    Goal GoalType
+    Weight float32
+    // true if this goal was skipped because the same goal type was already
+    // processed this turn (the seenGoals dedup)
+    Skipped bool
+    // human-readable summaries of the decisions this goal produced (not including subgoals)
+    Decisions []string
+    SubGoals []GoalDebugInfo
 }
 
 type GoalType int
@@ -57,7 +219,63 @@ const (
     GoalBuildArmy
     GoalIncreasePower
     GoalMeldNodes
+    GoalConnectCities // build engineers and roads to connect our cities
+    GoalEnchantUnits // cast beneficial unit enchantments (scout mobility + elite buffs)
+    GoalPlanarTravel // use open plane towers to expand onto the other plane
 )
+
+func (goal GoalType) String() string {
+    switch goal {
+        case GoalNone: return "None"
+        case GoalDefeatEnemies: return "Defeat Enemies"
+        case GoalBuildCities: return "Build Cities"
+        case GoalExploreTerritory: return "Explore Territory"
+        case GoalResearchMagic: return "Research Magic"
+        case GoalCastSpellOfMastery: return "Cast Spell of Mastery"
+        case GoalDefendCities: return "Defend Cities"
+        case GoalBuildArmy: return "Build Army"
+        case GoalIncreasePower: return "Increase Power"
+        case GoalMeldNodes: return "Meld Nodes"
+        case GoalConnectCities: return "Connect Cities"
+        case GoalEnchantUnits: return "Enchant Units"
+        case GoalPlanarTravel: return "Planar Travel"
+    }
+    return fmt.Sprintf("Goal(%d)", int(goal))
+}
+
+// describeDecision returns a short human-readable summary of an AI decision,
+// for the watch-mode debug overlay.
+func describeDecision(decision playerlib.AIDecision, buildingInfo buildinglib.BuildingInfos) string {
+    switch d := decision.(type) {
+        case *playerlib.AIProduceDecision:
+            if !d.Unit.IsNone() {
+                return fmt.Sprintf("%v: produce %v", d.City.Name, d.Unit.Name)
+            }
+            return fmt.Sprintf("%v: build %v", d.City.Name, buildingInfo.Name(d.Building))
+        case *playerlib.AIMoveStackDecision:
+            dest := ""
+            if len(d.Path) > 0 {
+                last := d.Path[len(d.Path)-1]
+                dest = fmt.Sprintf(" -> (%v,%v)", last.X, last.Y)
+            }
+            return fmt.Sprintf("move stack (%v,%v)%v", d.Stack.X(), d.Stack.Y(), dest)
+        case *playerlib.AIBuildOutpostDecision:
+            return fmt.Sprintf("build outpost (%v,%v)", d.Stack.X(), d.Stack.Y())
+        case *playerlib.AIBuildRoadDecision:
+            return fmt.Sprintf("build road (%v,%v) -> (%v,%v)", d.Stack.X(), d.Stack.Y(), d.X, d.Y)
+        case *playerlib.AIMeldNodeDecision:
+            return fmt.Sprintf("meld node (%v,%v)", d.Stack.X(), d.Stack.Y())
+        case *playerlib.AIPlaneShiftDecision:
+            return fmt.Sprintf("plane shift (%v,%v)", d.Stack.X(), d.Stack.Y())
+        case *playerlib.AICastSpellDecision:
+            return fmt.Sprintf("cast %v", d.Spell.Name)
+        case *playerlib.AICastUnitSpellDecision:
+            return fmt.Sprintf("cast %v on %v", d.Spell.Name, d.Target.GetName())
+        case *playerlib.AIResearchSpellDecision:
+            return fmt.Sprintf("research %v", d.Spell.Name)
+    }
+    return fmt.Sprintf("%T", decision)
+}
 
 type EnemyGoal struct {
     Goal GoalType
@@ -82,34 +300,86 @@ func (ai *Enemy2AI) ComputeGoals(self *playerlib.Player, aiServices playerlib.AI
 
     exploreGoal := EnemyGoal{
         Goal: GoalExploreTerritory,
+        Weight: 0.4,
     }
 
     buildArmyGoal := EnemyGoal{
         Goal: GoalBuildArmy,
+        Weight: 0.5,
     }
 
-    // only build an army if we have few stacks compared to the turn number
-    if uint64(len(self.Stacks)) < max(5, aiServices.GetTurnNumber() / 5) {
+    // only build an army if we have few stacks compared to the turn number, so
+    // the standing-army target grows as the game goes on (more stacks = more
+    // aggression / defense capacity).
+    armyTarget := max(5, aiServices.GetTurnNumber() / 5)
+    if armyTarget < 2 {
+        armyTarget = 2
+    }
+    if uint64(len(self.Stacks)) < armyTarget {
         exploreGoal.SubGoals = append(exploreGoal.SubGoals, buildArmyGoal)
     }
 
+    // base goal priorities. These weights surface in the watch-mode debug overlay
+    // so the AI's current disposition (aggressive vs. builder vs. turtle) is
+    // visible while spectating.
     goals = []EnemyGoal{
         EnemyGoal{
             Goal: GoalDefeatEnemies,
+            Weight: 0.9,
             SubGoals: []EnemyGoal{
                 exploreGoal,
             },
         },
         EnemyGoal{
             Goal: GoalBuildCities,
+            Weight: 0.7,
         },
         EnemyGoal{
             Goal: GoalIncreasePower,
+            Weight: 0.6,
         },
         EnemyGoal{
             Goal: GoalDefendCities,
+            Weight: 0.8,
         },
     }
+
+    // once we have a small empire, dedicate some effort to connecting cities
+    // with roads (1 engineer per 3 cities) for faster troop movement and trade
+    if len(self.Cities) >= 3 {
+        goals = append(goals, EnemyGoal{
+            Goal: GoalConnectCities,
+            Weight: 0.5,
+        })
+    }
+
+    // capture magic nodes with spirits for extra magic power. The goal self-guards
+    // (does nothing unless we know a spirit spell and there are reachable, cleared,
+    // unowned nodes), so it is always available once we have a city to summon from.
+    if knowsSpiritSpell(self) {
+        goals = append(goals, EnemyGoal{
+            Goal: GoalMeldNodes,
+            Weight: 0.55,
+        })
+    }
+
+    // when we know beneficial unit enchantments and have spare mana, buff our
+    // scouts (mobility) and best stacks (combat power). Placed last and gated on
+    // spare mana so it never steals the casting channel from summoning/expansion.
+    if knowsUnitEnchantment(self) {
+        goals = append(goals, EnemyGoal{
+            Goal: GoalEnchantUnits,
+            Weight: 0.45,
+        })
+    }
+
+    // ferry spare stacks through open plane towers to gain a foothold on the
+    // other plane. Self-guards: only acts when we have spare forces, a city on
+    // the source plane, and no established presence on the destination plane.
+    goals = append(goals, EnemyGoal{
+        Goal: GoalPlanarTravel,
+        Weight: 0.5,
+    })
 
     // goals = append(goals, exploreGoal)
 
@@ -187,6 +457,999 @@ func stackAttackPower(stack *playerlib.UnitStack) int {
     return unitAttackPower(stack.Units()...)
 }
 
+// combatProfile is the set of combat-relevant numbers used to estimate a
+// unit's fighting value. It is extracted uniformly from any units.StackUnit so
+// that the defenders of a lair and our own units are scored by the exact same
+// model.
+type combatProfile struct {
+    count int
+
+    meleeAttack   int
+    rangedAttack  int
+    rangedAttacks int // ammo: number of ranged shots available
+    rangedMagical bool
+
+    toHit    int // percent chance per attack point to land a hit
+    toDefend int // percent chance per defense point to block a hit
+    defense  int
+    hitPoints  int
+    resistance int
+
+    firstStrike    bool
+    armorPiercing  bool
+    lifeSteal      bool
+    weaponImmunity bool
+    missileImmunity bool
+    magicImmunity  bool
+    largeShield    bool
+    regeneration   bool
+    invisibility   bool
+
+    // expected extra per-figure damage from special attacks (breath, immolation, thrown, poison)
+    bonusAttack float64
+    // gaze / touch abilities that can destroy figures regardless of hit points
+    deadlyTouch bool
+}
+
+// unitCombatProfile reads a StackUnit into a combatProfile.
+func unitCombatProfile(unit units.StackUnit) combatProfile {
+    p := combatProfile{
+        count:           unit.GetCount(),
+        meleeAttack:     unit.GetMeleeAttackPower(),
+        rangedAttack:    unit.GetRangedAttackPower(),
+        rangedAttacks:   unit.GetRangedAttacks(),
+        rangedMagical:   unit.GetRangedAttackDamageType() == units.DamageRangedMagical,
+        toHit:           unit.GetToHitMelee(),
+        toDefend:        unit.GetToDefend(),
+        defense:         unit.GetDefense(),
+        hitPoints:       unit.GetHitPoints(),
+        resistance:      unit.GetResistance(),
+        firstStrike:     unit.HasAbility(data.AbilityFirstStrike),
+        armorPiercing:   unit.HasAbility(data.AbilityArmorPiercing),
+        lifeSteal:       unit.HasAbility(data.AbilityLifeSteal),
+        weaponImmunity:  unit.HasAbility(data.AbilityWeaponImmunity),
+        missileImmunity: unit.HasAbility(data.AbilityMissileImmunity),
+        magicImmunity:   unit.HasAbility(data.AbilityMagicImmunity),
+        largeShield:     unit.HasAbility(data.AbilityLargeShield),
+        regeneration:    unit.HasAbility(data.AbilityRegeneration),
+        invisibility:    unit.HasAbility(data.AbilityInvisibility),
+    }
+
+    if p.toHit <= 0 {
+        p.toHit = 30
+    }
+    if p.toDefend <= 0 {
+        p.toDefend = 30
+    }
+
+    // special offensive abilities add expected damage per figure
+    p.bonusAttack += float64(unit.GetAbilityValue(data.AbilityFireBreath))
+    p.bonusAttack += float64(unit.GetAbilityValue(data.AbilityLightningBreath))
+    p.bonusAttack += float64(unit.GetAbilityValue(data.AbilityThrown))
+    p.bonusAttack += float64(unit.GetAbilityValue(data.AbilityPoisonTouch))
+    if unit.HasAbility(data.AbilityImmolation) {
+        p.bonusAttack += 4
+    }
+
+    if unit.HasAbility(data.AbilityDeathGaze) || unit.HasAbility(data.AbilityStoningGaze) ||
+        unit.HasAbility(data.AbilityDoomGaze) || unit.HasAbility(data.AbilityDeathTouch) ||
+        unit.HasAbility(data.AbilityStoningTouch) {
+        p.deadlyTouch = true
+    }
+
+    return p
+}
+
+// profileStrength turns a combatProfile into a single fighting value. The value
+// combines expected damage output (offense) with effective hit points
+// (survivability) so that a unit which both hits hard and lives long is worth
+// disproportionately more than one that only does one of those.
+func profileStrength(p combatProfile) float64 {
+    if p.count <= 0 {
+        return 0
+    }
+    offense, effHP, _ := profileStrengthBreakdown(p)
+    return offense * effHP * float64(p.count)
+}
+
+// profileStrengthBreakdown computes the per-figure offense and effective-HP
+// factors used by profileStrength, and (optionally) returns human-readable
+// lines explaining each step. profileStrength multiplies offense * effHP *
+// count. Keeping the math here ensures the explanation never drifts from the
+// number actually used by the AI.
+func profileStrengthBreakdown(p combatProfile) (offense float64, effHP float64, lines []string) {
+    // --- offense: expected damage output per figure per round ---
+    pHit := clampFloat(float64(p.toHit)/100, 0.1, 0.9)
+
+    melee := float64(p.meleeAttack)
+    ranged := float64(p.rangedAttack)
+    if p.rangedMagical {
+        ranged *= 1.5
+    }
+    if p.rangedAttacks <= 0 {
+        ranged = 0
+    }
+
+    primary := math.Max(melee, ranged)
+    // a unit with both melee and ranged is more flexible; credit the lesser one a little
+    secondary := math.Min(melee, ranged) * 0.25
+
+    rawAttack := primary + secondary + p.bonusAttack
+    damage := rawAttack * pHit
+
+    var offMults []string
+    if p.firstStrike {
+        damage *= 1.15
+        offMults = append(offMults, "firstStrike x1.15")
+    }
+    if p.armorPiercing {
+        damage *= 1.25
+        offMults = append(offMults, "armorPiercing x1.25")
+    }
+    if p.lifeSteal {
+        damage *= 1.2
+        offMults = append(offMults, "lifeSteal x1.2")
+    }
+    if p.deadlyTouch {
+        damage += 5 // flat per-figure kill potential, independent of enemy HP
+        offMults = append(offMults, "deadlyTouch +5")
+    }
+
+    offense = math.Max(damage, 0.5) // floor so a 0-attack support unit still counts
+
+    offLine := fmt.Sprintf("  offense %.2f = attack %.1f x toHit %d%%", offense, rawAttack, p.toHit)
+    if p.bonusAttack > 0 {
+        offLine += fmt.Sprintf(" (incl +%.1f special)", p.bonusAttack)
+    }
+    if len(offMults) > 0 {
+        offLine += " x [" + strings.Join(offMults, ", ") + "]"
+    }
+    lines = append(lines, offLine)
+
+    // --- survivability: effective hit points per figure ---
+    pDef := clampFloat(float64(p.toDefend)/100, 0.1, 0.6)
+
+    defense := float64(p.defense)
+    if p.largeShield {
+        defense += 2
+    }
+
+    // each defense point blocks pDef of an incoming hit -> raises effective HP
+    effHP = float64(p.hitPoints) * (1 + defense*pDef)
+    // resistance wards off gaze / poison / spell effects
+    effHP *= 1 + float64(p.resistance)*0.015
+
+    var hpMults []string
+    if p.resistance > 0 {
+        hpMults = append(hpMults, fmt.Sprintf("resist %d x%.3f", p.resistance, 1+float64(p.resistance)*0.015))
+    }
+    if p.weaponImmunity {
+        effHP *= 1.8 // effectively defense 10 against normal weapons
+        hpMults = append(hpMults, "weaponImm x1.8")
+    }
+    if p.magicImmunity {
+        effHP *= 1.4
+        hpMults = append(hpMults, "magicImm x1.4")
+    }
+    if p.regeneration {
+        effHP *= 1.3
+        hpMults = append(hpMults, "regen x1.3")
+    }
+    if p.invisibility {
+        effHP *= 1.2
+        hpMults = append(hpMults, "invis x1.2")
+    }
+    if p.missileImmunity {
+        effHP *= 1.1
+        hpMults = append(hpMults, "missileImm x1.1")
+    }
+
+    hpLine := fmt.Sprintf("  effHP %.2f = hp %d x (1 + def %.0f x toDef %d%%)", effHP, p.hitPoints, defense, p.toDefend)
+    if len(hpMults) > 0 {
+        hpLine += " x [" + strings.Join(hpMults, ", ") + "]"
+    }
+    lines = append(lines, hpLine)
+
+    return offense, effHP, lines
+}
+
+// ExplainUnitStrength returns a fielded unit's combat-strength score along with
+// human-readable lines explaining how the score was derived. For the watch-mode
+// inspector.
+func ExplainUnitStrength(unit units.StackUnit) (int, []string) {
+    p := unitCombatProfile(unit)
+    offense, effHP, lines := profileStrengthBreakdown(p)
+    total := 0.0
+    if p.count > 0 {
+        total = offense * effHP * float64(p.count)
+    }
+    lines = append(lines, fmt.Sprintf("  strength = offense %.2f x effHP %.2f x count %d = %d",
+        offense, effHP, p.count, int(total)))
+    return int(total), lines
+}
+
+// ExplainUnitDataStrength scores a raw lair defender (units.Unit) and explains
+// the calculation, wrapping it exactly as combat does.
+func ExplainUnitDataStrength(unit units.Unit) (int, []string) {
+    wrapped := units.MakeOverworldUnit(unit, 0, 0, data.PlaneArcanus)
+    return ExplainUnitStrength(wrapped)
+}
+
+// LairAttackMargin is the exported safety margin a stack's strength must exceed
+// a lair's defender strength by before the AI commits to attacking.
+const LairAttackMargin = lairAttackMargin
+
+func clampFloat(value, low, high float64) float64 {
+    if value < low {
+        return low
+    }
+    if value > high {
+        return high
+    }
+    return value
+}
+
+// unitDataStrength scores the defenders found in a lair. They are raw
+// units.Unit values, so we wrap each one exactly as combat does
+// (MakeOverworldUnit) to expose the full StackUnit interface and score it with
+// the same model as our own units.
+func unitDataStrength(unit units.Unit) int {
+    wrapped := units.MakeOverworldUnit(unit, 0, 0, data.PlaneArcanus)
+    return int(profileStrength(unitCombatProfile(wrapped)))
+}
+
+// stackUnitStrength scores a single fielded unit (units.StackUnit).
+func stackUnitStrength(unit units.StackUnit) int {
+    return int(profileStrength(unitCombatProfile(unit)))
+}
+
+// StackCombatStrength is an exported wrapper around the AI's combat-strength
+// estimate for a whole stack, for use by the watch-mode inspector UI.
+func StackCombatStrength(stack *playerlib.UnitStack) int {
+    return stackCombatStrength(stack)
+}
+
+// UnitCombatStrength is an exported wrapper around the AI's combat-strength
+// estimate for a single unit, for use by the watch-mode inspector UI.
+func UnitCombatStrength(unit units.StackUnit) int {
+    return stackUnitStrength(unit)
+}
+
+// lairStrength is the total combat strength of an encounter's defenders.
+func lairStrength(encounter *maplib.ExtraEncounter) int {
+    if encounter == nil {
+        return 0
+    }
+    total := 0
+    for _, unit := range encounter.Units {
+        total += unitDataStrength(unit)
+    }
+    return total
+}
+
+// LairStrength is an exported wrapper around lairStrength for the watch-mode
+// inspector UI.
+func LairStrength(encounter *maplib.ExtraEncounter) int {
+    return lairStrength(encounter)
+}
+
+// combatUnits returns the units in the stack that can actually fight (nonzero
+// attack power). Settlers and other support units are excluded so the AI never
+// drags them into an attack on a lair or enemy.
+func combatUnits(stack *playerlib.UnitStack) []units.StackUnit {
+    var out []units.StackUnit
+    for _, unit := range stack.Units() {
+        if unitAttackPower(unit) > 0 {
+            out = append(out, unit)
+        }
+    }
+    return out
+}
+
+// unitsCombatStrength is the total combat strength of a slice of units.
+func unitsCombatStrength(list []units.StackUnit) int {
+    total := 0
+    for _, unit := range list {
+        total += stackUnitStrength(unit)
+    }
+    return total
+}
+
+// stackCombatStrength is the combat strength of a stack, counting only the
+// units that can fight (so a settler-only stack scores 0 and never attacks).
+func stackCombatStrength(stack *playerlib.UnitStack) int {
+    return unitsCombatStrength(combatUnits(stack))
+}
+
+func absInt(value int) int {
+    if value < 0 {
+        return -value
+    }
+    return value
+}
+
+// countEngineers counts how many road-building (Construction) units the player
+// owns across all stacks.
+func countEngineers(self *playerlib.Player) int {
+    total := 0
+    for _, stack := range self.Stacks {
+        for _, unit := range stack.Units() {
+            if unit.HasAbility(data.AbilityConstruction) {
+                total += 1
+            }
+        }
+    }
+    return total
+}
+
+// stackHasEngineer reports whether the stack contains a Construction unit.
+func stackHasEngineer(stack *playerlib.UnitStack) bool {
+    for _, unit := range stack.Units() {
+        if unit.HasAbility(data.AbilityConstruction) {
+            return true
+        }
+    }
+    return false
+}
+
+// stackHasSettler reports whether the stack contains a settler (a unit that can
+// found a city). Such stacks are owned by the BuildCities goal: they are never
+// sent to attack/raid an enemy or lair, and are not dragged off to explore, so
+// any escort that travels with the settler stays to protect it.
+func stackHasSettler(stack *playerlib.UnitStack) bool {
+    for _, unit := range stack.Units() {
+        if unit.HasAbility(data.AbilityCreateOutpost) {
+            return true
+        }
+    }
+    return false
+}
+
+// stackHasMelder reports whether the stack contains a spirit (a unit with the
+// Meld ability). Such stacks belong to the MeldNodes goal: they are never sent
+// to attack/raid or explore, so the spirit travels to a node to capture it.
+func stackHasMelder(stack *playerlib.UnitStack) bool {
+    for _, unit := range stack.Units() {
+        if unit.HasAbility(data.AbilityMeld) {
+            return true
+        }
+    }
+    return false
+}
+
+// melderUnits returns the meld-capable units (spirits) in a stack.
+func melderUnits(stack *playerlib.UnitStack) []units.StackUnit {
+    var out []units.StackUnit
+    for _, unit := range stack.ActiveUnits() {
+        if unit.HasAbility(data.AbilityMeld) {
+            out = append(out, unit)
+        }
+    }
+    return out
+}
+
+// countMelders counts how many meld-capable units (spirits) the player owns,
+// whether idle or already travelling toward a node.
+func countMelders(self *playerlib.Player) int {
+    total := 0
+    for _, stack := range self.Stacks {
+        for _, unit := range stack.Units() {
+            if unit.HasAbility(data.AbilityMeld) {
+                total += 1
+            }
+        }
+    }
+    return total
+}
+
+// findSpiritSpell returns the cheapest known summoning spell whose summoned unit
+// can meld a node (Magic Spirit, Guardian Spirit). Prefers the cheaper spell so
+// the AI usually summons Magic Spirit (cost 30) over Guardian Spirit (cost 80).
+func findSpiritSpell(self *playerlib.Player) (spellbook.Spell, bool) {
+    var best spellbook.Spell
+    found := false
+    summoning := self.KnownSpells.GetSpellsBySection(spellbook.SectionSummoning)
+    for _, spell := range summoning.Spells {
+        unit := units.GetUnitByName(spell.Name)
+        if unit.IsNone() || !unit.HasAbility(data.AbilityMeld) {
+            continue
+        }
+        if !found || spell.Cost(true) < best.Cost(true) {
+            best = spell
+            found = true
+        }
+    }
+    return best, found
+}
+
+// knowsSpiritSpell reports whether the wizard knows any spell that summons a
+// meld-capable spirit.
+func knowsSpiritSpell(self *playerlib.Player) bool {
+    _, ok := findSpiritSpell(self)
+    return ok
+}
+
+// knownUnitEnchantmentSpells returns the wizard's known, overland-castable spells
+// that apply a beneficial (non-curse) enchantment to a single unit. These are the
+// spells the AI can use to buff scouts and elite stacks on the overworld.
+func knownUnitEnchantmentSpells(self *playerlib.Player) []spellbook.Spell {
+    var out []spellbook.Spell
+    for _, spell := range self.KnownSpells.OverlandSpells().Spells {
+        if spell.GetUnitEnchantment() != data.UnitEnchantmentNone {
+            out = append(out, spell)
+        }
+    }
+    return out
+}
+
+// knowsUnitEnchantment reports whether the wizard knows any unit-enchantment spell.
+func knowsUnitEnchantment(self *playerlib.Player) bool {
+    return len(knownUnitEnchantmentSpells(self)) > 0
+}
+
+// findEnchantSpell returns the named spell from a list of candidate spells.
+func findEnchantSpell(spells []spellbook.Spell, name string) (spellbook.Spell, bool) {
+    for _, spell := range spells {
+        if spell.Name == name {
+            return spell, true
+        }
+    }
+    return spellbook.Spell{}, false
+}
+
+// strongestUnit returns the highest combat-strength unit in a slice, or nil.
+func strongestUnit(list []units.StackUnit) units.StackUnit {
+    var best units.StackUnit
+    bestStrength := -1
+    for _, unit := range list {
+        strength := stackUnitStrength(unit)
+        if strength > bestStrength {
+            bestStrength = strength
+            best = unit
+        }
+    }
+    return best
+}
+
+// aiHasCityOnPlane reports whether the wizard owns at least one city on a plane.
+func aiHasCityOnPlane(self *playerlib.Player, plane data.Plane) bool {
+    for _, city := range self.Cities {
+        if city.Plane == plane {
+            return true
+        }
+    }
+    return false
+}
+
+// countStacksOnPlane counts the wizard's stacks currently on a plane.
+func countStacksOnPlane(self *playerlib.Player, plane data.Plane) int {
+    n := 0
+    for _, stack := range self.Stacks {
+        if stack.Plane() == plane {
+            n += 1
+        }
+    }
+    return n
+}
+
+// minCitiesBeforeOffPlaneExpansion is the empire size at which the AI starts
+// pushing onto the other plane even if it could still settle more cities at
+// home. Below this it concentrates on its starting plane.
+const minCitiesBeforeOffPlaneExpansion = 4
+
+// aiNoRoomToSettle reports whether the wizard can no longer find a settlable
+// location reachable from any of its cities on the given plane (settler
+// expansion there is exhausted). Used to decide it is time to look to the other
+// plane.
+func aiNoRoomToSettle(self *playerlib.Player, aiServices playerlib.AIServices, plane data.Plane) bool {
+    fog := self.GetFog(plane)
+    for _, city := range self.Cities {
+        if city.Plane != plane {
+            continue
+        }
+        if len(aiServices.FindSettlableLocations(city.X, city.Y, city.Plane, fog)) > 0 {
+            return false
+        }
+    }
+    return true
+}
+
+// aiReadyToExpandOffPlane reports whether the wizard is mature enough on `from`
+// to start expanding onto the other plane: it is established there (has a city)
+// and either commands a sizable empire (>= minCitiesBeforeOffPlaneExpansion) or
+// has run out of room to settle more cities on `from`.
+func aiReadyToExpandOffPlane(self *playerlib.Player, aiServices playerlib.AIServices, from data.Plane) bool {
+    if !aiHasCityOnPlane(self, from) {
+        return false
+    }
+    return len(self.Cities) >= minCitiesBeforeOffPlaneExpansion ||
+        aiNoRoomToSettle(self, aiServices, from)
+}
+
+// aiWantsPlaneFoothold reports whether the wizard wants to ferry forces from
+// `from` to its opposite plane: it must be ready to expand off `from` (see
+// aiReadyToExpandOffPlane), have no city on the opposite plane yet, and hold
+// fewer than two stacks there. The "no city on the opposite plane" rule
+// structurally prevents a ferried stack from shifting straight back (its new
+// plane has no city, so it fails the test).
+func aiWantsPlaneFoothold(self *playerlib.Player, aiServices playerlib.AIServices, from data.Plane) bool {
+    opposite := from.Opposite()
+    return aiReadyToExpandOffPlane(self, aiServices, from) &&
+        !aiHasCityOnPlane(self, opposite) &&
+        countStacksOnPlane(self, opposite) < 2
+}
+
+// aiWantsToShift reports whether the given stack is a spare combat stack standing
+// on an open plane tower whose opposite plane the wizard wants a foothold on. Used
+// both to trigger the shift and to keep the explore goal from dragging the stack
+// off the tower first.
+func aiWantsToShift(self *playerlib.Player, aiServices playerlib.AIServices, stack *playerlib.UnitStack) bool {
+    if stackHasSettler(stack) || stackHasMelder(stack) {
+        return false
+    }
+    if stackCombatStrength(stack) <= 0 {
+        return false
+    }
+    useMap := aiServices.GetMap(stack.Plane())
+    if useMap == nil || !useMap.HasOpenTower(stack.X(), stack.Y()) {
+        return false
+    }
+    return aiWantsPlaneFoothold(self, aiServices, stack.Plane())
+}
+
+// nearestReachableOpenTower returns the shortest path from the stack to an
+// explored open plane tower on its current plane, or nil if none is reachable.
+// Used to route both spare armies and settlers toward a portal to the other
+// plane.
+func nearestReachableOpenTower(self *playerlib.Player, aiServices playerlib.AIServices, stack *playerlib.UnitStack) pathfinding.Path {
+    useMap := aiServices.GetMap(stack.Plane())
+    if useMap == nil {
+        return nil
+    }
+    fog := self.GetFog(stack.Plane())
+    var best pathfinding.Path
+    for _, tower := range useMap.GetOpenTowerLocations() {
+        if !self.IsExplored(tower.X, tower.Y, stack.Plane()) {
+            continue
+        }
+        path, ok := aiServices.FindPath(stack.X(), stack.Y(), tower.X, tower.Y, self, stack, fog)
+        if ok && len(path) > 0 {
+            if best == nil || len(path) < len(best) {
+                best = path
+            }
+        }
+    }
+    return best
+}
+
+// stackOnOwnedNode reports whether the stack is currently standing on a magic
+// node this wizard has melded (i.e. it is acting as that node's garrison).
+func stackOnOwnedNode(self *playerlib.Player, aiServices playerlib.AIServices, stack *playerlib.UnitStack) bool {
+    useMap := aiServices.GetMap(stack.Plane())
+    if useMap == nil {
+        return false
+    }
+    node := useMap.GetMagicNode(stack.X(), stack.Y())
+    return node != nil && node.MeldingWizard == self
+}
+
+// spareGarrisonUnits returns the combat units a stack can spare to garrison a
+// node. A loose field stack can spare all of its fighters; a stack sitting in
+// one of our cities only spares the fighters above the city's minimum defense.
+func spareGarrisonUnits(stack *playerlib.UnitStack, maybeCity *citylib.City) []units.StackUnit {
+    combat := combatUnits(stack)
+    if maybeCity == nil {
+        return combat
+    }
+
+    minHomePower := getCityMinimumAttackPower(maybeCity)
+    homePower := unitAttackPower(combat...)
+    var spare []units.StackUnit
+    for _, unit := range combat {
+        if homePower-unitAttackPower(unit) < minHomePower {
+            continue
+        }
+        spare = append(spare, unit)
+        homePower -= unitAttackPower(unit)
+    }
+    return spare
+}
+
+// findCheapDefender picks the lowest-cost ordinary military unit a city can
+// build to defend a node (skips settlers, engineers and spirits). Returns false
+// if the city has nothing suitable.
+func findCheapDefender(possible []units.Unit) (units.Unit, bool) {
+    var best units.Unit
+    found := false
+    for _, unit := range possible {
+        if unit.IsSettlers() || unit.HasAbility(data.AbilityConstruction) || unit.HasAbility(data.AbilityMeld) {
+            continue
+        }
+        // must be able to fight or take a hit
+        if rawUnitAttackPower(unit) == 0 && unit.Defense == 0 {
+            continue
+        }
+        if !found || unit.ProductionCost < best.ProductionCost {
+            best = unit
+            found = true
+        }
+    }
+    return best, found
+}
+
+// countSettlerPipeline returns how many settlers the empire is committed to:
+// settler units already in the field plus cities currently producing one. Used
+// to cap settler production so cities don't all spam settlers at once.
+func countSettlerPipeline(self *playerlib.Player) int {
+    count := 0
+    for _, stack := range self.Stacks {
+        for _, unit := range stack.Units() {
+            if unit.HasAbility(data.AbilityCreateOutpost) {
+                count++
+            }
+        }
+    }
+    for _, city := range self.Cities {
+        if city.ProducingUnit.IsSettlers() {
+            count++
+        }
+    }
+    return count
+}
+
+// settlerTravelUnits returns the subset of a stack that should accompany a
+// settler when it sets out to found a city: the settler(s) themselves plus a
+// small escort of fighters for protection. If the stack is sitting in one of
+// our cities, enough attack power is left behind to keep the city defended. The
+// result is used as the Units subset of an AIMoveStackDecision so the rest of a
+// city garrison stays home rather than marching off with the settler. The
+// second return value reports whether the settler actually has a fighter escort
+// (callers use this to avoid sending a settler off alone from a city).
+func settlerTravelUnits(stack *playerlib.UnitStack, maybeCity *citylib.City) ([]units.StackUnit, bool) {
+    const maxEscort = 2
+
+    var settlers []units.StackUnit
+    var fighters []units.StackUnit
+    for _, unit := range stack.ActiveUnits() {
+        if unit.HasAbility(data.AbilityCreateOutpost) {
+            settlers = append(settlers, unit)
+        } else if unitAttackPower(unit) > 0 {
+            fighters = append(fighters, unit)
+        }
+    }
+
+    // when leaving a city, keep enough behind to defend it: retain at least one
+    // fighter and at least half the desired minimum attack power. A settler in
+    // the wild (no city) can keep all its fighters together.
+    minHomePower := 0
+    if maybeCity != nil {
+        minHomePower = getCityMinimumAttackPower(maybeCity) / 2
+    }
+
+    homePower := unitAttackPower(fighters...)
+    var escort []units.StackUnit
+    for _, fighter := range fighters {
+        if len(escort) >= maxEscort {
+            break
+        }
+        // never take the last fighter from a city garrison
+        if maybeCity != nil && len(fighters)-len(escort)-1 < 1 {
+            break
+        }
+        // keep the city defended: only borrow a fighter if the remaining
+        // garrison still meets the minimum defensive power
+        if homePower-unitAttackPower(fighter) < minHomePower {
+            continue
+        }
+        escort = append(escort, fighter)
+        homePower -= unitAttackPower(fighter)
+    }
+
+    return append(settlers, escort...), len(escort) > 0
+}
+
+// aiEnemiesNearby reports whether the AI can currently see any enemy unit stack
+// within `radius` tiles of (x,y) on the given plane. Used to decide whether a
+// settler needs to wait for an escort before leaving a city: if the surrounding
+// area is clear, the settler is allowed to set out alone rather than sit idle.
+func aiEnemiesNearby(self *playerlib.Player, aiServices playerlib.AIServices, x int, y int, plane data.Plane, radius int) bool {
+    useMap := aiServices.GetMap(plane)
+    if useMap == nil {
+        return false
+    }
+
+    for _, enemyPlayer := range aiServices.GetEnemies(self) {
+        for _, enemyStack := range enemyPlayer.Stacks {
+            if enemyStack.Plane() != plane {
+                continue
+            }
+            // only react to threats we can actually see; remembered/fogged
+            // positions shouldn't pin a settler in town forever
+            if !self.IsVisible(enemyStack.X(), enemyStack.Y(), plane) {
+                continue
+            }
+            if useMap.TileDistance(x, y, enemyStack.X(), enemyStack.Y()) <= radius {
+                return true
+            }
+        }
+    }
+
+    return false
+}
+
+// stackBusyBuildingRoad reports whether any engineer in the stack is already
+// committed to building a road (busy or has a pending road path).
+func stackBusyBuildingRoad(stack *playerlib.UnitStack) bool {
+    for _, unit := range stack.Units() {
+        if unit.GetBusy() == units.BusyStatusBuildRoad {
+            return true
+        }
+        if len(unit.GetBuildRoadPath()) > 0 {
+            return true
+        }
+    }
+    return false
+}
+
+// findConstructionUnit returns the first buildable unit with the Construction
+// ability (an engineer), if any.
+func findConstructionUnit(possible []units.Unit) (units.Unit, bool) {
+    for _, unit := range possible {
+        if unit.HasAbility(data.AbilityConstruction) {
+            return unit, true
+        }
+    }
+    return units.UnitNone, false
+}
+
+// citiesRoadConnected reports whether the two points are joined by a contiguous
+// chain of road tiles (city tiles act as road junctions). Used to avoid sending
+// an engineer to build a road that already exists.
+func citiesRoadConnected(useMap *maplib.Map, cityPoints map[image.Point]bool, ax, ay, bx, by int) bool {
+    if useMap == nil {
+        return false
+    }
+    width := useMap.Width()
+    height := useMap.Height()
+
+    start := image.Pt(useMap.WrapX(ax), ay)
+    goal := image.Pt(useMap.WrapX(bx), by)
+    if start == goal {
+        return true
+    }
+
+    // a tile is part of the network if it has a road or is one of our cities
+    isNetwork := func(x, y int) bool {
+        x = useMap.WrapX(x)
+        if y < 0 || y >= height {
+            return false
+        }
+        if useMap.ContainsRoad(x, y) {
+            return true
+        }
+        return cityPoints[image.Pt(x, y)]
+    }
+
+    visited := make(map[image.Point]bool)
+    queue := []image.Point{start}
+    visited[start] = true
+
+    for len(queue) > 0 {
+        cur := queue[0]
+        queue = queue[1:]
+
+        for dy := -1; dy <= 1; dy++ {
+            for dx := -1; dx <= 1; dx++ {
+                if dx == 0 && dy == 0 {
+                    continue
+                }
+                nx := useMap.WrapX(cur.X + dx)
+                ny := cur.Y + dy
+                if ny < 0 || ny >= height || nx < 0 || nx >= width {
+                    continue
+                }
+                next := image.Pt(nx, ny)
+                if visited[next] {
+                    continue
+                }
+                if next == goal {
+                    return true
+                }
+                if isNetwork(nx, ny) {
+                    visited[next] = true
+                    queue = append(queue, next)
+                }
+            }
+        }
+    }
+
+    return false
+}
+
+// updateLairCatalogue refreshes ai.KnownLairs from the map: it records every
+// encounter on a tile the wizard has explored, marks an entry Scouted (and
+// records the defenders' Strength) once the tile is visible, and forgets
+// entries whose encounter has been cleared.
+func (ai *Enemy2AI) updateLairCatalogue(self *playerlib.Player, aiServices playerlib.AIServices) {
+    if ai.KnownLairs == nil {
+        ai.KnownLairs = make(map[LairKey]*LairInfo)
+    }
+
+    for _, plane := range []data.Plane{data.PlaneArcanus, data.PlaneMyrror} {
+        useMap := aiServices.GetMap(plane)
+        if useMap == nil {
+            continue
+        }
+
+        present := set.MakeSet[LairKey]()
+
+        for _, point := range useMap.GetEncounterLocations() {
+            // we only learn an encounter exists once we've explored its tile
+            if !self.IsExplored(point.X, point.Y, plane) {
+                continue
+            }
+
+            key := LairKey{X: point.X, Y: point.Y, Plane: plane}
+            present.Insert(key)
+
+            encounter := useMap.GetEncounter(point.X, point.Y)
+            if encounter == nil {
+                continue
+            }
+
+            info, ok := ai.KnownLairs[key]
+            if !ok {
+                info = &LairInfo{X: point.X, Y: point.Y, Plane: plane}
+                ai.KnownLairs[key] = info
+            }
+            info.Type = encounter.Type
+
+            // we can read the defenders only when we can currently see the tile
+            if self.IsVisible(point.X, point.Y, plane) {
+                info.Strength = lairStrength(encounter)
+                info.Scouted = true
+            }
+        }
+
+        // forget lairs that no longer exist on tiles we've explored (cleared)
+        for key := range ai.KnownLairs {
+            if key.Plane != plane || present.Contains(key) {
+                continue
+            }
+            if self.IsExplored(key.X, key.Y, plane) {
+                delete(ai.KnownLairs, key)
+            }
+        }
+    }
+}
+
+// updateScoutMemory refreshes ai.KnownEnemyCities from what the wizard can see:
+// it remembers every enemy city on a tile we have explored, and forgets a
+// remembered city once we can see its tile and the enemy city is gone (razed,
+// captured, or it was ours). This lets the AI plan offensives toward cities it
+// scouted earlier even after the tile falls back under fog.
+func (ai *Enemy2AI) updateScoutMemory(self *playerlib.Player, aiServices playerlib.AIServices) {
+    if ai.KnownEnemyCities == nil {
+        ai.KnownEnemyCities = make(map[CityKey]*EnemyCityInfo)
+    }
+
+    // record enemy cities on tiles we have explored
+    for _, enemy := range aiServices.GetEnemies(self) {
+        for _, city := range enemy.Cities {
+            if !self.IsExplored(city.X, city.Y, city.Plane) {
+                continue
+            }
+            key := CityKey{X: city.X, Y: city.Y, Plane: city.Plane}
+            ai.KnownEnemyCities[key] = &EnemyCityInfo{X: city.X, Y: city.Y, Plane: city.Plane}
+        }
+    }
+
+    // forget remembered cities we can currently see are no longer an enemy's
+    for key := range ai.KnownEnemyCities {
+        if !self.IsVisible(key.X, key.Y, key.Plane) {
+            continue
+        }
+        city, owner := aiServices.FindCity(key.X, key.Y, key.Plane)
+        if city == nil || owner == self {
+            delete(ai.KnownEnemyCities, key)
+        }
+    }
+}
+
+// findScoutPath returns the shortest path that sends the given stack toward the
+// nearest discovered-but-unscouted lair on its plane, so the AI can reveal what
+// is guarding it. Returns nil if there is nothing to scout.
+func (ai *Enemy2AI) findScoutPath(self *playerlib.Player, aiServices playerlib.AIServices, stack *playerlib.UnitStack) pathfinding.Path {
+    var shortestPath pathfinding.Path
+    fog := self.GetFog(stack.Plane())
+    for _, lair := range ai.KnownLairs {
+        if lair.Scouted || lair.Plane != stack.Plane() {
+            continue
+        }
+        path, ok := aiServices.FindPath(stack.X(), stack.Y(), lair.X, lair.Y, self, stack, fog)
+        if ok && len(path) > 0 {
+            if len(shortestPath) == 0 || len(path) < len(shortestPath) {
+                shortestPath = path
+            }
+        }
+    }
+    return shortestPath
+}
+
+// findNavalExplorePath returns a path that sends a ship out toward the unknown
+// sea so triremes leave port and scout instead of idling. The generic explore
+// logic samples mostly-land destinations that a sailing unit can never reach,
+// so naval stacks need their own water-only target search. It collects nearby
+// water tiles that are either unexplored or on the frontier (explored water
+// adjacent to fog), prefers the closest, and returns the first reachable one.
+func (ai *Enemy2AI) findNavalExplorePath(self *playerlib.Player, aiServices playerlib.AIServices, stack *playerlib.UnitStack) pathfinding.Path {
+    useMap := aiServices.GetMap(stack.Plane())
+    if useMap == nil {
+        return nil
+    }
+    fog := self.GetFog(stack.Plane())
+    plane := stack.Plane()
+    sx, sy := stack.X(), stack.Y()
+
+    type cand struct {
+        x, y, dist int
+    }
+    var candidates []cand
+
+    const radius = 12
+    for dy := -radius; dy <= radius; dy++ {
+        for dx := -radius; dx <= radius; dx++ {
+            if dx == 0 && dy == 0 {
+                continue
+            }
+            nx := useMap.WrapX(sx + dx)
+            ny := sy + dy
+            tile := useMap.GetTile(nx, ny)
+            if !tile.Valid() || !useMap.IsWater(nx, ny) {
+                continue
+            }
+
+            // target unexplored water directly, or explored water sitting next
+            // to a fogged tile (the edge of what we've seen) so the ship keeps
+            // pushing into the unknown even once its home waters are charted
+            target := !self.IsExplored(nx, ny, plane)
+            if !target {
+                for ddy := -1; ddy <= 1 && !target; ddy++ {
+                    for ddx := -1; ddx <= 1; ddx++ {
+                        if !self.IsExplored(useMap.WrapX(nx+ddx), ny+ddy, plane) {
+                            target = true
+                            break
+                        }
+                    }
+                }
+            }
+            if !target {
+                continue
+            }
+
+            candidates = append(candidates, cand{x: nx, y: ny, dist: useMap.TileDistance(sx, sy, nx, ny)})
+        }
+    }
+
+    slices.SortFunc(candidates, func(a, b cand) int {
+        return a.dist - b.dist
+    })
+
+    tried := 0
+    for _, c := range candidates {
+        if tried >= 20 {
+            break
+        }
+        tried++
+        path, ok := aiServices.FindPath(sx, sy, c.x, c.y, self, stack, fog)
+        if ok && len(path) > 0 {
+            return path
+        }
+    }
+
+    return nil
+}
+
 // return a subset of moveUnits that can move while still leaving minimumAttackPower behind
 func getMoveableUnits(moveUnits []units.StackUnit, minimumAttackPower int) []units.StackUnit {
 
@@ -227,13 +1490,49 @@ func getCityMinimumAttackPower(city *citylib.City) int {
     return city.Citizens() * attack_power_per_citizen
 }
 
+// cityDefenseTarget is the garrison attack power the AI actively builds toward
+// for a city, as opposed to getCityMinimumAttackPower (the bare floor used when
+// deciding how much to leave behind when units wander off). It is deliberately
+// higher and scales with the turn number because rampaging raider packs grow
+// stronger as the game goes on (see raider.go createMonsters, whose monster
+// budget ramps up to ~3x by turn 200), so standing garrisons must keep pace or
+// frontier towns get overrun.
+func cityDefenseTarget(city *citylib.City, turn uint64) int {
+    base := getCityMinimumAttackPower(city)
+
+    // growth tracks how far past turn 50 we are, capped at turn 200
+    growth := 0
+    if turn > 50 {
+        growth = int(turn - 50)
+        if growth > 150 {
+            growth = 150
+        }
+    }
+
+    // 1.5x the floor early, ramping to 3x of the floor by turn 200
+    scale := 1.5 + 1.5*float64(growth)/150.0
+    target := int(float64(base) * scale)
+
+    // even a brand-new one-citizen town should keep a real garrison so a single
+    // wandering raider pack can't walk in unopposed
+    const minimumGarrison = 24
+    if target < minimumGarrison {
+        target = minimumGarrison
+    }
+
+    return target
+}
+
 // the decisions to make for this goal
 // seenGoals is a set used to avoid computing the same goal twice
-func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.AIServices, goal EnemyGoal, seenGoals *set.Set[GoalType], aiData *AIData) []playerlib.AIDecision {
+func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.AIServices, goal EnemyGoal, seenGoals *set.Set[GoalType], aiData *AIData) ([]playerlib.AIDecision, GoalDebugInfo) {
+
+    info := GoalDebugInfo{Goal: goal.Goal, Weight: goal.Weight}
 
     // if we've seen this goal then just return nil
     if seenGoals.Contains(goal.Goal) {
-        return nil
+        info.Skipped = true
+        return nil, info
     }
 
     seenGoals.Insert(goal.Goal)
@@ -242,8 +1541,13 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
     // recursively satisfy subgoals first
     for _, subGoal := range goal.SubGoals {
-        decisions = append(decisions, ai.GoalDecisions(self, aiServices, subGoal, seenGoals, aiData)...)
+        subDecisions, subInfo := ai.GoalDecisions(self, aiServices, subGoal, seenGoals, aiData)
+        decisions = append(decisions, subDecisions...)
+        info.SubGoals = append(info.SubGoals, subInfo)
     }
+
+    // decisions produced by this goal's own logic (excluding subgoals) start here
+    ownStart := len(decisions)
 
     switch goal.Goal {
         case GoalDefeatEnemies:
@@ -269,6 +1573,15 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
             if len(possibleTarget) > 0 {
                 for _, stack := range self.Stacks {
+                    // never march a settler (or its escort) off to attack
+                    if stackHasSettler(stack) {
+                        continue
+                    }
+                    // spirits are reserved for capturing magic nodes
+                    if stackHasMelder(stack) {
+                        continue
+                    }
+
                     stackPower := stackAttackPower(stack)
 
                     if stackPower > 0 && stack.HasMoves() {
@@ -309,16 +1622,97 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                             }
                         }
 
+                        // fall back to a remembered enemy city we scouted earlier
+                        // but can't currently see: march a strong stack on it so
+                        // the AI keeps pressing an offensive using its scouting
+                        // memory. Gated on a healthy attack power so we don't send
+                        // weak stacks blindly into an unknown garrison.
+                        if len(shortestPath) == 0 && stackPower >= 20 {
+                            for _, known := range ai.KnownEnemyCities {
+                                if known.Plane != stack.Plane() {
+                                    continue
+                                }
+                                // visible cities were already considered above
+                                if self.IsVisible(known.X, known.Y, known.Plane) {
+                                    continue
+                                }
+                                pathToCity, ok := aiServices.FindPath(stack.X(), stack.Y(), known.X, known.Y, self, stack, self.GetFog(stack.Plane()))
+                                if ok {
+                                    if len(shortestPath) == 0 || len(pathToCity) < len(shortestPath) {
+                                        shortestPath = pathToCity
+                                    }
+                                }
+                            }
+                        }
+
                         if len(shortestPath) > 0 {
                             // log.Printf("AI %v moving stack at %v,%v to attack enemy via %v", self.Wizard.Name, stack.X(), stack.Y(), shortestPath)
+                            // only send the fighters; leave settlers/support behind
                             decisions = append(decisions, &playerlib.AIMoveStackDecision{
                                 Stack: stack,
                                 Path: shortestPath,
+                                Units: combatUnits(stack),
                             })
 
                             ai.Attacking[stack] = true
+                            dest := shortestPath[len(shortestPath)-1]
+                            ai.setActivity(stack, fmt.Sprintf("attacking enemy at (%d,%d)", dest.X, dest.Y))
                         }
                     }
+                }
+            }
+
+            // clear out monster lairs / nodes we have scouted and can beat
+            for _, stack := range self.Stacks {
+                if ai.Attacking[stack] || !stack.HasMoves() {
+                    continue
+                }
+
+                // never send a settler (or its escort) to raid a lair/node
+                if stackHasSettler(stack) {
+                    continue
+                }
+                // spirits are reserved for capturing magic nodes
+                if stackHasMelder(stack) {
+                    continue
+                }
+
+                stackStrength := stackCombatStrength(stack)
+                if stackStrength <= 0 {
+                    continue
+                }
+
+                var shortestPath pathfinding.Path
+                for _, lair := range ai.KnownLairs {
+                    if !lair.Scouted || lair.Plane != stack.Plane() {
+                        continue
+                    }
+
+                    // require a strength surplus over the lair before raiding it,
+                    // scaled by how dangerous the lair is.
+                    margin := requiredLairMargin(lair.Strength)
+                    if float32(stackStrength) < float32(lair.Strength) * margin {
+                        continue
+                    }
+
+                    path, ok := aiServices.FindPath(stack.X(), stack.Y(), lair.X, lair.Y, self, stack, self.GetFog(stack.Plane()))
+                    if ok && len(path) > 0 {
+                        if len(shortestPath) == 0 || len(path) < len(shortestPath) {
+                            shortestPath = path
+                        }
+                    }
+                }
+
+                if len(shortestPath) > 0 {
+                    // only send the fighters; leave settlers/support behind
+                    decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                        Stack: stack,
+                        Path: shortestPath,
+                        Units: combatUnits(stack),
+                    })
+                    ai.Attacking[stack] = true
+                    dest := shortestPath[len(shortestPath)-1]
+                    ai.setActivity(stack, fmt.Sprintf("clearing lair/node at (%d,%d)", dest.X, dest.Y))
                 }
             }
 
@@ -328,14 +1722,26 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                 return aiServices.FindStacksOnContinent(x, y, plane, self)
             })
 
+            turn := aiServices.GetTurnNumber()
+
             for _, city := range self.Cities {
+                // don't override a settler this empire is trying to build: either
+                // one BuildCities just queued this turn, or one already in
+                // progress from a previous turn. Otherwise expansion gets starved
+                // because defender production would clobber it every turn.
+                if ai.reservedSettlerCities[city] || city.ProducingUnit.IsSettlers() {
+                    continue
+                }
+
                 garrison := city.GetGarrison()
                 totalAttackPower := 0
                 for _, unit := range garrison {
                     totalAttackPower += unitAttackPower(unit)
                 }
 
-                if totalAttackPower < getCityMinimumAttackPower(city) {
+                // the garrison strength we want to maintain per city
+                defenseTarget := cityDefenseTarget(city, turn)
+                if totalAttackPower < defenseTarget {
                     // 1. find a roaming unit that can reach this city and enter patrol
                     // 2. produce a defending unit in this city
 
@@ -376,6 +1782,7 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                                 Stack: choice,
                                 Path: path,
                             })
+                            ai.setActivity(choice, fmt.Sprintf("moving to defend %s (%d,%d)", city.Name, city.X, city.Y))
                         }
                     } else {
                         // have to build a unit
@@ -411,6 +1818,38 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
             for _, stack := range self.Stacks {
                 if stack.HasMoves() && stack.ActiveUnitsHasAbility(data.AbilityCreateOutpost) {
                     // found a stack with a settler that is not currently moving
+
+                    // Once the empire is mature (or out of room at home), ferry a
+                    // settler onto the other plane through an open plane tower to
+                    // found our first city there, instead of settling locally.
+                    // aiWantsPlaneFoothold stops firing as soon as a city exists
+                    // on the far plane, so this bootstraps the foothold and then
+                    // hands expansion back to the normal local-settle logic.
+                    if aiWantsPlaneFoothold(self, aiServices, stack.Plane()) {
+                        maybeCity := self.FindCity(stack.X(), stack.Y(), stack.Plane())
+                        travelUnits, hasEscort := settlerTravelUnits(stack, maybeCity)
+                        // require an escort to leave a city only when enemies are nearby;
+                        // otherwise let the settler ferry out alone rather than stay stuck.
+                        if maybeCity == nil || hasEscort || !aiEnemiesNearby(self, aiServices, stack.X(), stack.Y(), stack.Plane(), 6) {
+                            useMap := aiServices.GetMap(stack.Plane())
+                            if useMap != nil && useMap.HasOpenTower(stack.X(), stack.Y()) {
+                                // standing on the tower: cross to the other plane now
+                                decisions = append(decisions, &playerlib.AIPlaneShiftDecision{Stack: stack})
+                                ai.setActivity(stack, fmt.Sprintf("settler planar travel to %v", stack.Plane().Opposite()))
+                                continue
+                            }
+                            if path := nearestReachableOpenTower(self, aiServices, stack); len(path) > 0 {
+                                decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                                    Stack: stack,
+                                    Path: path,
+                                    Units: travelUnits,
+                                })
+                                dest := path[len(path)-1]
+                                ai.setActivity(stack, fmt.Sprintf("settler heading to plane tower at (%d,%d)", dest.X, dest.Y))
+                                continue
+                            }
+                        }
+                    }
 
                     findNewPath := len(stack.CurrentPath) == 0
 
@@ -485,6 +1924,7 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
                                     if len(path.Path) == 0 {
                                         if aiServices.IsSettlableLocation(stack.X(), stack.Y(), stack.Plane()) {
+                                            ai.setActivity(stack, "founding a new city (building outpost)")
                                             return &playerlib.AIBuildOutpostDecision{
                                                 Stack: stack,
                                             }, true
@@ -492,13 +1932,28 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                                     }
                                 }
 
-                                // otherwise move towards the best settlable location
+                                // otherwise move towards the best settlable location.
+                                // take the settler plus a small escort for protection,
+                                // leaving the rest of any city garrison behind.
                                 for _, location := range locations {
                                     path := pathTo(location)
                                     // log.Printf("AI moving settler stack at %v,%v to settlable location %v,%v via %v", stack.X(), stack.Y(), location.X, location.Y, path)
+                                    maybeCity := self.FindCity(stack.X(), stack.Y(), stack.Plane())
+                                    travelUnits, hasEscort := settlerTravelUnits(stack, maybeCity)
+                                    // only hold a settler in a city for an escort when there are
+                                    // enemies in the surrounding area; otherwise let it set out
+                                    // alone so settlers aren't stuck inside towns indefinitely.
+                                    // (when there is no escort, travelUnits is just the settler(s),
+                                    // so the rest of the garrison stays home either way)
+                                    if maybeCity != nil && !hasEscort && aiEnemiesNearby(self, aiServices, stack.X(), stack.Y(), stack.Plane(), 6) {
+                                        ai.setActivity(stack, "settling: waiting at city for an escort (enemies nearby)")
+                                        return nil, false
+                                    }
+                                    ai.setActivity(stack, fmt.Sprintf("settling: moving to found a city at (%d,%d)", location.X, location.Y))
                                     return &playerlib.AIMoveStackDecision{
                                         Stack: stack,
                                         Path: path.Path,
+                                        Units: travelUnits,
                                     }, true
                                 }
 
@@ -514,16 +1969,36 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                 }
             }
 
-            for _, city := range self.Cities {
-                if !isMakingSomething(city) && chance(60) {
-                    locations := aiServices.FindSettlableLocations(city.X, city.Y, city.Plane, self.GetFog(city.Plane))
-                    if len(locations) > 0 && aiData.FoodPerTurn() > 0 && chance(len(locations) * 5) {
-                        decisions = append(decisions, &playerlib.AIProduceDecision{
-                            City: city,
-                            Building: buildinglib.BuildingNone,
-                            Unit: units.GetSettlerUnit(city.Race),
-                        })
-
+            // Cap how many settlers the empire pursues at once so cities don't
+            // all spam settlers simultaneously. Count settlers already in the
+            // field plus those in production, and only start one new settler per
+            // turn while under the cap. The cap grows with the empire so larger
+            // empires keep expanding.
+            maxConcurrentSettlers := 1 + len(self.Cities)/3
+            if maxConcurrentSettlers < 1 {
+                maxConcurrentSettlers = 1
+            }
+            settlerChance := 60
+            if aiData.FoodPerTurn() > 0 && countSettlerPipeline(self) < maxConcurrentSettlers {
+                for _, city := range self.Cities {
+                    if !isMakingSomething(city) && chance(settlerChance) {
+                        locations := aiServices.FindSettlableLocations(city.X, city.Y, city.Plane, self.GetFog(city.Plane))
+                        if len(locations) > 0 {
+                            decisions = append(decisions, &playerlib.AIProduceDecision{
+                                City: city,
+                                Building: buildinglib.BuildingNone,
+                                Unit: units.GetSettlerUnit(city.Race),
+                            })
+                            // reserve this city so GoalDefendCities (which runs
+                            // later and would otherwise override the production)
+                            // leaves the settler build alone
+                            if ai.reservedSettlerCities == nil {
+                                ai.reservedSettlerCities = make(map[*citylib.City]bool)
+                            }
+                            ai.reservedSettlerCities[city] = true
+                            // only one new settler per turn across the empire
+                            break
+                        }
                     }
                 }
             }
@@ -542,15 +2017,80 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
             for _, stack := range self.Stacks {
                 if stack.HasMoves() {
 
+                    // once the ConnectCities goal is active (>=3 cities) leave engineer
+                    // stacks for it to dispatch as road builders instead of sending them
+                    // off to scout/explore (engineers have a nominal attack power of 1
+                    // and would otherwise pass the scout filter below)
+                    if len(self.Cities) >= 3 && stackHasEngineer(stack) {
+                        continue
+                    }
+
+                    // settler stacks belong to the BuildCities goal; don't drag a
+                    // settler (or its escort) off to explore
+                    if stackHasSettler(stack) {
+                        continue
+                    }
+
+                    // spirit stacks belong to the MeldNodes goal; don't send them
+                    // off to explore instead of capturing a node
+                    if stackHasMelder(stack) {
+                        continue
+                    }
+
+                    // a stack standing on one of our melded nodes is its garrison;
+                    // leave it there to hold the node rather than wandering off to
+                    // explore (the attack/defense goals can still reclaim it)
+                    if len(stack.CurrentPath) == 0 && stackOnOwnedNode(self, aiServices, stack) {
+                        continue
+                    }
+
+                    // a spare stack sitting on an open tower we intend to plane
+                    // shift through belongs to the PlanarTravel goal; don't move
+                    // it off the tower before it can travel
+                    if len(stack.CurrentPath) == 0 && aiWantsToShift(self, aiServices, stack) {
+                        continue
+                    }
+
                     if len(stack.CurrentPath) > 0 {
                         decisions = append(decisions, &playerlib.AIMoveStackDecision{
                             Stack: stack,
                             Path: stack.CurrentPath,
                         })
+                        dest := stack.CurrentPath[len(stack.CurrentPath)-1]
+                        if _, exists := ai.StackActivity[stack]; !exists {
+                            ai.setActivity(stack, ai.describeTravelIntent(self, stack, dest.X, dest.Y))
+                        }
                         continue
                     }
 
                     if len(stack.CurrentPath) == 0 {
+                        // naval stacks can't path over land, so the generic explore
+                        // below (which samples mostly-land destinations) always fails
+                        // and leaves triremes idling in port. Split any ship out of a
+                        // mixed city garrison and send it to scout the open sea.
+                        if stack.HasSailingUnits(true) && !stack.CanMoveOnLand(false) {
+                            var shipUnits []units.StackUnit
+                            for _, unit := range stack.ActiveUnits() {
+                                if unit.IsSailing() && !unit.IsFlying() {
+                                    shipUnits = append(shipUnits, unit)
+                                }
+                            }
+                            if len(shipUnits) > 0 {
+                                if navalPath := ai.findNavalExplorePath(self, aiServices, stack); len(navalPath) > 0 {
+                                    decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                                        Stack: stack,
+                                        Path: navalPath,
+                                        Units: shipUnits,
+                                    })
+                                    dest := navalPath[len(navalPath)-1]
+                                    ai.setActivity(stack, fmt.Sprintf("scouting the seas towards (%d,%d)", dest.X, dest.Y))
+                                } else {
+                                    ai.setActivity(stack, "naval: no unexplored seas reachable")
+                                }
+                            }
+                            continue
+                        }
+
                         moveUnits := stack.ActiveUnits()
 
                         useMap := aiServices.GetMap(stack.Plane())
@@ -570,6 +2110,28 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
                         if len(moveUnits) == 0 {
                             continue
+                        }
+
+                        // if we know of a lair we haven't scouted yet, send the
+                        // fighters (never settlers) to reveal its contents so the
+                        // DefeatEnemies goal can later decide whether to clear it
+                        var scoutUnits []units.StackUnit
+                        for _, unit := range moveUnits {
+                            if unitAttackPower(unit) > 0 {
+                                scoutUnits = append(scoutUnits, unit)
+                            }
+                        }
+                        if len(scoutUnits) > 0 {
+                            if scoutPath := ai.findScoutPath(self, aiServices, stack); len(scoutPath) > 0 {
+                                decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                                    Stack: stack,
+                                    Path: scoutPath,
+                                    Units: scoutUnits,
+                                })
+                                dest := scoutPath[len(scoutPath)-1]
+                                ai.setActivity(stack, fmt.Sprintf("scouting a lair at (%d,%d)", dest.X, dest.Y))
+                                continue
+                            }
                         }
 
                         // split the stack in half
@@ -614,6 +2176,8 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                                 Path: path,
                                 Units: moveUnits,
                             })
+                            dest := path[len(path)-1]
+                            ai.setActivity(stack, fmt.Sprintf("exploring towards (%d,%d)", dest.X, dest.Y))
                         }
                     }
                 }
@@ -743,6 +2307,15 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
             // feels awkward to build buildings in cities here
             for _, city := range self.Cities {
+                // don't clobber a settler that GoalBuildCities reserved this turn:
+                // both goals target start-of-turn-idle cities and the engine
+                // applies production with a last-wins override, so without this
+                // guard the building queued here would replace the settler and the
+                // empire would never expand (the city looks idle because the
+                // settler decision hasn't been applied yet)
+                if ai.reservedSettlerCities[city] {
+                    continue
+                }
                 if !isMakingSomething(city) {
                     // create housing
                     switch {
@@ -817,15 +2390,564 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                 }
             }
 
+        case GoalConnectCities:
+            // need a few cities before roads are worth the engineer investment
+            if len(self.Cities) < 3 {
+                break
+            }
+
+            // budget: one engineer per three cities
+            engineerBudget := len(self.Cities) / 3
+            currentEngineers := countEngineers(self)
+
+            // produce another engineer if we are under budget and can afford it
+            if currentEngineers < engineerBudget && aiData.GoldPerTurn() > 0 && self.Gold > 20 {
+                for _, city := range self.Cities {
+                    if isMakingSomething(city) || ai.reservedSettlerCities[city] {
+                        continue
+                    }
+                    if engineer, ok := findConstructionUnit(city.ComputePossibleUnits()); ok {
+                        decisions = append(decisions, &playerlib.AIProduceDecision{
+                            City: city,
+                            Building: buildinglib.BuildingNone,
+                            Unit: engineer,
+                        })
+                        break // only queue one engineer per turn
+                    }
+                }
+            }
+
+            // index our city tiles per plane for the road-connectivity test
+            cityPointsByPlane := make(map[data.Plane]map[image.Point]bool)
+            for _, city := range self.Cities {
+                m := cityPointsByPlane[city.Plane]
+                if m == nil {
+                    m = make(map[image.Point]bool)
+                    cityPointsByPlane[city.Plane] = m
+                }
+                m[image.Pt(city.X, city.Y)] = true
+            }
+
+            // dispatch idle engineers to connect a not-yet-connected city pair
+            for _, stack := range self.Stacks {
+                if !stack.HasMoves() || !stackHasEngineer(stack) {
+                    continue
+                }
+                if stackBusyBuildingRoad(stack) || len(stack.CurrentPath) > 0 {
+                    continue
+                }
+
+                useMap := aiServices.GetMap(stack.Plane())
+                if useMap == nil {
+                    continue
+                }
+                cityPoints := cityPointsByPlane[stack.Plane()]
+
+                // home = nearest owned city to the engineer on this plane
+                var home *citylib.City
+                homeDist := math.MaxInt
+                for _, city := range self.Cities {
+                    if city.Plane != stack.Plane() {
+                        continue
+                    }
+                    d := absInt(useMap.XDistance(city.X, stack.X())) + absInt(city.Y-stack.Y())
+                    if d < homeDist {
+                        homeDist = d
+                        home = city
+                    }
+                }
+                if home == nil {
+                    continue
+                }
+
+                // target = nearest owned city not yet road-connected to home and
+                // reachable on foot from the engineer's position
+                var bestTarget *citylib.City
+                bestDist := math.MaxInt
+                for _, city := range self.Cities {
+                    if city.Plane != stack.Plane() || city == home {
+                        continue
+                    }
+                    if citiesRoadConnected(useMap, cityPoints, home.X, home.Y, city.X, city.Y) {
+                        continue
+                    }
+                    path, ok := aiServices.FindPath(stack.X(), stack.Y(), city.X, city.Y, self, stack, self.GetFog(stack.Plane()))
+                    if !ok || len(path) == 0 {
+                        continue
+                    }
+                    if len(path) < bestDist {
+                        bestDist = len(path)
+                        bestTarget = city
+                    }
+                }
+
+                if bestTarget != nil {
+                    decisions = append(decisions, &playerlib.AIBuildRoadDecision{
+                        Stack: stack,
+                        X: bestTarget.X,
+                        Y: bestTarget.Y,
+                    })
+                    ai.setActivity(stack, fmt.Sprintf("building road to %s (%d,%d)", bestTarget.Name, bestTarget.X, bestTarget.Y))
+                }
+            }
+
+        case GoalMeldNodes:
+            spiritSpell, knowSpirit := findSpiritSpell(self)
+            if !knowSpirit {
+                break
+            }
+
+            // gather candidate target nodes: explored, cleared of guardians (no
+            // encounter), not warped, and not yet melded by anyone.
+            type nodeTarget struct {
+                X, Y int
+                Plane data.Plane
+            }
+            var targets []nodeTarget
+            for _, plane := range []data.Plane{data.PlaneArcanus, data.PlaneMyrror} {
+                useMap := aiServices.GetMap(plane)
+                if useMap == nil {
+                    continue
+                }
+                for _, point := range useMap.GetMagicNodeLocations() {
+                    if !self.IsExplored(point.X, point.Y, plane) {
+                        continue
+                    }
+                    // a node still guarded by monsters must be cleared first (the
+                    // DefeatEnemies goal handles that); a spirit can't walk onto it
+                    if useMap.GetEncounter(point.X, point.Y) != nil {
+                        continue
+                    }
+                    node := useMap.GetMagicNode(point.X, point.Y)
+                    if node == nil || node.Warped || node.MeldingWizard != nil {
+                        continue
+                    }
+                    targets = append(targets, nodeTarget{X: point.X, Y: point.Y, Plane: plane})
+                }
+            }
+
+            // claimed tracks nodes a spirit is already heading to this turn so
+            // two spirits don't converge on the same node
+            claimed := make(map[image.Point]bool)
+
+            // move existing spirits onto nodes, or meld the one they stand on
+            for _, stack := range self.Stacks {
+                if !stack.HasMoves() || !stackHasMelder(stack) {
+                    continue
+                }
+                if len(stack.CurrentPath) > 0 {
+                    continue
+                }
+
+                useMap := aiServices.GetMap(stack.Plane())
+                if useMap == nil {
+                    continue
+                }
+
+                // already standing on a meldable node? capture it.
+                if node := useMap.GetMagicNode(stack.X(), stack.Y()); node != nil &&
+                    !node.Warped && node.MeldingWizard == nil &&
+                    useMap.GetEncounter(stack.X(), stack.Y()) == nil {
+                    decisions = append(decisions, &playerlib.AIMeldNodeDecision{Stack: stack})
+                    ai.setActivity(stack, fmt.Sprintf("melding the node at (%d,%d)", stack.X(), stack.Y()))
+                    continue
+                }
+
+                // otherwise head to the nearest reachable unclaimed target node
+                var bestPath pathfinding.Path
+                var bestPoint image.Point
+                for _, target := range targets {
+                    if target.Plane != stack.Plane() {
+                        continue
+                    }
+                    pt := image.Pt(target.X, target.Y)
+                    if claimed[pt] {
+                        continue
+                    }
+                    path, ok := aiServices.FindPath(stack.X(), stack.Y(), target.X, target.Y, self, stack, self.GetFog(stack.Plane()))
+                    if !ok || len(path) == 0 {
+                        continue
+                    }
+                    if len(bestPath) == 0 || len(path) < len(bestPath) {
+                        bestPath = path
+                        bestPoint = pt
+                    }
+                }
+
+                if len(bestPath) > 0 {
+                    claimed[bestPoint] = true
+                    decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                        Stack: stack,
+                        Path: bestPath,
+                        Units: melderUnits(stack),
+                    })
+                    ai.setActivity(stack, fmt.Sprintf("melding: traveling to node at (%d,%d)", bestPoint.X, bestPoint.Y))
+                }
+            }
+
+            // summon another spirit if there are still more open nodes than we
+            // have spirits, we are not already casting, can pay the upkeep, can
+            // actually cast overland, and have a city to summon into.
+            if len(targets) > countMelders(self) &&
+                self.CastingSpell.Invalid() &&
+                self.FindSummoningCity() != nil &&
+                self.ComputeOverworldCastingSkill() > 0 {
+
+                spiritUnit := units.GetUnitByName(spiritSpell.Name)
+                manaPerTurn := self.ManaPerTurn(aiServices.ComputePower(self), aiServices)
+                if !spiritUnit.IsNone() && manaPerTurn >= spiritUnit.UpkeepMana {
+                    decisions = append(decisions, &playerlib.AICastSpellDecision{Spell: spiritSpell})
+                }
+            }
+
+            // --- keep captured nodes defended when we can afford it ---
+            // Find our melded nodes that currently have no real defender.
+            type garrisonTarget struct {
+                X, Y int
+                Plane data.Plane
+            }
+            var undefendedNodes []garrisonTarget
+            for _, plane := range []data.Plane{data.PlaneArcanus, data.PlaneMyrror} {
+                useMap := aiServices.GetMap(plane)
+                if useMap == nil {
+                    continue
+                }
+                for _, point := range useMap.GetMagicNodeLocations() {
+                    node := useMap.GetMagicNode(point.X, point.Y)
+                    if node == nil || node.MeldingWizard != self {
+                        continue
+                    }
+                    if existing := self.FindStack(point.X, point.Y, plane); existing != nil && stackCombatStrength(existing) > 0 {
+                        continue
+                    }
+                    undefendedNodes = append(undefendedNodes, garrisonTarget{X: point.X, Y: point.Y, Plane: plane})
+                }
+            }
+
+            // Dispatch spare units to hold the nodes. These are existing units
+            // (already paid for) and are NOT reserved here, so a higher-priority
+            // goal that runs earlier next turn (mounting an attack, or defending a
+            // threatened city) can reclaim them.
+            claimedGarrison := make(map[*playerlib.UnitStack]bool)
+            for _, target := range undefendedNodes {
+                var bestStack *playerlib.UnitStack
+                var bestSpare []units.StackUnit
+                var bestPath pathfinding.Path
+                for _, stack := range self.Stacks {
+                    if claimedGarrison[stack] || ai.Attacking[stack] {
+                        continue
+                    }
+                    if !stack.HasMoves() || len(stack.CurrentPath) > 0 || stack.Plane() != target.Plane {
+                        continue
+                    }
+                    if stackHasSettler(stack) || stackHasMelder(stack) || stackHasEngineer(stack) {
+                        continue
+                    }
+                    // a stack already holding one of our nodes stays put
+                    if stackOnOwnedNode(self, aiServices, stack) {
+                        continue
+                    }
+
+                    maybeCity := self.FindCity(stack.X(), stack.Y(), stack.Plane())
+                    spare := spareGarrisonUnits(stack, maybeCity)
+                    if len(spare) == 0 {
+                        continue
+                    }
+
+                    path, ok := aiServices.FindPath(stack.X(), stack.Y(), target.X, target.Y, self, stack, self.GetFog(stack.Plane()))
+                    if !ok || len(path) == 0 {
+                        continue
+                    }
+                    if bestStack == nil || len(path) < len(bestPath) {
+                        bestStack = stack
+                        bestSpare = spare
+                        bestPath = path
+                    }
+                }
+                if bestStack != nil {
+                    claimedGarrison[bestStack] = true
+                    decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                        Stack: bestStack,
+                        Path: bestPath,
+                        Units: bestSpare,
+                    })
+                    ai.setActivity(bestStack, fmt.Sprintf("garrisoning the node at (%d,%d)", target.X, target.Y))
+                }
+            }
+
+            // If nodes are still undefended and we can afford the extra upkeep,
+            // train one cheap defender in the city nearest an open node.
+            if len(undefendedNodes) > 0 && aiData.GoldPerTurn() > 0 && self.Gold > 20 && aiData.FoodPerTurn() > 0 {
+                var bestCity *citylib.City
+                bestDist := math.MaxInt
+                for _, city := range self.Cities {
+                    if isMakingSomething(city) || ai.reservedSettlerCities[city] {
+                        continue
+                    }
+                    useMap := aiServices.GetMap(city.Plane)
+                    if useMap == nil {
+                        continue
+                    }
+                    for _, target := range undefendedNodes {
+                        if target.Plane != city.Plane {
+                            continue
+                        }
+                        d := absInt(useMap.XDistance(city.X, target.X)) + absInt(city.Y-target.Y)
+                        if d < bestDist {
+                            bestDist = d
+                            bestCity = city
+                        }
+                    }
+                }
+                if bestCity != nil {
+                    if defender, ok := findCheapDefender(bestCity.ComputePossibleUnits()); ok {
+                        decisions = append(decisions, &playerlib.AIProduceDecision{
+                            City: bestCity,
+                            Building: buildinglib.BuildingNone,
+                            Unit: defender,
+                        })
+                    }
+                }
+            }
+
+        case GoalEnchantUnits:
+            // Buff our own units with beneficial enchantments when we have spare
+            // casting capacity and a healthy mana cushion. Only one overworld
+            // spell can be queued at a time, so this emits at most one cast per
+            // turn and naturally yields the casting channel to summoning/expansion
+            // (those goals run earlier and set CastingSpell first).
+            if !self.CastingSpell.Invalid() || self.ComputeOverworldCastingSkill() <= 0 {
+                break
+            }
+
+            manaPerTurn := self.ManaPerTurn(aiServices.ComputePower(self), aiServices)
+            if manaPerTurn <= 0 {
+                break
+            }
+
+            enchantSpells := knownUnitEnchantmentSpells(self)
+            if len(enchantSpells) == 0 {
+                break
+            }
+
+            // keep a reserve so buffs never drain the mana pool that summoning
+            // and city/overworld casting rely on.
+            const enchantManaReserve = 40
+            affordable := func(spell spellbook.Spell) bool {
+                return self.Mana >= self.ComputeEffectiveSpellCost(spell, true) + enchantManaReserve
+            }
+
+            // emit a single enchant cast on a target unit; returns true if emitted.
+            castOn := func(spell spellbook.Spell, target units.StackUnit) bool {
+                if target == nil || !affordable(spell) {
+                    return false
+                }
+                if target.HasEnchantment(spell.GetUnitEnchantment()) {
+                    return false
+                }
+                decisions = append(decisions, &playerlib.AICastUnitSpellDecision{
+                    Spell: spell,
+                    Target: target,
+                })
+                if stack := self.FindStackByUnit(target); stack != nil {
+                    ai.setActivity(stack, fmt.Sprintf("casting %v on %v", spell.Name, target.GetName()))
+                }
+                return true
+            }
+
+            cast := false
+
+            // --- (b) scout mobility ---
+            // A lone roaming scout benefits most from movement enchantments:
+            // Water Walking lets it cross otherwise-impassable ocean, Path Finding
+            // ignores terrain movement penalties, so it reveals far more map per
+            // turn. We only target single-unit, non-city stacks because a unit
+            // enchantment helps that one unit's movement, not a mixed stack's.
+            mobilitySpells := []string{"Water Walking", "Path Finding", "Pathfinding"}
+            for _, name := range mobilitySpells {
+                if cast {
+                    break
+                }
+                spell, ok := findEnchantSpell(enchantSpells, name)
+                if !ok {
+                    continue
+                }
+                for _, stack := range self.Stacks {
+                    if ai.Attacking[stack] || stackHasSettler(stack) || stackHasMelder(stack) {
+                        continue
+                    }
+                    // only lone scouts roaming outside a city
+                    if self.FindCity(stack.X(), stack.Y(), stack.Plane()) != nil {
+                        continue
+                    }
+                    fighters := combatUnits(stack)
+                    if len(fighters) != 1 {
+                        continue
+                    }
+                    if castOn(spell, fighters[0]) {
+                        cast = true
+                        break
+                    }
+                }
+            }
+
+            // --- (e) elite stack combat buffs ---
+            // As we accumulate spare mana, reinforce our single strongest army so
+            // it can take on tougher lairs and enemies. Each turn we add the most
+            // impactful enchantment its lead unit is still missing, so buffs stack
+            // up over several turns.
+            if !cast {
+                var eliteStack *playerlib.UnitStack
+                eliteStrength := 0
+                for _, stack := range self.Stacks {
+                    if stackHasSettler(stack) || stackHasMelder(stack) {
+                        continue
+                    }
+                    // a lone scout isn't our elite army
+                    if len(combatUnits(stack)) < 2 {
+                        continue
+                    }
+                    strength := stackCombatStrength(stack)
+                    if strength > eliteStrength {
+                        eliteStrength = strength
+                        eliteStack = stack
+                    }
+                }
+
+                if eliteStack != nil {
+                    best := strongestUnit(combatUnits(eliteStack))
+                    // priority order of beneficial combat enchantments
+                    combatBuffs := []string{
+                        "Holy Weapon", "Holy Armor", "Giant Strength", "Bless",
+                        "Heroism", "Lionheart", "Iron Skin", "Endurance",
+                        "Elemental Armor", "Resist Magic", "True Sight", "Regeneration",
+                    }
+                    for _, name := range combatBuffs {
+                        spell, ok := findEnchantSpell(enchantSpells, name)
+                        if !ok {
+                            continue
+                        }
+                        if castOn(spell, best) {
+                            cast = true
+                            break
+                        }
+                    }
+                }
+            }
+
+        case GoalPlanarTravel:
+            // Expand to the other plane through open plane towers. The lair-clear
+            // goal already attacks guarded towers; once a tower is cleared the
+            // victorious stack is left standing on it, ready to travel.
+            //
+            // We only ferry when we have spare forces and want a foothold on the
+            // far plane (see aiWantsPlaneFoothold), so this never strips our core
+            // army or ping-pongs stacks back and forth.
+            if len(self.Stacks) < 3 {
+                break
+            }
+
+            // 1) shift any spare stack already standing on a wanted open tower
+            shifted := false
+            for _, stack := range self.Stacks {
+                if ai.Attacking[stack] {
+                    continue
+                }
+                if aiWantsToShift(self, aiServices, stack) {
+                    decisions = append(decisions, &playerlib.AIPlaneShiftDecision{Stack: stack})
+                    ai.setActivity(stack, fmt.Sprintf("planar travel to %v", stack.Plane().Opposite()))
+                    shifted = true
+                }
+            }
+
+            // 2) otherwise route one spare stack to the nearest explored open
+            //    tower leading to a plane we want a foothold on
+            if !shifted {
+                for _, plane := range []data.Plane{data.PlaneArcanus, data.PlaneMyrror} {
+                    if !aiWantsPlaneFoothold(self, aiServices, plane) {
+                        continue
+                    }
+                    useMap := aiServices.GetMap(plane)
+                    if useMap == nil {
+                        continue
+                    }
+
+                    var towers []image.Point
+                    for _, point := range useMap.GetOpenTowerLocations() {
+                        if self.IsExplored(point.X, point.Y, plane) {
+                            towers = append(towers, point)
+                        }
+                    }
+                    if len(towers) == 0 {
+                        continue
+                    }
+
+                    var bestStack *playerlib.UnitStack
+                    var bestPath pathfinding.Path
+                    for _, stack := range self.Stacks {
+                        if stack.Plane() != plane || ai.Attacking[stack] {
+                            continue
+                        }
+                        if stackHasSettler(stack) || stackHasMelder(stack) || stackHasEngineer(stack) {
+                            continue
+                        }
+                        if stackCombatStrength(stack) <= 0 {
+                            continue
+                        }
+                        // stacks already on a tower are handled by step 1
+                        if useMap.HasOpenTower(stack.X(), stack.Y()) {
+                            continue
+                        }
+                        // never empty a city below its minimum garrison
+                        if city := self.FindCity(stack.X(), stack.Y(), plane); city != nil {
+                            if len(getMoveableUnits(stack.Units(), getCityMinimumAttackPower(city))) == 0 {
+                                continue
+                            }
+                        }
+                        for _, tower := range towers {
+                            path, ok := aiServices.FindPath(stack.X(), stack.Y(), tower.X, tower.Y, self, stack, self.GetFog(plane))
+                            if ok && len(path) > 0 {
+                                if bestStack == nil || len(path) < len(bestPath) {
+                                    bestStack = stack
+                                    bestPath = path
+                                }
+                            }
+                        }
+                    }
+
+                    if bestStack != nil {
+                        decisions = append(decisions, &playerlib.AIMoveStackDecision{
+                            Stack: bestStack,
+                            Path: bestPath,
+                            Units: combatUnits(bestStack),
+                        })
+                        dest := bestPath[len(bestPath)-1]
+                        ai.setActivity(bestStack, fmt.Sprintf("traveling to plane tower at (%d,%d)", dest.X, dest.Y))
+                        break
+                    }
+                }
+            }
+
         default:
             log.Printf("WARNING: unhandled goal %v", goal.Goal)
     }
 
-    return decisions
+    // attribute the decisions this goal produced (after its subgoals) for the debug overlay
+    buildingInfo := aiServices.GetBuildingInfos()
+    for _, decision := range decisions[ownStart:] {
+        info.Decisions = append(info.Decisions, describeDecision(decision, buildingInfo))
+    }
+
+    return decisions, info
 }
 
 func (ai *Enemy2AI) Update(self *playerlib.Player, aiServices playerlib.AIServices) []playerlib.AIDecision {
     var decisions []playerlib.AIDecision
+
+    // refresh our knowledge of nearby lairs / nodes / enemy cities before planning
+    ai.updateLairCatalogue(self, aiServices)
+    ai.updateScoutMemory(self, aiServices)
+
     goals := ai.ComputeGoals(self, aiServices)
 
     // compute these values once for all goals
@@ -839,8 +2961,16 @@ func (ai *Enemy2AI) Update(self *playerlib.Player, aiServices playerlib.AIServic
     }
 
     seenGoals := set.MakeSet[GoalType]()
+    ai.LastGoalDebug = nil
+    // rebuild per-stack activity descriptions this turn (watch-mode inspector)
+    ai.StackActivity = make(map[*playerlib.UnitStack]string)
+    // clear the per-turn settler-production reservations so DefendCities can see
+    // which cities BuildCities has earmarked for a settler this turn
+    ai.reservedSettlerCities = make(map[*citylib.City]bool)
     for _, goal := range goals {
-        decisions = append(decisions, ai.GoalDecisions(self, aiServices, goal, seenGoals, &aiData)...)
+        goalDecisions, info := ai.GoalDecisions(self, aiServices, goal, seenGoals, &aiData)
+        decisions = append(decisions, goalDecisions...)
+        ai.LastGoalDebug = append(ai.LastGoalDebug, info)
     }
 
     if self.ResearchingSpell.Invalid() {
@@ -862,7 +2992,15 @@ func (ai *Enemy2AI) Update(self *playerlib.Player, aiServices playerlib.AIServic
 }
 
 func (ai *Enemy2AI) ConfirmEncounter(stack *playerlib.UnitStack, encounter *maplib.ExtraEncounter) bool {
-    return false
+    if stack == nil || encounter == nil {
+        return false
+    }
+
+    // only attack a lair if our army is comfortably stronger than its defenders.
+    // refusing leaves the stack one tile away, which reveals the lair's contents
+    // (so a too-weak stack effectively scouts it for a future, stronger attack).
+    strength := lairStrength(encounter)
+    return float32(stackCombatStrength(stack)) >= float32(strength) * requiredLairMargin(strength)
 }
 
 func (ai *Enemy2AI) InvalidMove(stack *playerlib.UnitStack) {

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -113,6 +113,25 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
         game.maybeDoNaturesWrath(player)
     }
 
+    // AI unit-enchantment casts carry a pre-chosen target unit; apply the
+    // enchantment directly instead of opening the interactive target picker
+    // (which only exists for the human player).
+    if player.IsAI() && player.CastingSpellTarget != nil {
+        target := player.CastingSpellTarget
+        player.CastingSpellTarget = nil
+
+        enchantment := spell.GetUnitEnchantment()
+        if enchantment != data.UnitEnchantmentNone {
+            // only apply if the unit is still alive (in one of our stacks)
+            // and doesn't already have the enchantment
+            if stack := player.FindStackByUnit(target); stack != nil && !target.HasEnchantment(enchantment) {
+                target.AddEnchantment(enchantment)
+            }
+            return
+        }
+        // not a recognized unit enchantment; fall through to normal handling
+    }
+
     switch spell.Name {
         /*
             SUMMONING SPELLS

--- a/game/magic/game/cast.go
+++ b/game/magic/game/cast.go
@@ -113,25 +113,6 @@ func (game *Game) doCastSpell(player *playerlib.Player, spell spellbook.Spell) {
         game.maybeDoNaturesWrath(player)
     }
 
-    // AI unit-enchantment casts carry a pre-chosen target unit; apply the
-    // enchantment directly instead of opening the interactive target picker
-    // (which only exists for the human player).
-    if player.IsAI() && player.CastingSpellTarget != nil {
-        target := player.CastingSpellTarget
-        player.CastingSpellTarget = nil
-
-        enchantment := spell.GetUnitEnchantment()
-        if enchantment != data.UnitEnchantmentNone {
-            // only apply if the unit is still alive (in one of our stacks)
-            // and doesn't already have the enchantment
-            if stack := player.FindStackByUnit(target); stack != nil && !target.HasEnchantment(enchantment) {
-                target.AddEnchantment(enchantment)
-            }
-            return
-        }
-        // not a recognized unit enchantment; fall through to normal handling
-    }
-
     switch spell.Name {
         /*
             SUMMONING SPELLS
@@ -1640,6 +1621,19 @@ func (game *Game) doDisenchantArea(yield coroutine.YieldFunc, player *playerlib.
 }
 
 func (game *Game) doCastOnUnit(player *playerlib.Player, spell spellbook.Spell, animationIndex int, before UnitEnchantmentCallback, after UnitEnchantmentCallback) {
+    // AI unit-enchantment casts carry a pre-chosen target. Apply before/after
+    // here so Lycanthropy, Chaos Channels, Black Channels, etc. still run,
+    // instead of opening the human tile picker.
+    if player.IsAI() && player.CastingSpellTarget != nil {
+        target := player.CastingSpellTarget
+        player.CastingSpellTarget = nil
+
+        if player.FindStackByUnit(target) != nil && before(target) {
+            after(target)
+        }
+        return
+    }
+
     var selected func (yield coroutine.YieldFunc, tileX int, tileY int)
     selected = func (yield coroutine.YieldFunc, tileX int, tileY int){
         game.doMoveCamera(yield, tileX, tileY)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -5597,9 +5597,11 @@ func (game *Game) CreateOutpost(settlers units.StackUnit, player *playerlib.Play
     return newCity
 }
 
-func (game *Game) DoMeld(unit units.StackUnit, player *playerlib.Player, node *maplib.ExtraMagicNode){
-    node.Meld(player, unit.GetRawUnit())
+func (game *Game) DoMeld(unit units.StackUnit, player *playerlib.Player, node *maplib.ExtraMagicNode) bool {
+    melded := node.Meld(player, unit.GetRawUnit())
+    // whether melding succeeded or not the melding unit is removed
     player.RemoveUnit(unit)
+    return melded
 }
 
 // tryMeldNode melds the magic node the given stack is standing on, if the stack
@@ -5619,8 +5621,9 @@ func (game *Game) tryMeldNode(stack *playerlib.UnitStack, player *playerlib.Play
     }
     for _, unit := range stack.Units() {
         if unit.HasAbility(data.AbilityMeld) {
-            game.DoMeld(unit, player, node)
-            return true
+            if game.DoMeld(unit, player, node) {
+                return true
+            }
         }
     }
     return false

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3893,8 +3893,8 @@ func (handlers *GameMoveHandlers) ShowMovement(x int, y int, stack *playerlib.Un
     handlers.Game.showMovement(handlers.Yield, x, y, stack, center)
 }
 
-func (handlers *GameMoveHandlers) DoEncounter(player *playerlib.Player, stack *playerlib.UnitStack, encounter *maplib.ExtraEncounter, map_ *maplib.Map, x int, y int) {
-    handlers.Game.doEncounter(handlers.Yield, player, stack, encounter, map_, x, y)
+func (handlers *GameMoveHandlers) DoEncounter(player *playerlib.Player, stack *playerlib.UnitStack, encounter *maplib.ExtraEncounter, map_ *maplib.Map, x int, y int) combat.CombatState {
+    return handlers.Game.doEncounter(handlers.Yield, player, stack, encounter, map_, x, y)
 }
 
 func (handlers *GameMoveHandlers) DoCombat(player *playerlib.Player, stack *playerlib.UnitStack, enemy *playerlib.Player, enemyStack *playerlib.UnitStack, zone combat.ZoneType) combat.CombatState {
@@ -4010,6 +4010,26 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
                     if stack != nil {
                         game.CreateOutpost(stack, player)
                     }
+                case *playerlib.AIBuildRoadDecision:
+                    build := decision.(*playerlib.AIBuildRoadDecision)
+                    roadStack := build.Stack
+                    path := game.FindRoadPath(roadStack.X(), roadStack.Y(), build.X, build.Y, player, roadStack, player.GetFog(roadStack.Plane()))
+                    if len(path) > 0 {
+                        for _, unit := range roadStack.Units() {
+                            if unit.HasAbility(data.AbilityConstruction) {
+                                unit.SetBuildRoadPath(path)
+                            }
+                        }
+                        game.MaybeBuildRoads(roadStack, player)
+                    }
+                case *playerlib.AIMeldNodeDecision:
+                    meld := decision.(*playerlib.AIMeldNodeDecision)
+                    game.tryMeldNode(meld.Stack, player)
+                case *playerlib.AIPlaneShiftDecision:
+                    shift := decision.(*playerlib.AIPlaneShiftDecision)
+                    if err := game.PlaneShift(shift.Stack, player); err == nil {
+                        shift.Stack.CurrentPath = nil
+                    }
                 case *playerlib.AIProduceDecision:
                     produce := decision.(*playerlib.AIProduceDecision)
                     log.Printf("ai %v city %v producing %v %v", player.Wizard.Name, produce.City.Name, game.Model.BuildingInfo.Name(produce.Building), produce.Unit.Name)
@@ -4027,6 +4047,12 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
                     if player.CastingSpell.Invalid() {
                         player.CastingSpell = cast.Spell
                     }
+                case *playerlib.AICastUnitSpellDecision:
+                    cast := decision.(*playerlib.AICastUnitSpellDecision)
+                    if player.CastingSpell.Invalid() {
+                        player.CastingSpell = cast.Spell
+                        player.CastingSpellTarget = cast.Target
+                    }
             }
         }
 
@@ -4037,6 +4063,20 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
             for !stack.AnyOutOfMoves() && len(stack.CurrentPath) > 0 {
                 stack.CurrentPath = game.Model.doAiMoveUnit(moveHandlers, player, stack)
             }
+        }
+
+        // continue any in-progress road building and attempt to meld any node
+        // a stack is now standing on (engineers/melders may have just arrived).
+        for _, stack := range slices.Clone(player.Stacks) {
+            for _, unit := range stack.Units() {
+                if unit.GetBusy() == units.BusyStatusBuildRoad && len(unit.GetBuildRoadPath()) > 0 {
+                    game.MaybeBuildRoads(stack, player)
+                    break
+                }
+            }
+        }
+        for _, stack := range slices.Clone(player.Stacks) {
+            game.tryMeldNode(stack, player)
         }
 
         player.AIBehavior.PostUpdate(player, game.Model)
@@ -5554,6 +5594,30 @@ func (game *Game) CreateOutpost(settlers units.StackUnit, player *playerlib.Play
 func (game *Game) DoMeld(unit units.StackUnit, player *playerlib.Player, node *maplib.ExtraMagicNode){
     node.Meld(player, unit.GetRawUnit())
     player.RemoveUnit(unit)
+}
+
+// tryMeldNode melds the magic node the given stack is standing on, if the stack
+// contains a unit able to meld (a magic spirit) and the node is unowned by this
+// player and not warped. Returns true if a meld happened.
+func (game *Game) tryMeldNode(stack *playerlib.UnitStack, player *playerlib.Player) bool {
+    useMap := game.GetMap(stack.Plane())
+    if useMap == nil {
+        return false
+    }
+    if useMap.GetEncounter(stack.X(), stack.Y()) != nil {
+        return false
+    }
+    node := useMap.GetMagicNode(stack.X(), stack.Y())
+    if node == nil || node.Warped || node.MeldingWizard == player {
+        return false
+    }
+    for _, unit := range stack.Units() {
+        if unit.HasAbility(data.AbilityMeld) {
+            game.DoMeld(unit, player, node)
+            return true
+        }
+    }
+    return false
 }
 
 func (game *Game) DoBuildAction(player *playerlib.Player){

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -1750,7 +1750,7 @@ func (model *GameModel) FindStacksOnContinent(x int, y int, plane data.Plane, pl
 
 type MovementHandler interface {
     ShowMovement(x int, y int, stack *playerlib.UnitStack, center bool)
-    DoEncounter(player *playerlib.Player, stack *playerlib.UnitStack, encounter *maplib.ExtraEncounter, map_ *maplib.Map, x int, y int)
+    DoEncounter(player *playerlib.Player, stack *playerlib.UnitStack, encounter *maplib.ExtraEncounter, map_ *maplib.Map, x int, y int) combat.CombatState
     DoCombat(player *playerlib.Player, stack *playerlib.UnitStack, enemy *playerlib.Player, enemyStack *playerlib.UnitStack, zone combat.ZoneType) combat.CombatState
     DefeatCity(player *playerlib.Player, stack *playerlib.UnitStack, enemy *playerlib.Player, city *citylib.City) (bool, int)
 }
@@ -1818,7 +1818,15 @@ func (model *GameModel) doAiMoveUnit(handlers MovementHandler, player *playerlib
 
         if encounter != nil {
             // game.doEncounter(yield, player, stack, encounter, mapUse, stack.X(), stack.Y())
-            handlers.DoEncounter(player, stack, encounter, mapUse, stack.X(), stack.Y())
+            state := handlers.DoEncounter(player, stack, encounter, mapUse, stack.X(), stack.Y())
+
+            // if we fled the encounter, step back off its tile instead of
+            // lingering on top of the (still-guarded) lair / node / tower
+            if state == combat.CombatStateAttackerFlee {
+                stack.SetX(oldX)
+                stack.SetY(oldY)
+            }
+
             return nil
         }
 

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -221,8 +221,12 @@ func (model *GameModel) FindPath(oldX int, oldY int, newX int, newY int, player 
         tileTo := useMap.GetTile(newX, newY)
         tileFrom := useMap.GetTile(oldX, oldY)
 
-        // if this is a water unit that cannot walk on land then just return nil immediately since the move is impossible
-        if tileTo.Tile.IsLand() && !stack.CanMoveOnLand(true) {
+        // if this stack contains a water-bound unit (a ship) that cannot walk on
+        // land then the move onto land is impossible. Check ALL units, not just
+        // the active ones: AI movement does not split inactive units off the
+        // stack (see doAiMoveUnit), so an inactive ship must not be dragged
+        // ashore when the active land units walk inland.
+        if tileTo.Tile.IsLand() && !stack.CanMoveOnLand(false) {
             return nil, false
         }
 
@@ -495,9 +499,11 @@ func (model *GameModel) ComputeTerrainCost(stack playerlib.PathStack, sourceX in
         return false
     }
 
-    // sailing units cannot move onto land
+    // sailing units cannot move onto land. Check ALL units (not just active
+    // ones) so an inactive ship in the stack is never dragged ashore when the
+    // active land units walk onto land.
     if tileTo.Tile.IsLand() {
-        if !stack.CanMoveOnLand(true) {
+        if !stack.CanMoveOnLand(false) {
             return fraction.Zero(), false
         }
     }

--- a/game/magic/game/path_test.go
+++ b/game/magic/game/path_test.go
@@ -199,4 +199,41 @@ func TestPathBasic(test *testing.T) {
     if !checkValidPathUnexplored(2, 1, units.HighMenSwordsmen) {
         test.Errorf("Land walker should be able to path to unexplored water tile")
     }
+
+    // an inactive ship sharing a stack with active land units must not be
+    // dragged onto land. AI movement does not split inactive units off first
+    // (human movement does), so pathfinding has to reject the move.
+    func() {
+        player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
+
+        warship := player1.AddUnit(units.MakeOverworldUnit(units.Warship, 1, 0, data.PlaneArcanus))
+        swordsmen := player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 1, 0, data.PlaneArcanus))
+
+        stack := player1.FindStack(1, 0, data.PlaneArcanus)
+        stack.SetActive(warship, false)
+        stack.SetActive(swordsmen, true)
+
+        path, ok := model.FindPath(1, 0, 2, 0, player1, stack, fog)
+        if ok && len(path) > 0 {
+            test.Errorf("stack with an inactive ship must not path from water onto land")
+        }
+    }()
+
+    // same rule once the mixed stack is already on the coast: active land
+    // units must not walk further inland while the ship is still in the stack
+    func() {
+        player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
+
+        warship := player1.AddUnit(units.MakeOverworldUnit(units.Warship, 2, 0, data.PlaneArcanus))
+        swordsmen := player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 2, 0, data.PlaneArcanus))
+
+        stack := player1.FindStack(2, 0, data.PlaneArcanus)
+        stack.SetActive(warship, false)
+        stack.SetActive(swordsmen, true)
+
+        path, ok := model.FindPath(2, 0, 3, 0, player1, stack, fog)
+        if ok && len(path) > 0 {
+            test.Errorf("stack with an inactive ship must not path further inland")
+        }
+    }()
 }

--- a/game/magic/game/path_test.go
+++ b/game/magic/game/path_test.go
@@ -201,8 +201,10 @@ func TestPathBasic(test *testing.T) {
     }
 
     // an inactive ship sharing a stack with active land units must not be
-    // dragged onto land. AI movement does not split inactive units off first
-    // (human movement does), so pathfinding has to reject the move.
+    // dragged onto land. Ships only occupy ocean/shore (both !IsLand), so
+    // the case that matters is water -> land. AI movement does not split
+    // inactive units off first (human movement does), so pathfinding has
+    // to reject the move.
     func() {
         player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
 
@@ -216,24 +218,6 @@ func TestPathBasic(test *testing.T) {
         path, ok := model.FindPath(1, 0, 2, 0, player1, stack, fog)
         if ok && len(path) > 0 {
             test.Errorf("stack with an inactive ship must not path from water onto land")
-        }
-    }()
-
-    // same rule once the mixed stack is already on the coast: active land
-    // units must not walk further inland while the ship is still in the stack
-    func() {
-        player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, 3, 1, map[herolib.HeroType]string{}, &model)
-
-        warship := player1.AddUnit(units.MakeOverworldUnit(units.Warship, 2, 0, data.PlaneArcanus))
-        swordsmen := player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 2, 0, data.PlaneArcanus))
-
-        stack := player1.FindStack(2, 0, data.PlaneArcanus)
-        stack.SetActive(warship, false)
-        stack.SetActive(swordsmen, true)
-
-        path, ok := model.FindPath(2, 0, 3, 0, player1, stack, fog)
-        if ok && len(path) > 0 {
-            test.Errorf("stack with an inactive ship must not path further inland")
         }
     }()
 }

--- a/game/magic/game/serialize.go
+++ b/game/magic/game/serialize.go
@@ -194,7 +194,10 @@ func MakeModelFromSerialized(
             if player.GetBanner() == data.BannerBrown {
                 player.AIBehavior = ai.MakeRaiderAI()
             } else {
-                player.AIBehavior = ai.MakeEnemyAI()
+                // use the same active wizard AI as a freshly-started game
+                // (model.go AddPlayer) so loading a save doesn't silently drop
+                // back to the legacy EnemyAI
+                player.AIBehavior = ai.MakeEnemy2AI()
             }
             player.StrategicCombat = true
         }

--- a/game/magic/load/convert.go
+++ b/game/magic/load/convert.go
@@ -631,7 +631,9 @@ func (saveGame *SaveGame) convertPlayer(playerIndex int, wizards []setup.WizardC
 
     var aiBehavior playerlib.AIBehavior
     if !human {
-        aiBehavior = ai.MakeEnemyAI()
+        // use the active wizard AI (same as a freshly-started game) rather than
+        // the legacy EnemyAI, so imported original saves play with the real AI
+        aiBehavior = ai.MakeEnemy2AI()
     }
 
     enchantmentMap := map[int]data.Enchantment{

--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -357,11 +357,14 @@ func makeEncounter(encounterType EncounterType, difficulty data.DifficultySettin
             budget = (rand.N(30) + 1) * 30
         }
     } else {
+        // Wider spread and a lower floor so strong lairs vary more
+        // (fewer uniformly-maxed high-end lairs), then scaled down ~25%.
         if plane == data.PlaneArcanus || encounterType == EncounterTypePlaneTower {
-            budget = (rand.N(80) + 1) * 50 + 250
+            budget = (rand.N(145) + 1) * 30 + 75
         } else {
-            budget = (rand.N(90) + 1) * 50 + 250
+            budget = (rand.N(160) + 1) * 30 + 75
         }
+        budget = int(float64(budget) * 0.75)
     }
 
     bonus := float64(0)
@@ -1314,6 +1317,35 @@ func (mapObject *Map) GetEncounterLocations() []image.Point {
 
     for point, extras := range mapObject.ExtraMap {
         _, exists := extras[ExtraKindEncounter]
+        if exists {
+            out = append(out, point)
+        }
+    }
+
+    return out
+}
+
+func (mapObject *Map) GetMagicNodeLocations() []image.Point {
+    var out []image.Point
+
+    for point, extras := range mapObject.ExtraMap {
+        _, exists := extras[ExtraKindMagicNode]
+        if exists {
+            out = append(out, point)
+        }
+    }
+
+    return out
+}
+
+// GetOpenTowerLocations returns every tile on this map that holds an open
+// (already-cleared) plane tower. A unit standing on an open tower can planar
+// travel to the same tile on the opposite plane.
+func (mapObject *Map) GetOpenTowerLocations() []image.Point {
+    var out []image.Point
+
+    for point, extras := range mapObject.ExtraMap {
+        _, exists := extras[ExtraKindOpenTower]
         if exists {
             out = append(out, point)
         }

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -67,6 +67,19 @@ type AICastSpellDecision struct {
     Spell spellbook.Spell
 }
 
+// request that the AI begin casting a unit-enchantment spell on a specific
+// target unit. The engine sets CastingSpell + CastingSpellTarget; when the
+// multi-turn cast completes, the enchantment is applied directly to Target
+// (bypassing the interactive target-selection UI used by human players).
+type AICastUnitSpellDecision struct {
+    Spell spellbook.Spell
+    Target units.StackUnit
+}
+
+func (decision *AICastUnitSpellDecision) String() string {
+    return fmt.Sprintf("CastUnitSpell %v on %v", decision.Spell.Name, decision.Target.GetName())
+}
+
 type AICreateUnitDecision struct {
     Unit units.Unit
     X int
@@ -78,6 +91,41 @@ type AICreateUnitDecision struct {
 
 type AIBuildOutpostDecision struct {
     Stack *UnitStack
+}
+
+// request the engineer stack to build a road from its current location to the
+// target tile (typically another friendly city). The engine computes the road
+// path and starts construction.
+type AIBuildRoadDecision struct {
+    Stack *UnitStack
+    X int
+    Y int
+}
+
+func (decision *AIBuildRoadDecision) String() string {
+    return fmt.Sprintf("BuildRoad from (%v,%v) to (%v,%v)", decision.Stack.X(), decision.Stack.Y(), decision.X, decision.Y)
+}
+
+// request that a spirit (a unit with the Meld ability) standing on a magic node
+// meld with it, bringing the node's magic power under the wizard's control. The
+// engine validates the stack is on an unmelded node and consumes the spirit.
+type AIMeldNodeDecision struct {
+    Stack *UnitStack
+}
+
+func (decision *AIMeldNodeDecision) String() string {
+    return fmt.Sprintf("MeldNode at (%v,%v)", decision.Stack.X(), decision.Stack.Y())
+}
+
+// request that a stack standing on an open plane tower travel to the same tile
+// on the opposite plane. The engine validates the move (PlaneShift) and clears
+// the stack's stale path.
+type AIPlaneShiftDecision struct {
+    Stack *UnitStack
+}
+
+func (decision *AIPlaneShiftDecision) String() string {
+    return fmt.Sprintf("PlaneShift at (%v,%v)", decision.Stack.X(), decision.Stack.Y())
 }
 
 // choose a new spell to research
@@ -339,6 +387,10 @@ type Player struct {
     // how much mana has been put towards the current spell. When this value equals
     // the spell's casting cost, the spell is cast
     CastingSpellProgress int
+
+    // for AI unit-enchantment casts: the unit the spell should be applied to
+    // when the cast completes. nil for human casts and non-targeted spells.
+    CastingSpellTarget units.StackUnit
 
     // the artifact currently being created by a spell cast of Create Artifact or Enchant Item
     CreateArtifact *artifact.Artifact
@@ -971,6 +1023,7 @@ func (player *Player) InitializeResearchableSpells(spells *spellbook.Spells) {
 func (player *Player) InterruptCastingSpell() {
     player.CastingSpell = spellbook.Spell{}
     player.CastingSpellProgress = 0
+    player.CastingSpellTarget = nil
 }
 
 // the base casting skill + any heroes with the caster ability in the fortress


### PR DESCRIPTION
## Summary
Rebase of [#716](https://github.com/kazzmir/master-of-magic/pull/716) (alexfibreplanner) onto current master, stacked on [#738](https://github.com/kazzmir/master-of-magic/pull/738).

We cannot push to the original branch, so this is a follow-up PR that
keeps the Enemy2 goal planner and applies Jon's review notes.

### From #716
- Weighted goal tree for Enemy2: defeat, expand, power, defend, roads,
  meld nodes, unit enchantments, planar travel
- Lair clearing that only commits stacks strong enough to win
- `AIBuildRoadDecision`, `AIMeldNodeDecision`, `AICastUnitSpellDecision`,
  `AIPlaneShiftDecision` + engine handlers
- `DoEncounter` returns `CombatState` so a fleeing attacker walks back
  to its origin tile
- `GetMagicNodeLocations` / `GetOpenTowerLocations`

### Review fixes
- **Walking rules** live in #738 (the `CanMoveOnLand(false)` split + tests),
  which this PR is stacked on. That is the ship-on-land bug: AI movement
  does not split inactive units, so an inactive warship was dragged inland.
- **Unit enchantments** no longer `AddEnchantment` and return in
  `doCastSpell`. AI still sets `CastingSpellTarget`; `doCastOnUnit` applies
  `before`/`after` on that unit so Lycanthropy / Chaos Channels / Black
  Channels still run, and skips the human tile picker.

## Test plan
- [x] `go test ./game/magic/game/ ./game/magic/ai/ ./game/magic/player/ ./game/magic/maplib/`
- [x] `go build ./game/magic`
- [ ] Watch an AI-vs-AI game (`-watch`) and confirm lairs, roads, meld, planes

Original test-plan box from #716 left unchecked on purpose — still wants
a watch-mode pass.