### PR TITLE
items: render as spell when viewing item

### DIFF
--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -7,7 +7,6 @@ import (
     "cmp"
     "log"
     "math/rand/v2"
-    "strings"
     _ "log"
 
     "github.com/kazzmir/master-of-magic/lib/lbx"
@@ -677,9 +676,6 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
         for mask, ability := range abilityMap {
             if abilitiesValue&mask != 0 {
                 name := ability.Name()
-                if enchantment := ability.Enchantment(); enchantment != data.UnitEnchantmentNone {
-                    name = fmt.Sprintf("%v, as %v spell", ability.Name(), strings.ToLower(enchantment.Name()))
-                }
                 powers = append(powers, Power{Type: PowerTypeAbility1, Amount: 0, Name: name, Ability: ability})
             }
         }

--- a/game/magic/artifact/item.go
+++ b/game/magic/artifact/item.go
@@ -676,6 +676,7 @@ func ReadArtifacts(cache *lbx.LbxCache) ([]Artifact, error) {
         for mask, ability := range abilityMap {
             if abilitiesValue&mask != 0 {
                 name := ability.Name()
+                // note: the "Spell as spell X" is rendered in the view code, not here
                 powers = append(powers, Power{Type: PowerTypeAbility1, Amount: 0, Name: name, Ability: ability})
             }
         }

--- a/game/magic/artifact/view.go
+++ b/game/magic/artifact/view.go
@@ -4,6 +4,8 @@ import (
     "image"
     "slices"
     "cmp"
+    "fmt"
+    "strings"
 
     "github.com/kazzmir/master-of-magic/lib/font"
     "github.com/kazzmir/master-of-magic/game/magic/util"
@@ -56,7 +58,7 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
     maxRowLength := itemBackground.Bounds().Dx() - 20
 
     type PowerColumn struct {
-        power Power
+        name string
         length float64
     }
 
@@ -71,14 +73,20 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
     columns := make([]PowerColumn, len(artifact.Powers))
     for i := range artifact.Powers {
         power := artifact.Powers[i]
-        width := float64(attributeFont.MeasureTextWidth(power.Name, 1))
+
+        name := power.Name
+        if enchantment := power.Ability.Enchantment(); enchantment != data.UnitEnchantmentNone {
+            name = fmt.Sprintf("%v, as %v spell", power.Ability.Name(), strings.ToLower(enchantment.Name()))
+        }
+
+        width := float64(attributeFont.MeasureTextWidth(name, 1))
         powerLength := width + 3 + float64(dot.Bounds().Dx()) + 1
 
         // force column alignment
         if powerLength < 80 {
             powerLength = 80
         }
-        columns[i] = PowerColumn{power: power, length: powerLength}
+        columns[i] = PowerColumn{name: name, length: powerLength}
     }
 
     columns = slices.SortedFunc(slices.Values(columns), func(a, b PowerColumn) int {
@@ -117,7 +125,7 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
             scale.DrawScaled(screen, dot, &options)
 
             x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1), 0)
-            attributeFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, column.power.Name)
+            attributeFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, column.name)
 
             options.GeoM.Translate(column.length + 2, 0)
         }

--- a/game/magic/artifact/view.go
+++ b/game/magic/artifact/view.go
@@ -41,23 +41,8 @@ func RenderArtifactImage(screen *ebiten.Image, imageCache *util.ImageCache, arti
     return itemImage
 }
 
