### PR TITLE
ai: port Enemy2 economy and encounter tweaks from #701

### DIFF
--- a/game/magic/ai/ai_test.go
+++ b/game/magic/ai/ai_test.go
@@ -7,7 +7,21 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
+    "github.com/kazzmir/master-of-magic/game/magic/units"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
 )
+
+func TestUnitAttackPowerUsesToHit(test *testing.T) {
+    swordsmen := units.MakeOverworldUnit(units.HighMenSwordsmen, 0, 0, data.PlaneArcanus)
+    if unitAttackPower(swordsmen) <= 0 {
+        test.Errorf("swordsmen should have positive attack power after to-hit scaling")
+    }
+
+    settler := units.MakeOverworldUnit(units.HighMenSettlers, 0, 0, data.PlaneArcanus)
+    if unitAttackPower(settler) != 0 {
+        test.Errorf("settlers should still count as 0 attack power, got %v", unitAttackPower(settler))
+    }
+}
 
 func TestBuyItem(test *testing.T) {
     enemy := MakeEnemyAI()

--- a/game/magic/ai/enemy2.go
+++ b/game/magic/ai/enemy2.go
@@ -157,25 +157,26 @@ type AIData struct {
 }
 
 func rawUnitAttackPower(unit units.Unit) int {
-    meleePower := float32(unit.GetMeleeAttackPower())
-    rangedPower := float32(unit.GetRangedAttackPower())
-    if unit.GetRangedAttackDamageType() == units.DamageRangedMagical {
-        rangedPower *= 1.5
-    }
-
-    return int(max(meleePower, rangedPower)) * unit.GetCount()
+    overworld := units.MakeOverworldUnit(unit, 0, 0, data.PlaneArcanus)
+    return unitAttackPower(overworld)
 }
 
 func unitAttackPower(unit ...units.StackUnit) int {
     total := 0
     for _, u := range unit {
-        meleePower := float32(u.GetMeleeAttackPower())
-        rangedPower := float32(u.GetRangedAttackPower())
+        meleePower := float32(u.GetMeleeAttackPower()) * float32(u.GetToHitMelee()) / 100
+        rangedPower := float32(u.GetRangedAttackPower()) * 0.3
         if u.GetRangedAttackDamageType() == units.DamageRangedMagical {
             rangedPower *= 1.5
         }
 
-        power := int(max(meleePower, rangedPower)) * u.GetCount()
+        best := max(meleePower, rangedPower)
+        // to-hit can shrink a 1-attack unit below 1; keep a floor so they
+        // still count as combatants. True 0-attack units (settlers) stay 0.
+        power := 0
+        if best > 0 {
+            power = int(max(1, best)) * u.GetCount()
+        }
 
         total += power
     }
@@ -758,7 +759,8 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                                 Building: buildinglib.BuildingTradeGoods,
                                 Unit: units.UnitNone,
                             })
-                        case chance(40):
+                        // always try to build something rather than sitting idle
+                        default:
 
                             // FIXME: if unrest is high then build a shrine/temple/etc
                             // if money production is low then build a marketplace/bank/etc
