### PR TITLE
watch: add some ui controls

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -401,6 +401,7 @@ type Game struct {
     MovingStack *playerlib.UnitStack
 
     HudUI *uilib.UI
+    WatchUI *uilib.UI
     Help helplib.Help
 
     Camera camera.Camera
@@ -2322,6 +2323,27 @@ func (game *Game) doRandomEvent(yield coroutine.YieldFunc, event *RandomEvent, s
         game.Counter += 1
         yield()
     }
+}
+
+func (game *Game) SetWatchMode() {
+    game.WatchMode = true
+    game.WatchUI = game.MakeWatchUI()
+}
+
+func (game *Game) MakeWatchUI() *uilib.UI {
+
+    ui := &uilib.UI{
+        Cache: game.Cache,
+        Draw: func(ui *uilib.UI, screen *ebiten.Image){
+            ui.StandardDraw(screen)
+        },
+    }
+
+    var elements []*uilib.UIElement
+
+    ui.SetElementsFromArray(elements)
+
+    return ui
 }
 
 // the game is in a paused state where the user can look around but no updates are occurring
@@ -8267,7 +8289,11 @@ func (game *Game) DrawGame(screen *ebiten.Image){
         FogBlack: game.GetFogImage(),
     }
 
-    if !game.WatchMode {
+    if game.WatchMode {
+        overworld.DrawOverworld(screen, ebiten.GeoM{})
+
+        game.WatchUI.Draw(game.WatchUI, screen)
+    } else {
         overworldScreen := screen.SubImage(image.Rect(0, scale.Scale(18), scale.Scale(240), scale.Scale(data.ScreenHeight))).(*ebiten.Image)
         overworld.DrawOverworld(overworldScreen, ebiten.GeoM{})
 
@@ -8284,8 +8310,6 @@ func (game *Game) DrawGame(screen *ebiten.Image){
         */
 
         game.HudUI.Draw(game.HudUI, screen)
-    } else {
-        overworld.DrawOverworld(screen, ebiten.GeoM{})
     }
 
     // DEBUGGING: show tile coordinates on screen

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2341,6 +2341,17 @@ func (game *Game) MakeWatchUI() *uilib.UI {
 
     var elements []*uilib.UIElement
 
+    turnBox := image.Rect(5, 5, 100, 30)
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            vector.FillRect(screen, float32(turnBox.Min.X), float32(turnBox.Min.Y), float32(turnBox.Dx()), float32(turnBox.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
+
+            var options ebiten.DrawImageOptions
+            game.Fonts.WhiteFont.PrintOptions(screen, float64(turnBox.Min.X), float64(turnBox.Min.Y), font.FontOptions{DropShadow: true, Scale: 2, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Turn: %v", game.Model.TurnNumber))
+        },
+    })
+
     ui.SetElementsFromArray(elements)
 
     return ui

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2336,6 +2336,42 @@ func (game *Game) SetWatchMode(watchSpeed int) {
     ebiten.SetTPS(watchSpeed)
 }
 
+func makeFadeInElement(fadeSpeed uint64, minAlpha float32, insetDistance int, counter *uint64, makeElement func(*util.AlphaFadeFunc) *uilib.UIElement) []*uilib.UIElement {
+    scaleAlpha := func(fade util.AlphaFadeFunc, minAlpha float32) util.AlphaFadeFunc {
+        return func() float32 {
+            value := fade()
+            return minAlpha + (1 - minAlpha) * value
+        }
+    }
+
+    var alphaFunc util.AlphaFadeFunc = func () float32 {
+        return minAlpha
+    }
+    update := false
+
+    newElement := makeElement(&alphaFunc)
+
+    return []*uilib.UIElement{
+        &uilib.UIElement{
+            Layer: newElement.Layer,
+            Rect: newElement.Rect.Inset(-insetDistance),
+            Inside: func(element *uilib.UIElement, x int, y int){
+                if !update {
+                    alphaFunc = scaleAlpha(util.MakeFadeIn(fadeSpeed, counter), minAlpha)
+                    update = true
+                }
+            },
+            NotInside: func(element *uilib.UIElement){
+                if update {
+                    update = false
+                    alphaFunc = scaleAlpha(util.MakeFadeOut(fadeSpeed, counter), minAlpha)
+                }
+            },
+        },
+        newElement,
+    }
+}
+
 func (game *Game) MakeWatchUI() *uilib.UI {
 
     ui := &uilib.UI{
@@ -2382,79 +2418,54 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         ebiten.SetTPS(game.watchSpeed)
     }
 
-    scaleAlpha := func(fade util.AlphaFadeFunc, minAlpha float32) util.AlphaFadeFunc {
-        return func() float32 {
-            value := fade()
-            return minAlpha + (1 - minAlpha) * value
-        }
-    }
+    elements = append(elements, makeFadeInElement(20, 0.4, 10, &game.Counter, 
+        func (alphaFunc *util.AlphaFadeFunc) *uilib.UIElement {
+            return &uilib.UIElement{
+                Layer: 1,
+                Rect: speedRect,
+                LeftClick: func(element *uilib.UIElement){
+                    mouseX, _ := inputmanager.MousePosition()
+                    mouseX = scale.Unscale(mouseX)
+                    updateSpeed(mouseX)
+                    speedClicked = true
+                },
+                LeftClickRelease: func(element *uilib.UIElement){
+                    speedClicked = false
+                },
+                Inside: func(element *uilib.UIElement, x int, y int) {
+                    if speedClicked {
+                        mouseX, _ := inputmanager.MousePosition()
+                        mouseX = scale.Unscale(mouseX)
+                        updateSpeed(mouseX)
+                    }
+                },
+                /*
+                Inside: func(element *uilib.UIElement, x int, y int){
+                    log.Printf("inside speed rect: %v, %v", x, y)
+                },
+                */
+                Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+                    alpha := (*alphaFunc)()
 
-    speedAlphaMin := float32(0.4)
+                    vector.FillRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), color.NRGBA{R: 0, G: 0, B: 0, A: uint8(float32(0x80) * alpha)}, false)
+                    vector.StrokeRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), 1, color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: uint8(0xff * alpha)}, false)
 
-    var speedRectAlpha util.AlphaFadeFunc = func () float32 {
-        return speedAlphaMin
-    }
-    updateSpeedRectAlpha := false
+                    relative := float64(game.watchSpeed) / float64(maxSpeed)
+                    position := float64(speedRect.Min.X) + relative * float64(speedRect.Dx() - cursor.Bounds().Dx())
 
-    elements = append(elements, &uilib.UIElement{
-        Layer: 1,
-        Rect: speedRect.Inset(-10),
-        Inside: func(element *uilib.UIElement, x int, y int){
-            if !updateSpeedRectAlpha {
-                speedRectAlpha = scaleAlpha(util.MakeFadeIn(20, &game.Counter), speedAlphaMin)
-                updateSpeedRectAlpha = true
+                    var options ebiten.DrawImageOptions
+                    options.ColorScale.ScaleAlpha(alpha)
+                    options.GeoM.Translate(position, float64(speedRect.Min.Y + 2))
+                    scale.DrawScaled(screen, cursor, &options)
+
+                    options.GeoM.Translate(0, -2 - float64(game.Fonts.WhiteFont.Height()))
+                    _, y := options.GeoM.Apply(0, 0)
+                    game.Fonts.WhiteFont.PrintOptions(screen, float64(speedRect.Min.X), y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Speed: %v", game.watchSpeed))
+
+                },
             }
         },
-        NotInside: func(element *uilib.UIElement){
-            if updateSpeedRectAlpha {
-                updateSpeedRectAlpha = false
-                speedRectAlpha = scaleAlpha(util.MakeFadeOut(20, &game.Counter), speedAlphaMin)
-            }
-        },
-    })
-
-    elements = append(elements, &uilib.UIElement{
-        Layer: 1,
-        Rect: speedRect,
-        LeftClick: func(element *uilib.UIElement){
-            mouseX, _ := inputmanager.MousePosition()
-            mouseX = scale.Unscale(mouseX)
-            updateSpeed(mouseX)
-            speedClicked = true
-        },
-        LeftClickRelease: func(element *uilib.UIElement){
-            speedClicked = false
-        },
-        Inside: func(element *uilib.UIElement, x int, y int) {
-            if speedClicked {
-                mouseX, _ := inputmanager.MousePosition()
-                mouseX = scale.Unscale(mouseX)
-                updateSpeed(mouseX)
-            }
-        },
-        /*
-        Inside: func(element *uilib.UIElement, x int, y int){
-            log.Printf("inside speed rect: %v, %v", x, y)
-        },
-        */
-        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            vector.FillRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), color.NRGBA{R: 0, G: 0, B: 0, A: uint8(float32(0x80) * speedRectAlpha())}, false)
-            vector.StrokeRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), 1, color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: uint8(0xff * speedRectAlpha())}, false)
-
-            relative := float64(game.watchSpeed) / float64(maxSpeed)
-            position := float64(speedRect.Min.X) + relative * float64(speedRect.Dx() - cursor.Bounds().Dx())
-
-            var options ebiten.DrawImageOptions
-            options.ColorScale.ScaleAlpha(speedRectAlpha())
-            options.GeoM.Translate(position, float64(speedRect.Min.Y + 2))
-            scale.DrawScaled(screen, cursor, &options)
-
-            options.GeoM.Translate(0, -2 - float64(game.Fonts.WhiteFont.Height()))
-            _, y := options.GeoM.Apply(0, 0)
-            game.Fonts.WhiteFont.PrintOptions(screen, float64(speedRect.Min.X), y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Speed: %v", game.watchSpeed))
-
-        },
-    })
+    )...)
 
     ui.SetElementsFromArray(elements)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2476,8 +2476,9 @@ func (game *Game) MakeWatchUI() *uilib.UI {
 
     // show wizard portraits. clicking on them focuses the camera on the city that contains wizard's fortress
 
-    for i, player := range game.Model.Players {
-        if player.Admin {
+    playerCount := 0
+    for _, player := range game.Model.Players {
+        if player.Admin || player.IsHuman() {
             continue
         }
 
@@ -2496,7 +2497,7 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         scaleOptions.GeoM.Scale(0.5, 0.5)
         portrait.DrawImage(portraitLarge, &scaleOptions)
 
-        rect := image.Rect(0, 0, portrait.Bounds().Dx(), portrait.Bounds().Dy()).Add(image.Pt(data.ScreenWidth - 5 - portrait.Bounds().Dx(), 5 + i * (portrait.Bounds().Dy() + 5)))
+        rect := image.Rect(0, 0, portrait.Bounds().Dx(), portrait.Bounds().Dy()).Add(image.Pt(data.ScreenWidth - 5 - portrait.Bounds().Dx(), 5 + playerCount * (portrait.Bounds().Dy() + 5)))
         var options ebiten.DrawImageOptions
         options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
         elements = append(elements, makeFadeInElement(20, 0.4, 10, &game.Counter,
@@ -2528,6 +2529,8 @@ func (game *Game) MakeWatchUI() *uilib.UI {
                 }
             },
         )...)
+
+        playerCount += 1
     }
 
     ui.SetElementsFromArray(elements)
@@ -2563,7 +2566,11 @@ func (game *Game) ProcessEvents(yield coroutine.YieldFunc) {
                         // compress ui refreshes
                         switch lastEvent.(type) {
                             case *GameEventRefreshUI: // nothing, since we just did a refresh
-                            default: game.HudUI = game.MakeHudUI()
+                            default:
+                                game.HudUI = game.MakeHudUI()
+                                if game.WatchMode {
+                                    game.WatchUI = game.MakeWatchUI()
+                                }
                         }
                     case *GameEventHireHero:
                         hire := event.(*GameEventHireHero)

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -402,6 +402,9 @@ type Game struct {
 
     HudUI *uilib.UI
     WatchUI *uilib.UI
+
+    // speed that the game runs at (updates/second)
+    watchSpeed int
     Help helplib.Help
 
     Camera camera.Camera
@@ -2325,9 +2328,12 @@ func (game *Game) doRandomEvent(yield coroutine.YieldFunc, event *RandomEvent, s
     }
 }
 
-func (game *Game) SetWatchMode() {
+func (game *Game) SetWatchMode(watchSpeed int) {
     game.WatchMode = true
     game.WatchUI = game.MakeWatchUI()
+    game.watchSpeed = watchSpeed
+
+    ebiten.SetTPS(watchSpeed)
 }
 
 func (game *Game) MakeWatchUI() *uilib.UI {
@@ -2341,14 +2347,25 @@ func (game *Game) MakeWatchUI() *uilib.UI {
 
     var elements []*uilib.UIElement
 
-    turnBox := image.Rect(5, 5, 100, 30)
+    // show the current turn
+    turnBox := image.Rect(5, 5, scale.Scale(35), scale.Scale(10))
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             vector.FillRect(screen, float32(turnBox.Min.X), float32(turnBox.Min.Y), float32(turnBox.Dx()), float32(turnBox.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
 
             var options ebiten.DrawImageOptions
-            game.Fonts.WhiteFont.PrintOptions(screen, float64(turnBox.Min.X), float64(turnBox.Min.Y), font.FontOptions{DropShadow: true, Scale: 2, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Turn: %v", game.Model.TurnNumber))
+            game.Fonts.WhiteFont.PrintOptions(screen, float64(turnBox.Min.X) + 1, float64(turnBox.Min.Y) + 1, font.FontOptions{DropShadow: true, Scale: 2, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Turn: %v", game.Model.TurnNumber))
+        },
+    })
+
+    speedRect := image.Rect(0, 0, scale.Scale(100), scale.Scale(10)).Add(image.Pt(5, scale.Scale(data.ScreenHeight) - 5 - scale.Scale(10)))
+    // slider that controls the speed of the game
+    elements = append(elements, &uilib.UIElement{
+        Layer: 1,
+        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+            vector.FillRect(screen, float32(speedRect.Min.X), float32(speedRect.Min.Y), float32(speedRect.Dx()), float32(speedRect.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
+            vector.StrokeRect(screen, float32(speedRect.Min.X), float32(speedRect.Min.Y), float32(speedRect.Dx()), float32(speedRect.Dy()), 1, color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, false)
         },
     })
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2500,6 +2500,20 @@ func (game *Game) MakeWatchUI() *uilib.UI {
                     Rect: rect,
                     Layer: 1,
                     LeftClick: func(element *uilib.UIElement){
+                        fortress := player.FindFortressCity()
+                        if fortress != nil {
+                            event := GameEventMoveCamera{
+                                Plane: fortress.Plane,
+                                X: fortress.X,
+                                Y: fortress.Y,
+                                Instant: false,
+                            }
+
+                            select {
+                                case game.Events <- &event:
+                                default:
+                            }
+                        }
                     },
                     Draw: func(element *uilib.UIElement, screen *ebiten.Image){
                         options.ColorScale.Reset()

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2474,6 +2474,43 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         },
     )...)
 
+    // show wizard portraits. clicking on them focuses the camera on the city that contains wizard's fortress
+
+    for i, player := range game.Model.Players {
+        if player.Admin {
+            continue
+        }
+
+        if player.Defeated {
+            continue
+        }
+
+        portraitLarge, _ := game.ImageCache.GetImage("lilwiz.lbx", mirror.GetWizardPortraitIndex(player.Wizard.Base, player.Wizard.Banner), 0)
+        portrait := ebiten.NewImage(portraitLarge.Bounds().Dx() / 2, portraitLarge.Bounds().Dy() / 2)
+        var scaleOptions ebiten.DrawImageOptions
+        scaleOptions.GeoM.Scale(0.5, 0.5)
+        portrait.DrawImage(portraitLarge, &scaleOptions)
+
+        rect := image.Rect(0, 0, portrait.Bounds().Dx(), portrait.Bounds().Dy()).Add(image.Pt(data.ScreenWidth - 5 - portrait.Bounds().Dx(), 5 + i * (portrait.Bounds().Dy() + 5)))
+        var options ebiten.DrawImageOptions
+        options.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
+        elements = append(elements, makeFadeInElement(20, 0.4, 10, &game.Counter,
+            func (alphaFunc *util.AlphaFadeFunc) *uilib.UIElement {
+                return &uilib.UIElement{
+                    Rect: rect,
+                    Layer: 1,
+                    LeftClick: func(element *uilib.UIElement){
+                    },
+                    Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+                        options.ColorScale.Reset()
+                        options.ColorScale.ScaleAlpha((*alphaFunc)())
+                        scale.DrawScaled(screen, portrait, &options)
+                    },
+                }
+            },
+        )...)
+    }
+
     ui.SetElementsFromArray(elements)
 
     return ui

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2359,13 +2359,22 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         },
     })
 
-    speedRect := image.Rect(0, 0, scale.Scale(100), scale.Scale(10)).Add(image.Pt(5, scale.Scale(data.ScreenHeight) - 5 - scale.Scale(10)))
     // slider that controls the speed of the game
+    speedRect := image.Rect(0, 0, scale.Scale(100), scale.Scale(10)).Add(image.Pt(5, scale.Scale(data.ScreenHeight) - 5 - scale.Scale(10)))
+    cursor, _ := game.ImageCache.GetImage("spellscr.lbx", 3, 0)
+    maxSpeed := 2000
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
             vector.FillRect(screen, float32(speedRect.Min.X), float32(speedRect.Min.Y), float32(speedRect.Dx()), float32(speedRect.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
             vector.StrokeRect(screen, float32(speedRect.Min.X), float32(speedRect.Min.Y), float32(speedRect.Dx()), float32(speedRect.Dy()), 1, color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, false)
+
+            relative := float64(game.watchSpeed) / float64(maxSpeed)
+            position := float64(speedRect.Min.X) + relative * float64(speedRect.Dx() - cursor.Bounds().Dx())
+
+            var options ebiten.DrawImageOptions
+            options.GeoM.Translate(scale.Unscale(position), scale.Unscale(float64(speedRect.Min.Y + 2)))
+            scale.DrawScaled(screen, cursor, &options)
         },
     })
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2485,6 +2485,11 @@ func (game *Game) MakeWatchUI() *uilib.UI {
             continue
         }
 
+        // skip neutral player
+        if player.GetBanner() == data.BannerBrown {
+            continue
+        }
+
         portraitLarge, _ := game.ImageCache.GetImage("lilwiz.lbx", mirror.GetWizardPortraitIndex(player.Wizard.Base, player.Wizard.Banner), 0)
         portrait := ebiten.NewImage(portraitLarge.Bounds().Dx() / 2, portraitLarge.Bounds().Dy() / 2)
         var scaleOptions ebiten.DrawImageOptions

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2385,15 +2385,22 @@ func (game *Game) MakeWatchUI() *uilib.UI {
 
     // show the current turn
     turnBox := image.Rect(5, 5, scale.Scale(35), scale.Scale(10))
-    elements = append(elements, &uilib.UIElement{
-        Layer: 1,
-        Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            vector.FillRect(screen, float32(turnBox.Min.X), float32(turnBox.Min.Y), float32(turnBox.Dx()), float32(turnBox.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
+    elements = append(elements, makeFadeInElement(20, 0.4, 10, &game.Counter, 
+        func (alphaFunc *util.AlphaFadeFunc) *uilib.UIElement {
+            return &uilib.UIElement{
+                Layer: 1,
+                Rect: turnBox,
+                Draw: func(element *uilib.UIElement, screen *ebiten.Image){
+                    alpha := (*alphaFunc)()
+                    vector.FillRect(screen, float32(turnBox.Min.X), float32(turnBox.Min.Y), float32(turnBox.Dx()), float32(turnBox.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: uint8(0x80 * alpha)}, false)
 
-            var options ebiten.DrawImageOptions
-            game.Fonts.WhiteFont.PrintOptions(screen, float64(turnBox.Min.X) + 1, float64(turnBox.Min.Y) + 1, font.FontOptions{DropShadow: true, Scale: 2, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Turn: %v", game.Model.TurnNumber))
+                    var options ebiten.DrawImageOptions
+                    options.ColorScale.ScaleAlpha(alpha)
+                    game.Fonts.WhiteFont.PrintOptions(screen, float64(turnBox.Min.X) + 1, float64(turnBox.Min.Y) + 1, font.FontOptions{DropShadow: true, Scale: 2, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Turn: %v", game.Model.TurnNumber))
+                },
+            }
         },
-    })
+    )...)
 
     // slider that controls the speed of the game
     speedRect := image.Rect(0, 0, 150, 10).Add(image.Pt(5, data.ScreenHeight - 5 - 10))

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2364,27 +2364,42 @@ func (game *Game) MakeWatchUI() *uilib.UI {
     cursor, _ := game.ImageCache.GetImage("spellscr.lbx", 3, 0)
     maxSpeed := 2000
     lowestSpeed := 5
+    speedClicked := false
+
+    updateSpeed := func(mouseX int) {
+        relative := float64(mouseX - speedRect.Min.X) / float64(speedRect.Dx() - cursor.Bounds().Dx())
+        if relative < 0 {
+            // can't go lower than 5 TPS
+            relative = 0
+        }
+        if relative > 1 {
+            relative = 1
+        }
+        game.watchSpeed = int(relative * float64(maxSpeed))
+        if game.watchSpeed < lowestSpeed {
+            game.watchSpeed = lowestSpeed
+        }
+        ebiten.SetTPS(game.watchSpeed)
+    }
+
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
         Rect: speedRect,
         LeftClick: func(element *uilib.UIElement){
             mouseX, _ := inputmanager.MousePosition()
             mouseX = scale.Unscale(mouseX)
-            log.Printf("mouseX: %v, speedRect: %v", mouseX, speedRect)
-            relative := float64(mouseX - speedRect.Min.X) / float64(speedRect.Dx() - cursor.Bounds().Dx())
-            if relative < 0 {
-                // can't go lower than 5 TPS
-                relative = 0
+            updateSpeed(mouseX)
+            speedClicked = true
+        },
+        LeftClickRelease: func(element *uilib.UIElement){
+            speedClicked = false
+        },
+        Inside: func(element *uilib.UIElement, x int, y int) {
+            if speedClicked {
+                mouseX, _ := inputmanager.MousePosition()
+                mouseX = scale.Unscale(mouseX)
+                updateSpeed(mouseX)
             }
-            if relative > 1 {
-                relative = 1
-            }
-            game.watchSpeed = int(relative * float64(maxSpeed))
-            if game.watchSpeed < lowestSpeed {
-                game.watchSpeed = lowestSpeed
-            }
-            log.Printf("watch speed: %v", game.watchSpeed)
-            ebiten.SetTPS(game.watchSpeed)
         },
         /*
         Inside: func(element *uilib.UIElement, x int, y int){

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2382,6 +2382,28 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         ebiten.SetTPS(game.watchSpeed)
     }
 
+    var speedRectAlpha util.AlphaFadeFunc = func () float32 {
+        return 0.2
+    }
+    updateSpeedRectAlpha := false
+
+    elements = append(elements, &uilib.UIElement{
+        Layer: 2,
+        Rect: speedRect.Inset(-10),
+        Inside: func(element *uilib.UIElement, x int, y int){
+            if !updateSpeedRectAlpha {
+                speedRectAlpha = util.MakeFadeIn(20, &game.Counter)
+                updateSpeedRectAlpha = true
+            }
+        },
+        NotInside: func(element *uilib.UIElement){
+            if updateSpeedRectAlpha {
+                updateSpeedRectAlpha = false
+                speedRectAlpha = util.MakeFadeOut(20, &game.Counter)
+            }
+        },
+    })
+
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
         Rect: speedRect,
@@ -2407,13 +2429,14 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         },
         */
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            vector.FillRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
-            vector.StrokeRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), 1, color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, false)
+            vector.FillRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), color.NRGBA{R: 0, G: 0, B: 0, A: uint8(float32(0x80) * speedRectAlpha())}, false)
+            vector.StrokeRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), 1, color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: uint8(0xff * speedRectAlpha())}, false)
 
             relative := float64(game.watchSpeed) / float64(maxSpeed)
             position := float64(speedRect.Min.X) + relative * float64(speedRect.Dx() - cursor.Bounds().Dx())
 
             var options ebiten.DrawImageOptions
+            options.ColorScale.ScaleAlpha(speedRectAlpha())
             options.GeoM.Translate(position, float64(speedRect.Min.Y + 2))
             scale.DrawScaled(screen, cursor, &options)
 

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2360,21 +2360,52 @@ func (game *Game) MakeWatchUI() *uilib.UI {
     })
 
     // slider that controls the speed of the game
-    speedRect := image.Rect(0, 0, scale.Scale(100), scale.Scale(10)).Add(image.Pt(5, scale.Scale(data.ScreenHeight) - 5 - scale.Scale(10)))
+    speedRect := image.Rect(0, 0, 150, 10).Add(image.Pt(5, data.ScreenHeight - 5 - 10))
     cursor, _ := game.ImageCache.GetImage("spellscr.lbx", 3, 0)
     maxSpeed := 2000
+    lowestSpeed := 5
     elements = append(elements, &uilib.UIElement{
         Layer: 1,
+        Rect: speedRect,
+        LeftClick: func(element *uilib.UIElement){
+            mouseX, _ := inputmanager.MousePosition()
+            mouseX = scale.Unscale(mouseX)
+            log.Printf("mouseX: %v, speedRect: %v", mouseX, speedRect)
+            relative := float64(mouseX - speedRect.Min.X) / float64(speedRect.Dx() - cursor.Bounds().Dx())
+            if relative < 0 {
+                // can't go lower than 5 TPS
+                relative = 0
+            }
+            if relative > 1 {
+                relative = 1
+            }
+            game.watchSpeed = int(relative * float64(maxSpeed))
+            if game.watchSpeed < lowestSpeed {
+                game.watchSpeed = lowestSpeed
+            }
+            log.Printf("watch speed: %v", game.watchSpeed)
+            ebiten.SetTPS(game.watchSpeed)
+        },
+        /*
+        Inside: func(element *uilib.UIElement, x int, y int){
+            log.Printf("inside speed rect: %v, %v", x, y)
+        },
+        */
         Draw: func(element *uilib.UIElement, screen *ebiten.Image){
-            vector.FillRect(screen, float32(speedRect.Min.X), float32(speedRect.Min.Y), float32(speedRect.Dx()), float32(speedRect.Dy()), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
-            vector.StrokeRect(screen, float32(speedRect.Min.X), float32(speedRect.Min.Y), float32(speedRect.Dx()), float32(speedRect.Dy()), 1, color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, false)
+            vector.FillRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), color.RGBA{R: 0, G: 0, B: 0, A: 0x80}, false)
+            vector.StrokeRect(screen, scale.Scale(float32(speedRect.Min.X)), scale.Scale(float32(speedRect.Min.Y)), scale.Scale(float32(speedRect.Dx())), scale.Scale(float32(speedRect.Dy())), 1, color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, false)
 
             relative := float64(game.watchSpeed) / float64(maxSpeed)
             position := float64(speedRect.Min.X) + relative * float64(speedRect.Dx() - cursor.Bounds().Dx())
 
             var options ebiten.DrawImageOptions
-            options.GeoM.Translate(scale.Unscale(position), scale.Unscale(float64(speedRect.Min.Y + 2)))
+            options.GeoM.Translate(position, float64(speedRect.Min.Y + 2))
             scale.DrawScaled(screen, cursor, &options)
+
+            options.GeoM.Translate(0, -2 - float64(game.Fonts.WhiteFont.Height()))
+            _, y := options.GeoM.Apply(0, 0)
+            game.Fonts.WhiteFont.PrintOptions(screen, float64(speedRect.Min.X), y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Justify: font.FontJustifyLeft, Options: &options}, fmt.Sprintf("Speed: %v", game.watchSpeed))
+
         },
     })
 
@@ -3881,6 +3912,12 @@ func (game *Game) DoViewInput(yield coroutine.YieldFunc) {
     }
 
     if game.WatchMode {
+        game.WatchUI.StandardUpdate()
+
+        if ebiten.IsKeyPressed(ebiten.KeyEscape) || ebiten.IsKeyPressed(ebiten.KeyCapsLock) {
+            game.State = GameStateQuit
+        }
+
         keys := inpututil.AppendJustPressedKeys(nil)
         for _, key := range keys {
             switch key {
@@ -3916,6 +3953,10 @@ func (game *Game) Update(yield coroutine.YieldFunc) GameState {
     switch game.State {
         case GameStateRunning:
             game.HudUI.StandardUpdate()
+
+            if game.WatchMode {
+                game.WatchUI.StandardUpdate()
+            }
 
             // kind of a hack to not allow player to interact with anything other than the current ui modal
             if len(game.Model.Players) > 0 && game.Model.CurrentPlayer >= 0 {

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -2382,24 +2382,33 @@ func (game *Game) MakeWatchUI() *uilib.UI {
         ebiten.SetTPS(game.watchSpeed)
     }
 
+    scaleAlpha := func(fade util.AlphaFadeFunc, minAlpha float32) util.AlphaFadeFunc {
+        return func() float32 {
+            value := fade()
+            return minAlpha + (1 - minAlpha) * value
+        }
+    }
+
+    speedAlphaMin := float32(0.4)
+
     var speedRectAlpha util.AlphaFadeFunc = func () float32 {
-        return 0.2
+        return speedAlphaMin
     }
     updateSpeedRectAlpha := false
 
     elements = append(elements, &uilib.UIElement{
-        Layer: 2,
+        Layer: 1,
         Rect: speedRect.Inset(-10),
         Inside: func(element *uilib.UIElement, x int, y int){
             if !updateSpeedRectAlpha {
-                speedRectAlpha = util.MakeFadeIn(20, &game.Counter)
+                speedRectAlpha = scaleAlpha(util.MakeFadeIn(20, &game.Counter), speedAlphaMin)
                 updateSpeedRectAlpha = true
             }
         },
         NotInside: func(element *uilib.UIElement){
             if updateSpeedRectAlpha {
                 updateSpeedRectAlpha = false
-                speedRectAlpha = util.MakeFadeOut(20, &game.Counter)
+                speedRectAlpha = scaleAlpha(util.MakeFadeOut(20, &game.Counter), speedAlphaMin)
             }
         },
     })

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -622,7 +622,7 @@ func startWatchMode(yield coroutine.YieldFunc, game *MagicGame) error {
 
     realGame := initializeGame(game, settings, wizard)
 
-    realGame.WatchMode = true
+    realGame.SetWatchMode()
 
     human := realGame.Model.GetHumanPlayer()
     if human != nil {

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -622,7 +622,7 @@ func startWatchMode(yield coroutine.YieldFunc, game *MagicGame) error {
 
     realGame := initializeGame(game, settings, wizard)
 
-    realGame.SetWatchMode()
+    realGame.SetWatchMode(300)
 
     human := realGame.Model.GetHumanPlayer()
     if human != nil {
@@ -892,10 +892,6 @@ func main() {
     mouse.Initialize()
 
     ebiten.SetCursorMode(ebiten.CursorModeHidden)
-
-    if watchMode {
-        ebiten.SetTPS(300)
-    }
 
     game, err := NewMagicGame(dataPath, startGame, loadSave, enableMusic, watchMode)
 

--- a/game/magic/main.go
+++ b/game/magic/main.go
@@ -622,7 +622,7 @@ func startWatchMode(yield coroutine.YieldFunc, game *MagicGame) error {
 
     realGame := initializeGame(game, settings, wizard)
 
-    realGame.SetWatchMode(300)
+    realGame.SetWatchMode(100)
 
     human := realGame.Model.GetHumanPlayer()
     if human != nil {


### PR DESCRIPTION
show some useful UI elements in watch mode so the user has some control over watch mode and can view the game state

<img width="1224" height="746" alt="image" src="https://github.com/user-attachments/assets/54fb2e4a-73d0-41bc-bec2-f35680b33c73" />

click on a wizard portrait focuses the camera on that wizards fortress city.

the slider at the bottom left adjusts how fast the game speed is. 60 is normal, and the slider can go upto 2000.

current turn is at upper left.

all the elements fade out while the mouse is not near them, but become more opaque as the mouse gets close