-func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact Artifact, counter uint64, titleFont *font.Font, attributeFont *font.Font, options ebiten.DrawImageOptions) {
-    itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
-    scale.DrawScaled(screen, itemBackground, &options)
-
-    options.GeoM.Translate(float64(10), float64(8))
-
-    itemImage := RenderArtifactImage(screen, imageCache, artifact, counter, options)
-
-    x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X + 3), float64(4))
-    titleFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, artifact.Name)
-
-    dot, _ := imageCache.GetImage("itemisc.lbx", 26, 0)
-    savedGeom := options.GeoM
-
-    maxRowLength := itemBackground.Bounds().Dx() - 20
-
-    type PowerColumn struct {
+func renderItemRows(screen *ebiten.Image, maxRowLength int, savedGeom ebiten.GeoM, names []string, dot *ebiten.Image, attributeFont *font.Font, options *ebiten.DrawImageOptions) {
+    type Column struct {
         name string
         length float64
     }
@@ -65,20 +50,14 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
     // a row can contain X powers (usually at most 2). If a row contains a power that is too long
     // then that row will only contain 1 power, and the next power will be on the next row
     type Row struct {
-        Columns []PowerColumn
+        Columns []Column
     }
 
     var rows []Row
 
-    columns := make([]PowerColumn, len(artifact.Powers))
-    for i := range artifact.Powers {
-        power := artifact.Powers[i]
-
-        name := power.Name
-        if enchantment := power.Ability.Enchantment(); enchantment != data.UnitEnchantmentNone {
-            name = fmt.Sprintf("%v, as %v spell", power.Ability.Name(), strings.ToLower(enchantment.Name()))
-        }
-
+    columns := make([]Column, len(names))
+    for i := range names {
+        name := names[i]
         width := float64(attributeFont.MeasureTextWidth(name, 1))
         powerLength := width + 3 + float64(dot.Bounds().Dx()) + 1
 
@@ -86,10 +65,10 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
         if powerLength < 80 {
             powerLength = 80
         }
-        columns[i] = PowerColumn{name: name, length: powerLength}
+        columns[i] = Column{name: name, length: powerLength}
     }
 
-    columns = slices.SortedFunc(slices.Values(columns), func(a, b PowerColumn) int {
+    columns = slices.SortedFunc(slices.Values(columns), func(a, b Column) int {
         return cmp.Compare(a.length, b.length)
     })
 
@@ -111,7 +90,7 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
         }
 
         if !added {
-            rows = append(rows, Row{Columns: []PowerColumn{column}})
+            rows = append(rows, Row{Columns: []Column{column}})
         }
     }
 
@@ -122,12 +101,42 @@ func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifa
         options.GeoM.Translate(0, float64(rowI * 13))
 
         for _, column := range row.Columns {
-            scale.DrawScaled(screen, dot, &options)
+            scale.DrawScaled(screen, dot, options)
 
             x, y := options.GeoM.Apply(float64(dot.Bounds().Dx() + 1), 0)
-            attributeFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: &options, Scale: scale.ScaleAmount}, column.name)
+            attributeFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Options: options, Scale: scale.ScaleAmount}, column.name)
 
             options.GeoM.Translate(column.length + 2, 0)
         }
     }
+}
+
+func RenderArtifactBox(screen *ebiten.Image, imageCache *util.ImageCache, artifact Artifact, counter uint64, titleFont *font.Font, attributeFont *font.Font, options ebiten.DrawImageOptions) {
+    itemBackground, _ := imageCache.GetImage("itemisc.lbx", 25, 0)
+    scale.DrawScaled(screen, itemBackground, &options)
+
+    options.GeoM.Translate(float64(10), float64(8))
+
+    itemImage := RenderArtifactImage(screen, imageCache, artifact, counter, options)
+
+    x, y := options.GeoM.Apply(float64(itemImage.Bounds().Max.X + 3), float64(4))
+    titleFont.PrintOptions(screen, x, y, font.FontOptions{DropShadow: true, Scale: scale.ScaleAmount, Options: &options}, artifact.Name)
+
+    dot, _ := imageCache.GetImage("itemisc.lbx", 26, 0)
+
+    maxRowLength := itemBackground.Bounds().Dx() - 20
+
+    names := make([]string, len(artifact.Powers))
+    for i := range artifact.Powers {
+        power := artifact.Powers[i]
+
+        name := power.Name
+        if enchantment := power.Ability.Enchantment(); enchantment != data.UnitEnchantmentNone {
+            name = fmt.Sprintf("%v, as %v spell", power.Ability.Name(), strings.ToLower(enchantment.Name()))
+        }
+
+        names[i] = name
+    }
+
+    renderItemRows(screen, maxRowLength, options.GeoM, names, dot, attributeFont, &options)
 }

--- a/test/overworld/main.go
+++ b/test/overworld/main.go
@@ -6301,6 +6301,124 @@ func createScenario67(cache *lbx.LbxCache) *gamelib.Game {
     return game
 }
 