@@ -862,7 +864,14 @@ func (ai *Enemy2AI) Update(self *playerlib.Player, aiServices playerlib.AIServic
 }
 
 func (ai *Enemy2AI) ConfirmEncounter(stack *playerlib.UnitStack, encounter *maplib.ExtraEncounter) bool {
-    return false
+    armyPower := stackAttackPower(stack)
+
+    encounterPower := 0
+    for _, unit := range encounter.Units {
+        encounterPower += rawUnitAttackPower(unit)
+    }
+
+    return armyPower >= encounterPower - rand.N(10)
 }
 
 func (ai *Enemy2AI) InvalidMove(stack *playerlib.UnitStack) {
@@ -918,11 +927,32 @@ func (ai *Enemy2AI) NewTurn(player *playerlib.Player) {
 
     player.RebalanceFood()
 
-    ai.Attacking = make(map[*playerlib.UnitStack]bool)
-
-    for _, city := range player.Cities {
-        log.Printf("ai %v city %v farmer=%v worker=%v rebel=%v", player.Wizard.Name, city.Name, city.Farmers, city.Workers, city.Rebels)
+    ok := true
+    for ok && player.Gold + player.GoldPerTurn() * 3 < 0 {
+        var newRate fraction.Fraction
+        newRate, ok = player.NextTaxRate(player.TaxRate)
+        if ok {
+            player.UpdateTaxRate(newRate)
+        }
     }
+
+    if player.Gold < 50 && player.Mana > 200 {
+        ai.ConvertManaToGold(player)
+    }
+
+    ai.Attacking = make(map[*playerlib.UnitStack]bool)
+}
+
+func (ai *Enemy2AI) ConvertManaToGold(self *playerlib.Player) {
+    manaToConvert := int(float64(self.Mana) * 0.2)
+
+    alchemyConversion := 0.5
+    if self.Wizard.RetortEnabled(data.RetortAlchemy) {
+        alchemyConversion = 1
+    }
+
+    self.Mana -= manaToConvert
+    self.Gold += int(float64(manaToConvert) * alchemyConversion)
 }
 
 func (ai *Enemy2AI) ConfirmRazeTown(city *citylib.City) bool {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3913,7 +3913,7 @@ func MakeMoveHandlers(game *Game, yield coroutine.YieldFunc) MovementHandler {
 }
 
 func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player) {
-    log.Printf("AI %v year %v: make decisions", player.Wizard.Name, game.Model.TurnNumber)
+    // log.Printf("AI %v year %v: make decisions", player.Wizard.Name, game.Model.TurnNumber)
 
     if player.AIBehavior != nil {
         decisionResult := make(chan []playerlib.AIDecision)
@@ -3924,7 +3924,7 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
             close(decisionResult)
         }()
 
-        log.Printf("AI %v waiting for decisions", player.Wizard.Name)
+        // log.Printf("AI %v waiting for decisions", player.Wizard.Name)
         var decisions []playerlib.AIDecision
         done := false
 
@@ -3964,7 +3964,7 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
 
         game.PopDrawer()
 
-        log.Printf("AI %v Decisions: %v", player.Wizard.Name, decisions)
+        // log.Printf("AI %v Decisions: %v", player.Wizard.Name, decisions)
 
         for _, decision := range decisions {
             switch decision.(type) {
@@ -4012,7 +4012,7 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
                     }
                 case *playerlib.AIProduceDecision:
                     produce := decision.(*playerlib.AIProduceDecision)
-                    log.Printf("ai %v city %v producing %v %v", player.Wizard.Name, produce.City.Name, game.Model.BuildingInfo.Name(produce.Building), produce.Unit.Name)
+                    log.Printf("Year=%v AI %v(%v) city %v producing %v %v", game.Model.TurnNumber, player.Wizard.Name, player.GetBanner(), produce.City.Name, game.Model.BuildingInfo.Name(produce.Building), produce.Unit.Name)
                     produce.City.ProducingBuilding = produce.Building
                     produce.City.ProducingUnit = produce.Unit
                 case *playerlib.AIResearchSpellDecision:
@@ -7169,7 +7169,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
                             default:
                         }
                     } else {
-                        log.Printf("ai created %v", game.Model.BuildingInfo.Name(newBuilding.Building))
+                        log.Printf("Year=%v AI %v(%v) city %v created %v", game.Model.TurnNumber, player.Wizard.Name, player.GetBanner(), city.Name, game.Model.BuildingInfo.Name(newBuilding.Building))
                     }
                 case *citylib.CityEventOutpostDestroyed:
                     removeCities = append(removeCities, city)
@@ -7206,6 +7206,7 @@ func (game *Game) StartPlayerTurn(player *playerlib.Player) {
 
                     if player.AIBehavior != nil {
                         player.AIBehavior.ProducedUnit(city, player)
+                        log.Printf("Year=%v AI %v(%v) city %v created unit %v", game.Model.TurnNumber, player.Wizard.Name, player.GetBanner(), city.Name, overworldUnit.GetName())
                     }
                 }
             }
@@ -7627,6 +7628,19 @@ func (game *Game) EndOfTurn() {
         }
 
         player.UpdateDiplomaticRelations()
+    }
+
+    if game.WatchMode {
+        log.Printf("---- End of Year %v Summary ----", game.Model.TurnNumber - 1)
+        for _, player := range game.Model.Players {
+            if !player.IsHuman() {
+                power := game.Model.ComputePower(player)
+                log.Printf("Wizard %v (%v) - Gold: %v (%v), Food: %v, Mana: %v (%v), Cities: %v, Units: %v, Tax: %v, Research: %v (%v)",
+                    player.Wizard.Name, player.GetBanner(), player.Gold, player.GoldPerTurn(), player.FoodPerTurn(), player.Mana, player.ManaPerTurn(power, game.Model),
+                    len(player.Cities), player.UnitCount(), player.TaxRate,
+                    player.ResearchingSpell.Name, player.ResearchProgress)
+            }
+        }
     }
 
 }

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -5,7 +5,7 @@ import (
     "slices"
     "math"
     "math/rand/v2"
-    "log"
+    _ "log"
 
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/units"
@@ -1770,7 +1770,7 @@ func (model *GameModel) doAiMoveUnit(handlers MovementHandler, player *playerlib
     to := path[0]
     path = path[1:]
 
-    log.Printf("  moving stack %v to %v, %v", stack, to.X, to.Y)
+    // log.Printf("  moving stack %v to %v, %v", stack, to.X, to.Y)
     getStack := func(x int, y int) (playerlib.PathStack, bool) {
         found := player.FindStack(x, y, stack.Plane())
         return found, found != nil

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -1195,6 +1195,26 @@ func (player *Player) UpdateTaxRate(rate fraction.Fraction){
     player.UpdateUnrest()
 }
 
+func (player *Player) NextTaxRate(rate fraction.Fraction) (fraction.Fraction, bool) {
+    rates := []fraction.Fraction{
+        fraction.Zero(),
+        fraction.Make(1, 2),
+        fraction.Make(1, 1),
+        fraction.Make(3, 2),
+        fraction.Make(2, 1),
+        fraction.Make(5, 2),
+        fraction.Make(3, 1),
+    }
+
+    for i := range rates {
+        if i < len(rates) - 1 && rate.Equals(rates[i]) {
+            return rates[i + 1], true
+        }
+    }
+
+    return fraction.Zero(), false
+}
+
 func (player *Player) UpdateUnrest(){
     for _, city := range player.Cities {
         city.UpdateUnrest()

--- a/game/magic/player/player_test.go
+++ b/game/magic/player/player_test.go
@@ -8,6 +8,7 @@ import (
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/lib/fraction"
 )
 
 func TestHeroNames(test *testing.T) {
@@ -78,6 +79,20 @@ func TestResearchPoints(test *testing.T) {
 
     if computeEffectiveResearchPerTurn(&wizard, points, natureSpell) != int(points * (1 + 0.1 + 0.25)) {
         test.Errorf("Research points computation doesn't work")
+    }
+}
+
+func TestNextTaxRate(test *testing.T) {
+    player := MakePlayer(setup.WizardCustom{}, true, 1, 1, make(map[hero.HeroType]string), nil)
+
+    rate, ok := player.NextTaxRate(fraction.FromInt(1))
+    if !ok || !rate.Equals(fraction.Make(3, 2)) {
+        test.Errorf("expected 1 -> 3/2, got %v ok=%v", rate, ok)
+    }
+
+    rate, ok = player.NextTaxRate(fraction.Make(3, 1))
+    if ok {
+        test.Errorf("3 gold tax is the maximum, got next %v", rate)
     }
 }
 


### PR DESCRIPTION
## Summary
Rebase of the useful bits from [#701](https://github.com/kazzmir/master-of-magic/pull/701) (`more-ai`, Jan 2026, conflicts with master).

#701 is a small Enemy2 patch, not the goal-planner in #716/#739. These pieces still apply on current master:

- **Attack power** counts melee to-hit and scales ranged by 0.3. 0-attack units (settlers) stay 0 so they are not treated as combatants.
- **Cities always try to build** instead of a 40% chance to sit idle (`chance(40)` → `default`).
- **ConfirmEncounter** is no longer `return false`. The stack attacks if its power is at least the lair’s, minus a small random fudge. (#739 replaces this with a stronger lair-margin check if that stack lands.)
- **Tax / alchemy:** `NewTurn` still resets tax to 1, then raises it while `gold + 3 * goldPerTurn < 0`. If gold &lt; 50 and mana &gt; 200, convert 20% of mana (½ rate, or 1:1 with Alchemy).
- **`Player.NextTaxRate`** walks the original 0 / ½ / 1 / 1½ / 2 / 2½ / 3 ladder.
- Quieter per-turn AI logs; year-prefixed produce/create lines; watch-mode end-of-year summary.

## Left on #701
- Watch mode: skip raiders and drop opponents to 1. That changes how `-watch` is used, not how the AI plays a normal game.

## Tests
- `TestNextTaxRate`
- `TestUnitAttackPowerUsesToHit` (swordsmen &gt; 0, settlers == 0)

`go test ./game/magic/ai/ ./game/magic/player/ ./game/magic/game/` and `go build ./game/magic` pass.