+// create artifact with ability powers
+func createScenario68(cache *lbx.LbxCache) *gamelib.Game {
+    log.Printf("Running scenario 68")
+
+    wizard := setup.WizardCustom{
+        Name: "bob",
+        Banner: data.BannerBlue,
+        Race: data.RaceTroll,
+        Retorts: []data.Retort{
+            data.RetortAlchemy,
+            data.RetortSageMaster,
+            data.RetortRunemaster,
+        },
+        Books: []data.WizardBook{
+            data.WizardBook{
+                Magic: data.LifeMagic,
+                Count: 3,
+            },
+            data.WizardBook{
+                Magic: data.SorceryMagic,
+                Count: 8,
+            },
+        },
+    }
+
+    game := gamelib.MakeGame(cache, musiclib.MakeMusic(cache), settings.MakeSettings(cache), setup.NewGameSettings{LandSize: 0})
+
+    game.Model.Plane = data.PlaneArcanus
+
+    player := game.AddPlayer(wizard, true)
+    player.Admin = true
+
+    player.TaxRate = fraction.Zero()
+
+    x, y, _ := game.FindValidCityLocation(game.Model.Plane)
+
+    /*
+    x = 20
+    y = 20
+    */
+
+    city := citylib.MakeCity("Test City", x, y, data.RaceHighElf, game.Model.BuildingInfo, game.Model.CurrentMap(), game.Model, player)
+    city.Population = 16190
+    city.Plane = data.PlaneArcanus
+    city.Buildings.Insert(buildinglib.BuildingFortress)
+    city.Buildings.Insert(buildinglib.BuildingSummoningCircle)
+    city.Buildings.Insert(buildinglib.BuildingGranary)
+    city.Buildings.Insert(buildinglib.BuildingFarmersMarket)
+    city.ProducingBuilding = buildinglib.BuildingBank
+    city.ProducingUnit = units.UnitNone
+    city.Race = wizard.Race
+    city.Farmers = 14
+    city.Workers = 3
+
+    city.ResetCitizens()
+
+    player.AddCity(city)
+
+    player.Gold = 83
+    player.Mana = 9600
+    player.CastingSkillPower = 50000
+
+    allSpells, _ := spellbook.ReadSpellsFromCache(cache)
+
+    player.KnownSpells.AddSpell(allSpells.FindByName("Animate Dead"))
+    player.KnownSpells.AddSpell(allSpells.FindByName("Enchant Item"))
+
+    player.CastingSpell = allSpells.FindByName("Enchant Item")
+    player.CreateArtifact = &artifact.Artifact{
+        Name: "Powers",
+        Image: 7,
+        Type: artifact.ArtifactTypeSword,
+        Powers: []artifact.Power{
+            {
+                Type: artifact.PowerTypeAttack,
+                Amount: 1,
+                Name: "+1 Attack",
+            },
+            {
+                Type: artifact.PowerTypeAbility1,
+                Name: "Haste",
+                Ability: data.ItemAbilityHaste,
+                Magic: data.SorceryMagic,
+            },
+        },
+    }
+
+    // game.Map.Map.Terrain[3][6] = terrain.TileNatureForest.Index
+
+    // log.Printf("City at %v, %v", x, y)
+
+    player.LiftFog(x, y, 30, data.PlaneArcanus)
+    player.LiftFog(x, y, 30, data.PlaneMyrror)
+
+    drake := player.AddUnit(units.MakeOverworldUnitFromUnit(units.GreatDrake, x + 1, y + 1, data.PlaneArcanus, wizard.Banner, player.MakeExperienceInfo(), player.MakeUnitEnchantmentProvider()))
+
+    // player.AddUnit(units.MakeOverworldUnitFromUnit(units.HighMenSpearmen, 30, 30, data.PlaneArcanus, wizard.Banner))
+
+    stack := player.FindStackByUnit(drake)
+    player.SetSelectedStack(stack)
+
+    player.LiftFog(stack.X(), stack.Y(), 2, data.PlaneArcanus)
+
+    enemy1 := game.AddPlayer(setup.WizardCustom{
+        Name: "dingus",
+        Banner: data.BannerRed,
+    }, false)
+
+    player.AddPowerHistory(playerlib.WizardPower{Army: 30, Magic: 4053, SpellResearch: 40})
+    enemy1.AddPowerHistory(playerlib.WizardPower{Army: 15, Magic: 3088, SpellResearch: 30})
+
+    game.Camera.Center(stack.X(), stack.Y())
+
+    // game.Events <- &gamelib.GameEventGameMenu{}
+
+    return game
+}
+
 func NewEngine(scenario int) (*Engine, error) {
     cache := lbx.AutoCache()
 
@@ -6374,6 +6492,7 @@ func NewEngine(scenario int) (*Engine, error) {
         case 65: game = createScenario65(cache)
         case 66: game = createScenario66(cache)
         case 67: game = createScenario67(cache)
+        case 68: game = createScenario68(cache)
         default: game = createScenario1(cache)
     }
 


### PR DESCRIPTION
Instead of updating the name, just render it differently so that newly created artifacts (from Enchant Item) get the same treatment as builtin items.