### PR TITLE
ai: wire difficulty and Aggressive AI into Enemy2

### DIFF
--- a/game/magic/ai/ai_test.go
+++ b/game/magic/ai/ai_test.go
@@ -1,14 +1,20 @@
 package ai
 
 import (
+    "image"
     "testing"
 
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
+    citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
     "github.com/kazzmir/master-of-magic/game/magic/units"
     "github.com/kazzmir/master-of-magic/game/magic/data"
+    "github.com/kazzmir/master-of-magic/game/magic/pathfinding"
+    "github.com/kazzmir/master-of-magic/game/magic/maplib"
+    buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
+    "github.com/kazzmir/master-of-magic/lib/set"
 )
 
 func TestUnitAttackPowerUsesToHit(test *testing.T) {
@@ -49,5 +55,297 @@ func TestBuyItem(test *testing.T) {
 
     if self.Gold != 700 {
         test.Errorf("expected 700 gold after purchase, got %d", self.Gold)
+    }
+}
+
+// stubAIServices is a no-LBX stand-in for GameModel so Enemy2 gates can be tested.
+type stubAIServices struct {
+    difficulty data.DifficultySetting
+    aggressive bool
+    enemies []*playerlib.Player
+}
+
+func (s *stubAIServices) GetCityEnchantmentsByBanner(banner data.BannerType) []playerlib.CityEnchantment {
+    return nil
+}
+
+func (s *stubAIServices) FindPath(oldX int, oldY int, newX int, newY int, player *playerlib.Player, stack playerlib.PathStack, fog data.FogMap) (pathfinding.Path, bool) {
+    return pathfinding.Path{image.Pt(oldX, oldY), image.Pt(newX, newY)}, true
+}
+
+func (s *stubAIServices) FindSettlableLocations(x int, y int, plane data.Plane, fog data.FogMap) []image.Point {
+    return []image.Point{image.Pt(x + 3, y)}
+}
+
+func (s *stubAIServices) IsSettlableLocation(x int, y int, plane data.Plane) bool {
+    return true
+}
+
+func (s *stubAIServices) GetDifficulty() data.DifficultySetting {
+    return s.difficulty
+}
+
+func (s *stubAIServices) GetAggressiveAI() bool {
+    return s.aggressive
+}
+
+func (s *stubAIServices) GetMap(data.Plane) *maplib.Map {
+    return nil
+}
+
+func (s *stubAIServices) FindCitiesOnContinent(x int, y int, plane data.Plane, player *playerlib.Player) []*citylib.City {
+    return nil
+}
+
+func (s *stubAIServices) FindStacksOnContinent(x int, y int, plane data.Plane, player *playerlib.Player) []*playerlib.UnitStack {
+    return nil
+}
+
+func (s *stubAIServices) GetTurnNumber() uint64 {
+    return 20
+}
+
+func (s *stubAIServices) ComputeMaximumPopulation(int, int, data.Plane) int {
+    return 10
+}
+
+func (s *stubAIServices) ComputePower(player *playerlib.Player) int {
+    return 0
+}
+
+func (s *stubAIServices) AllCities() []*citylib.City {
+    return nil
+}
+
+func (s *stubAIServices) FindStack(x int, y int, plane data.Plane) (*playerlib.UnitStack, *playerlib.Player) {
+    return nil, nil
+}
+
+func (s *stubAIServices) FindCity(x int, y int, plane data.Plane) (*citylib.City, *playerlib.Player) {
+    return nil, nil
+}
+
+func (s *stubAIServices) ComputeCityStackInfo() playerlib.CityStackInfo {
+    return playerlib.CityStackInfo{}
+}
+
+func (s *stubAIServices) GetEnemies(player *playerlib.Player) []*playerlib.Player {
+    return s.enemies
+}
+
+func (s *stubAIServices) GetBuildingInfos() buildinglib.BuildingInfos {
+    return nil
+}
+
+func testPlayer() *playerlib.Player {
+    return playerlib.MakePlayer(setup.WizardCustom{}, false, 20, 20, map[herolib.HeroType]string{}, &playerlib.NoGlobalEnchantments{})
+}
+
+func testCity(name string, x int, y int) *citylib.City {
+    city := citylib.MakeCity(name, x, y, data.RaceHighMen, nil, nil, nil, nil)
+    city.Plane = data.PlaneArcanus
+    return city
+}
+
+func TestEnemy2KnobsClassicVsAggressive(test *testing.T) {
+    classic := enemy2Knobs{Aggressive: false, Difficulty: data.DifficultyAverage}
+    if classic.connectCitiesMin() != 2 {
+        test.Errorf("classic Average should start roads at 2 cities, got %d", classic.connectCitiesMin())
+    }
+    if classic.canQueueSettler(0) {
+        test.Errorf("classic Average should not queue a settler at 0 food")
+    }
+    if !classic.canQueueSettler(1) {
+        test.Errorf("classic Average should queue a settler when food is surplus")
+    }
+    if classic.settlerChance() != 60 {
+        test.Errorf("classic settler chance should stay 60, got %d", classic.settlerChance())
+    }
+
+    aggressive := enemy2Knobs{Aggressive: true, Difficulty: data.DifficultyAverage}
+    if aggressive.connectCitiesMin() != 2 {
+        test.Errorf("Aggressive AI should start roads at 2 cities, got %d", aggressive.connectCitiesMin())
+    }
+    if !aggressive.canQueueSettler(0) {
+        test.Errorf("Aggressive AI should queue a settler at 0 food")
+    }
+    if aggressive.canQueueSettler(-1) {
+        test.Errorf("Aggressive AI should still not queue a settler while starving")
+    }
+
+    hard := enemy2Knobs{Aggressive: false, Difficulty: data.DifficultyHard}
+    if hard.connectCitiesMin() != 2 {
+        test.Errorf("Hard should start roads at 2 cities, got %d", hard.connectCitiesMin())
+    }
+    if !hard.canQueueSettler(0) {
+        test.Errorf("Hard should queue a settler at 0 food")
+    }
+
+    intro := enemy2Knobs{Aggressive: false, Difficulty: data.DifficultyIntro}
+    if intro.connectCitiesMin() != 3 {
+        test.Errorf("Intro should keep the 3-city road gate, got %d", intro.connectCitiesMin())
+    }
+    if intro.canQueueSettler(0) {
+        test.Errorf("Intro should not queue a settler at 0 food")
+    }
+
+    easy := enemy2Knobs{Aggressive: false, Difficulty: data.DifficultyEasy}
+    if easy.connectCitiesMin() != 3 {
+        test.Errorf("Easy Classic should keep the 3-city road gate, got %d", easy.connectCitiesMin())
+    }
+}
+
+func TestMakeEnemy2KnobsUsesDifficultyAndAggressive(test *testing.T) {
+    services := &stubAIServices{difficulty: data.DifficultyAverage, aggressive: false}
+    knobs := makeEnemy2Knobs(services)
+    if knobs.Difficulty != data.DifficultyAverage || knobs.Aggressive {
+        test.Errorf("expected Average/classic knobs, got difficulty=%v aggressive=%v", knobs.Difficulty, knobs.Aggressive)
+    }
+
+    services.difficulty = data.DifficultyImpossible
+    services.aggressive = true
+    knobs = makeEnemy2Knobs(services)
+    if knobs.Difficulty != data.DifficultyImpossible || !knobs.Aggressive {
+        test.Errorf("GetDifficulty/GetAggressiveAI were ignored: difficulty=%v aggressive=%v", knobs.Difficulty, knobs.Aggressive)
+    }
+}
+
+func hasGoalType(goals []EnemyGoal, goalType GoalType) bool {
+    for _, goal := range goals {
+        if goal.Goal == goalType {
+            return true
+        }
+    }
+    return false
+}
+
+func TestComputeGoalsConnectCitiesUsesDifficulty(test *testing.T) {
+    self := testPlayer()
+    self.AddCity(testCity("Alpha", 1, 1))
+    self.AddCity(testCity("Beta", 5, 5))
+
+    ai := MakeEnemy2AI()
+    intro := ai.ComputeGoals(self, &stubAIServices{difficulty: data.DifficultyIntro})
+    if hasGoalType(intro, GoalConnectCities) {
+        test.Errorf("Intro with 2 cities should not enable GoalConnectCities")
+    }
+
+    classic := ai.ComputeGoals(self, &stubAIServices{difficulty: data.DifficultyAverage})
+    if !hasGoalType(classic, GoalConnectCities) {
+        test.Errorf("classic Average with 2 cities should enable GoalConnectCities")
+    }
+
+    hard := ai.ComputeGoals(self, &stubAIServices{difficulty: data.DifficultyHard})
+    if !hasGoalType(hard, GoalConnectCities) {
+        test.Errorf("Hard with 2 cities should enable GoalConnectCities")
+    }
+
+    aggressive := ai.ComputeGoals(self, &stubAIServices{difficulty: data.DifficultyAverage, aggressive: true})
+    if !hasGoalType(aggressive, GoalConnectCities) {
+        test.Errorf("Aggressive AI with 2 cities should enable GoalConnectCities")
+    }
+}
+
+func countMoveDecisions(decisions []playerlib.AIDecision) int {
+    count := 0
+    for _, decision := range decisions {
+        if _, ok := decision.(*playerlib.AIMoveStackDecision); ok {
+            count++
+        }
+    }
+    return count
+}
+
+func TestGoalDefeatEnemiesAttacksVisibleCityWithoutEnemyStack(test *testing.T) {
+    self := testPlayer()
+    for range 4 {
+        self.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 1, 1, data.PlaneArcanus))
+    }
+    // a settler must not be sent on the attack
+    self.AddUnit(units.MakeOverworldUnit(units.HighMenSettlers, 2, 2, data.PlaneArcanus))
+
+    enemy := testPlayer()
+    enemy.AddCity(testCity("Rival", 8, 8))
+
+    self.LiftFogAll(data.PlaneArcanus)
+
+    services := &stubAIServices{
+        difficulty: data.DifficultyAverage,
+        enemies: []*playerlib.Player{enemy},
+    }
+
+    ai := MakeEnemy2AI()
+    seenGoals := set.MakeSet[GoalType]()
+    decisions, _ := ai.GoalDecisions(self, services, EnemyGoal{Goal: GoalDefeatEnemies, Weight: 0.9}, seenGoals, &AIData{
+        FoodPerTurn: func() int { return 1 },
+        GoldPerTurn: func() int { return 1 },
+    })
+
+    if countMoveDecisions(decisions) < 1 {
+        test.Errorf("expected a city march with no visible enemy stack, got %#v", decisions)
+    }
+
+    for _, decision := range decisions {
+        move, ok := decision.(*playerlib.AIMoveStackDecision)
+        if !ok {
+            continue
+        }
+        if stackHasSettler(move.Stack) {
+            test.Errorf("settler stack was sent to attack a city")
+        }
+    }
+}
+
+func TestGoalDefeatEnemiesAttacksRememberedCityWithoutVisibleStack(test *testing.T) {
+    self := testPlayer()
+    for range 4 {
+        self.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 1, 1, data.PlaneArcanus))
+    }
+
+    enemy := testPlayer()
+    enemy.AddCity(testCity("Fogged", 8, 8))
+
+    services := &stubAIServices{
+        difficulty: data.DifficultyAverage,
+        enemies: []*playerlib.Player{enemy},
+    }
+
+    ai := MakeEnemy2AI()
+    ai.KnownEnemyCities[CityKey{X: 8, Y: 8, Plane: data.PlaneArcanus}] = &EnemyCityInfo{X: 8, Y: 8, Plane: data.PlaneArcanus}
+
+    seenGoals := set.MakeSet[GoalType]()
+    decisions, _ := ai.GoalDecisions(self, services, EnemyGoal{Goal: GoalDefeatEnemies, Weight: 0.9}, seenGoals, &AIData{
+        FoodPerTurn: func() int { return 1 },
+        GoldPerTurn: func() int { return 1 },
+    })
+
+    if countMoveDecisions(decisions) < 1 {
+        test.Errorf("expected a march on a remembered city with no visible stacks, got %#v", decisions)
+    }
+}
+
+func TestGoalDefeatEnemiesAggressiveMarchesSmallStackOnVisibleCity(test *testing.T) {
+    self := testPlayer()
+    self.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 1, 1, data.PlaneArcanus))
+
+    enemy := testPlayer()
+    enemy.AddCity(testCity("Hamlet", 8, 8))
+    self.LiftFogAll(data.PlaneArcanus)
+
+    services := &stubAIServices{
+        difficulty: data.DifficultyAverage,
+        aggressive: true,
+        enemies: []*playerlib.Player{enemy},
+    }
+
+    ai := MakeEnemy2AI()
+    seenGoals := set.MakeSet[GoalType]()
+    decisions, _ := ai.GoalDecisions(self, services, EnemyGoal{Goal: GoalDefeatEnemies, Weight: 0.9}, seenGoals, &AIData{
+        FoodPerTurn: func() int { return 1 },
+        GoldPerTurn: func() int { return 1 },
+    })
+
+    if countMoveDecisions(decisions) < 1 {
+        test.Errorf("Aggressive AI should march a single swordsmen stack on a visible city, got %#v", decisions)
     }
 }

--- a/game/magic/ai/ai_test.go
+++ b/game/magic/ai/ai_test.go
@@ -58,6 +58,40 @@ func TestBuyItem(test *testing.T) {
     }
 }
 
+func TestNavalExploreIgnoresOffMapEdge(test *testing.T) {
+    const width = 8
+    const height = 3
+
+    wrapX := func(x int) int {
+        x = x % width
+        if x < 0 {
+            x += width
+        }
+        return x
+    }
+
+    player := playerlib.MakePlayer(setup.WizardCustom{}, false, width, height, map[herolib.HeroType]string{}, &playerlib.NoGlobalEnchantments{})
+    player.LiftFogAll(data.PlaneArcanus)
+
+    // fully charted polar ocean must not look like a fog frontier just because
+    // y=-1 is off the map
+    if navalTileIsExploreTarget(player, wrapX, height, 3, 0, data.PlaneArcanus) {
+        test.Errorf("explored polar water should not be an explore target")
+    }
+
+    // still-fogged water to the south is a real frontier
+    player.ArcanusFog[3][1] = data.FogTypeUnexplored
+    if !navalTileIsExploreTarget(player, wrapX, height, 3, 0, data.PlaneArcanus) {
+        test.Errorf("water next to unexplored land/sea should be an explore target")
+    }
+
+    // unexplored water itself is a target
+    player.ArcanusFog[4][0] = data.FogTypeUnexplored
+    if !navalTileIsExploreTarget(player, wrapX, height, 4, 0, data.PlaneArcanus) {
+        test.Errorf("unexplored water should be an explore target")
+    }
+}
+
 // stubAIServices is a no-LBX stand-in for GameModel so Enemy2 gates can be tested.
 type stubAIServices struct {
     difficulty data.DifficultySetting

--- a/game/magic/ai/enemy2.go
+++ b/game/magic/ai/enemy2.go
@@ -295,8 +295,85 @@ func chance(percent int) bool {
     return rand.N(100) < percent
 }
 
+// enemy2Knobs is Classic vs Aggressive (plus new-game difficulty) for Enemy2.
+// Classic (Aggressive AI off, Average) keeps today's expansion gates so Average
+// is not wildly meaner: settlers need a food surplus, engineers wait for 3
+// cities. Hard+ and the Aggressive AI checkbox settle earlier, will queue a
+// settler at 0 food, and start roads at 2 cities.
+//
+// City attacks on known/visible enemy cities never require a visible rival
+// stack — that gate was a bug versus original 1.31 (ReMoM as a behavior spec,
+// not code to copy). Lair raid margins are unchanged in both profiles.
+type enemy2Knobs struct {
+    Aggressive bool
+    Difficulty data.DifficultySetting
+}
+
+func makeEnemy2Knobs(aiServices playerlib.AIServices) enemy2Knobs {
+    return enemy2Knobs{
+        Aggressive: aiServices.GetAggressiveAI(),
+        Difficulty: aiServices.GetDifficulty(),
+    }
+}
+
+func (knobs enemy2Knobs) pressure() bool {
+    return knobs.Aggressive || knobs.Difficulty >= data.DifficultyHard
+}
+
+func (knobs enemy2Knobs) connectCitiesMin() int {
+    // Intro/Easy Classic wait for 3 cities. Average and up (and Aggressive)
+    // start roads at 2 — original 1.31 connected the first towns, and waiting
+    // for 3 meant engineers sat idle on Average because a second city was rare.
+    if knobs.Difficulty <= data.DifficultyEasy && !knobs.Aggressive {
+        return 3
+    }
+    return 2
+}
+
+// visibleCityAssumedPower is the dummy garrison we pretend a seen enemy city
+// has. Early stacks are ~6 (one swordsmen); 15 made city marches a no-op even
+// after the visible-stack gate was lifted.
+func (knobs enemy2Knobs) visibleCityAssumedPower() int {
+    if knobs.Aggressive {
+        return 5
+    }
+    if knobs.Difficulty >= data.DifficultyHard {
+        return 8
+    }
+    return 10
+}
+
+func (knobs enemy2Knobs) rememberedCityMinPower() int {
+    if knobs.pressure() {
+        return 12
+    }
+    return 20
+}
+
+func (knobs enemy2Knobs) settlerChance() int {
+    if knobs.Aggressive {
+        return 90
+    }
+    if knobs.Difficulty >= data.DifficultyHard {
+        return 75
+    }
+    return 60
+}
+
+func (knobs enemy2Knobs) canQueueSettler(foodPerTurn int) bool {
+    if foodPerTurn > 0 {
+        return true
+    }
+    // Aggressive / Hard+: do not starve expansion at break-even food forever
+    if foodPerTurn == 0 && knobs.pressure() {
+        return true
+    }
+    return false
+}
+
 func (ai *Enemy2AI) ComputeGoals(self *playerlib.Player, aiServices playerlib.AIServices) []EnemyGoal {
     var goals []EnemyGoal
+    knobs := makeEnemy2Knobs(aiServices)
 
     exploreGoal := EnemyGoal{
         Goal: GoalExploreTerritory,
@@ -312,6 +389,9 @@ func (ai *Enemy2AI) ComputeGoals(self *playerlib.Player, aiServices playerlib.AI
     // the standing-army target grows as the game goes on (more stacks = more
     // aggression / defense capacity).
     armyTarget := max(5, aiServices.GetTurnNumber() / 5)
+    if knobs.pressure() {
+        armyTarget = max(6, aiServices.GetTurnNumber() / 4)
+    }
     if armyTarget < 2 {
         armyTarget = 2
     }
@@ -321,7 +401,8 @@ func (ai *Enemy2AI) ComputeGoals(self *playerlib.Player, aiServices playerlib.AI
 
     // base goal priorities. These weights surface in the watch-mode debug overlay
     // so the AI's current disposition (aggressive vs. builder vs. turtle) is
-    // visible while spectating.
+    // visible while spectating. List order still picks which goal runs; weights
+    // are for LastGoalDebug, not selection.
     goals = []EnemyGoal{
         EnemyGoal{
             Goal: GoalDefeatEnemies,
@@ -344,9 +425,8 @@ func (ai *Enemy2AI) ComputeGoals(self *playerlib.Player, aiServices playerlib.AI
         },
     }
 
-    // once we have a small empire, dedicate some effort to connecting cities
-    // with roads (1 engineer per 3 cities) for faster troop movement and trade
-    if len(self.Cities) >= 3 {
+    // Intro/Easy Classic wait for 3 cities; Average and Aggressive/Hard+ start at 2
+    if len(self.Cities) >= knobs.connectCitiesMin() {
         goals = append(goals, EnemyGoal{
             Goal: GoalConnectCities,
             Weight: 0.5,
@@ -1538,6 +1618,12 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
     seenGoals.Insert(goal.Goal)
 
+    if ai.Attacking == nil {
+        ai.Attacking = make(map[*playerlib.UnitStack]bool)
+    }
+
+    knobs := makeEnemy2Knobs(aiServices)
+
     var decisions []playerlib.AIDecision
 
     // recursively satisfy subgoals first
@@ -1552,7 +1638,11 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
     switch goal.Goal {
         case GoalDefeatEnemies:
-            // find possible enemy targets
+            // March on visible enemy cities and remembered scouted cities even
+            // when no rival STACK is currently visible. Original 1.31 (ReMoM
+            // behavior spec) does not wait for a field army to appear first;
+            // requiring possibleTarget left city offense dead and only lair
+            // raids ran. Lair margins below stay independent of this gate.
             var possibleTarget []*playerlib.UnitStack
             var possibleCities []*citylib.City
             for _, enemyPlayer := range aiServices.GetEnemies(self) {
@@ -1572,7 +1662,15 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                 }
             }
 
-            if len(possibleTarget) > 0 {
+            hasUnseenKnownCity := false
+            for _, known := range ai.KnownEnemyCities {
+                if !self.IsVisible(known.X, known.Y, known.Plane) {
+                    hasUnseenKnownCity = true
+                    break
+                }
+            }
+
+            if len(possibleTarget) > 0 || len(possibleCities) > 0 || hasUnseenKnownCity {
                 for _, stack := range self.Stacks {
                     // never march a settler (or its escort) off to attack
                     if stackHasSettler(stack) {
@@ -1591,8 +1689,7 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
 
                         for _, city := range possibleCities {
                             if city.Plane == stack.Plane() {
-                                // just assume the city has some power in it
-                                targetPower := 15
+                                targetPower := knobs.visibleCityAssumedPower()
                                 if stackPower > targetPower - rand.N(10) {
                                     pathToCity, ok := aiServices.FindPath(stack.X(), stack.Y(), city.X, city.Y, self, stack, self.GetFog(stack.Plane()))
                                     if ok {
@@ -1628,7 +1725,7 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
                         // the AI keeps pressing an offensive using its scouting
                         // memory. Gated on a healthy attack power so we don't send
                         // weak stacks blindly into an unknown garrison.
-                        if len(shortestPath) == 0 && stackPower >= 20 {
+                        if len(shortestPath) == 0 && stackPower >= knobs.rememberedCityMinPower() {
                             for _, known := range ai.KnownEnemyCities {
                                 if known.Plane != stack.Plane() {
                                     continue
@@ -1976,11 +2073,14 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
             // turn while under the cap. The cap grows with the empire so larger
             // empires keep expanding.
             maxConcurrentSettlers := 1 + len(self.Cities)/3
+            if knobs.pressure() {
+                maxConcurrentSettlers = 1 + len(self.Cities)/2
+            }
             if maxConcurrentSettlers < 1 {
                 maxConcurrentSettlers = 1
             }
-            settlerChance := 60
-            if aiData.FoodPerTurn() > 0 && countSettlerPipeline(self) < maxConcurrentSettlers {
+            settlerChance := knobs.settlerChance()
+            if knobs.canQueueSettler(aiData.FoodPerTurn()) && countSettlerPipeline(self) < maxConcurrentSettlers {
                 for _, city := range self.Cities {
                     if !isMakingSomething(city) && chance(settlerChance) {
                         locations := aiServices.FindSettlableLocations(city.X, city.Y, city.Plane, self.GetFog(city.Plane))
@@ -2018,11 +2118,11 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
             for _, stack := range self.Stacks {
                 if stack.HasMoves() {
 
-                    // once the ConnectCities goal is active (>=3 cities) leave engineer
+                    // once the ConnectCities goal is active leave engineer
                     // stacks for it to dispatch as road builders instead of sending them
                     // off to scout/explore (engineers have a nominal attack power of 1
                     // and would otherwise pass the scout filter below)
-                    if len(self.Cities) >= 3 && stackHasEngineer(stack) {
+                    if len(self.Cities) >= knobs.connectCitiesMin() && stackHasEngineer(stack) {
                         continue
                     }
 
@@ -2393,13 +2493,15 @@ func (ai *Enemy2AI) GoalDecisions(self *playerlib.Player, aiServices playerlib.A
             }
 
         case GoalConnectCities:
-            // need a few cities before roads are worth the engineer investment
-            if len(self.Cities) < 3 {
+            // Intro/Easy Classic: 3 cities. Average and Aggressive/Hard+: 2 so
+            // engineers are not left idle until an empire that rarely forms.
+            minCities := knobs.connectCitiesMin()
+            if len(self.Cities) < minCities {
                 break
             }
 
-            // budget: one engineer per three cities
-            engineerBudget := len(self.Cities) / 3
+            // budget: one engineer per connectCitiesMin cities
+            engineerBudget := len(self.Cities) / minCities
             currentEngineers := countEngineers(self)
 
             // produce another engineer if we are under budget and can afford it

--- a/game/magic/ai/enemy2.go
+++ b/game/magic/ai/enemy2.go
@@ -1485,26 +1485,15 @@ func (ai *Enemy2AI) findNavalExplorePath(self *playerlib.Player, aiServices play
             }
             nx := useMap.WrapX(sx + dx)
             ny := sy + dy
+            if ny < 0 || ny >= useMap.Height() {
+                continue
+            }
             tile := useMap.GetTile(nx, ny)
             if !tile.Valid() || !useMap.IsWater(nx, ny) {
                 continue
             }
 
-            // target unexplored water directly, or explored water sitting next
-            // to a fogged tile (the edge of what we've seen) so the ship keeps
-            // pushing into the unknown even once its home waters are charted
-            target := !self.IsExplored(nx, ny, plane)
-            if !target {
-                for ddy := -1; ddy <= 1 && !target; ddy++ {
-                    for ddx := -1; ddx <= 1; ddx++ {
-                        if !self.IsExplored(useMap.WrapX(nx+ddx), ny+ddy, plane) {
-                            target = true
-                            break
-                        }
-                    }
-                }
-            }
-            if !target {
+            if !navalTileIsExploreTarget(self, useMap.WrapX, useMap.Height(), nx, ny, plane) {
                 continue
             }
 
@@ -1529,6 +1518,34 @@ func (ai *Enemy2AI) findNavalExplorePath(self *playerlib.Player, aiServices play
     }
 
     return nil
+}
+
+// navalTileIsExploreTarget is true for unexplored water, or explored water that
+// sits next to a still-fogged tile. Off-map Y is not fog: IsExplored(x, -1)
+// returns false, so treating it as unexplored made every polar water tile look
+// like a frontier. Ships then parked on y=0 / y=height-1 and pathfinding
+// exploded along that strip.
+func navalTileIsExploreTarget(self *playerlib.Player, wrapX func(int) int, height int, x int, y int, plane data.Plane) bool {
+    if !self.IsExplored(x, y, plane) {
+        return true
+    }
+
+    for ddy := -1; ddy <= 1; ddy++ {
+        neighborY := y + ddy
+        if neighborY < 0 || neighborY >= height {
+            continue
+        }
+        for ddx := -1; ddx <= 1; ddx++ {
+            if ddx == 0 && ddy == 0 {
+                continue
+            }
+            if !self.IsExplored(wrapX(x + ddx), neighborY, plane) {
+                return true
+            }
+        }
+    }
+
+    return false
 }
 
 // return a subset of moveUnits that can move while still leaving minimumAttackPower behind

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -628,6 +628,12 @@ func MakeGameWithModel(lbxCache *lbx.LbxCache, music *musiclib.Music, gameSettin
 
     // game.Model = MakeGameModel(terrainData, settings, data.PlaneArcanus, game.Events, heroNames, game.AllSpells(), createArtifactPool(lbxCache), buildingInfo)
     game.Model = makeModel(lbxCache, game.Events)
+    game.Model.IsAggressiveAI = func() bool {
+        if gameSettings == nil {
+            return false
+        }
+        return gameSettings.AggressiveAI
+    }
 
     game.HudUI = game.MakeHudUI()
     game.PushDrawer(func(screen *ebiten.Image){

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4151,9 +4151,17 @@ func (game *Game) doAiUpdate(yield coroutine.YieldFunc, player *playerlib.Player
 
     if player.AIBehavior != nil {
         decisionResult := make(chan []playerlib.AIDecision)
+        thinkStart := time.Now()
+        thinkYear := game.Model.TurnNumber
+        thinkName := player.Wizard.Name
+        thinkBanner := player.GetBanner()
         go func() {
             // run AI in background so the UI doesn't totally freeze
             out := player.AIBehavior.Update(player, game.Model)
+            elapsed := time.Since(thinkStart)
+            if elapsed >= time.Second {
+                log.Printf("Year=%v AI %v(%v) thought for %v (%d decisions)", thinkYear, thinkName, thinkBanner, elapsed, len(out))
+            }
             decisionResult <- out
             close(decisionResult)
         }()

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -356,29 +356,7 @@ func (model *GameModel) FindPath(oldX int, oldY int, newX int, newY int, player 
     }
 
     neighbors := func (x int, y int) []image.Point {
-        out := make([]image.Point, 0, 8)
-        x = useMap.WrapX(x)
-
-        // wrap X so Dijkstra does not treat x=-1 / x=width as new tiles.
-        // unwrapped neighbors made late-game AI pathfinding take minutes
-        // (samePoint wraps, but the node map key does not).
-        add := func(nx int, ny int) {
-            if ny < 0 || ny >= useMap.Height() {
-                return
-            }
-            out = append(out, image.Pt(useMap.WrapX(nx), ny))
-        }
-
-        add(x - 1, y)
-        add(x, y - 1)
-        add(x + 1, y)
-        add(x, y + 1)
-        add(x - 1, y - 1)
-        add(x - 1, y + 1)
-        add(x + 1, y - 1)
-        add(x + 1, y + 1)
-
-        return out
+        return pathfinding.NeighborsWrapX(x, y, useMap.Height(), useMap.WrapX)
     }
 
     path, ok := pathfinding.FindPath(image.Pt(oldX, oldY), image.Pt(newX, newY), 10000, tileCost, neighbors, tileEqual)

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -213,6 +213,9 @@ func (model *GameModel) FindPath(oldX int, oldY int, newX int, newY int, player 
         return nil, false
     }
 
+    oldX = useMap.WrapX(oldX)
+    newX = useMap.WrapX(newX)
+
     if oldX == newX && oldY == newY {
         return nil, true
     }
@@ -354,43 +357,26 @@ func (model *GameModel) FindPath(oldX int, oldY int, newX int, newY int, player 
 
     neighbors := func (x int, y int) []image.Point {
         out := make([]image.Point, 0, 8)
+        x = useMap.WrapX(x)
 
-        // cardinals first, followed by diagonals
-        // left
-        out = append(out, image.Pt(x - 1, y))
-
-        // up
-        if y > 0 {
-            out = append(out, image.Pt(x, y - 1))
+        // wrap X so Dijkstra does not treat x=-1 / x=width as new tiles.
+        // unwrapped neighbors made late-game AI pathfinding take minutes
+        // (samePoint wraps, but the node map key does not).
+        add := func(nx int, ny int) {
+            if ny < 0 || ny >= useMap.Height() {
+                return
+            }
+            out = append(out, image.Pt(useMap.WrapX(nx), ny))
         }
 
-        // right
-        out = append(out, image.Pt(x + 1, y))
-
-        // down
-        if y < useMap.Height() - 1 {
-            out = append(out, image.Pt(x, y + 1))
-        }
-
-        // up left
-        if y > 0 {
-            out = append(out, image.Pt(x - 1, y - 1))
-        }
-
-        // down left
-        if y < useMap.Height() - 1 {
-            out = append(out, image.Pt(x - 1, y + 1))
-        }
-
-        // up right
-        if y > 0 {
-            out = append(out, image.Pt(x + 1, y - 1))
-        }
-
-        // down right
-        if y < useMap.Height() - 1 {
-            out = append(out, image.Pt(x + 1, y + 1))
-        }
+        add(x - 1, y)
+        add(x, y - 1)
+        add(x + 1, y)
+        add(x, y + 1)
+        add(x - 1, y - 1)
+        add(x - 1, y + 1)
+        add(x + 1, y - 1)
+        add(x + 1, y + 1)
 
         return out
     }

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -36,6 +36,10 @@ type GameModel struct {
 
     Settings setup.NewGameSettings
 
+    // live read of the session-only Aggressive AI checkbox (not serialized).
+    // Set by MakeGameWithModel from game Settings. Nil means Classic.
+    IsAggressiveAI func() bool
+
     heroNames map[int]map[herolib.HeroType]string
     allSpells spellbook.Spells
 
@@ -664,6 +668,13 @@ func (model *GameModel) FindStack(x int, y int, plane data.Plane) (*playerlib.Un
 
 func (model *GameModel) GetDifficulty() data.DifficultySetting {
     return model.Settings.Difficulty
+}
+
+func (model *GameModel) GetAggressiveAI() bool {
+    if model.IsAggressiveAI == nil {
+        return false
+    }
+    return model.IsAggressiveAI()
 }
 
 func (model *GameModel) GetTurnNumber() uint64 {

--- a/game/magic/game/path_test.go
+++ b/game/magic/game/path_test.go
@@ -3,6 +3,7 @@ package game
 import (
     "testing"
     "image"
+    "time"
 
     playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
     herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
@@ -220,4 +221,60 @@ func TestPathBasic(test *testing.T) {
             test.Errorf("stack with an inactive ship must not path from water onto land")
         }
     }()
+}
+
+func TestFindPathUnreachableAcrossOceanDoesNotHang(test *testing.T) {
+    var model GameModel
+
+    terrainData := terrain.MakeTerrainData([]image.Image{nil, nil}, []terrain.TerrainTile{
+        terrain.TerrainTile{TileIndex: 0, Tile: terrain.TileLand},
+        terrain.TerrainTile{TileIndex: 1, Tile: terrain.TileOcean},
+    })
+
+    const width = 40
+    const height = 3
+
+    xmap := maplib.Map{
+        Map: terrain.MakeMap(height, width),
+        Data: terrainData,
+        Plane: data.PlaneArcanus,
+    }
+
+    // two land strips separated by explored ocean. A land walker cannot cross,
+    // so Dijkstra must exhaust the graph. Unwrapped X neighbors made that
+    // search walk off the map until the cost cap (~seconds per call).
+    for x := 0; x < width; x++ {
+        xmap.Map.Terrain[x][0] = 0
+        xmap.Map.Terrain[x][1] = 1
+        xmap.Map.Terrain[x][2] = 0
+    }
+
+    model.ArcanusMap = &xmap
+
+    fog := make(data.FogMap, width)
+    for x := 0; x < width; x++ {
+        fog[x] = make([]data.FogType, height)
+        for y := 0; y < height; y++ {
+            fog[x][y] = data.FogTypeVisible
+        }
+    }
+
+    player1 := playerlib.MakePlayer(setup.WizardCustom{}, true, width, height, map[herolib.HeroType]string{}, &model)
+    player1.AddUnit(units.MakeOverworldUnit(units.HighMenSwordsmen, 0, 0, data.PlaneArcanus))
+    stack := player1.FindStack(0, 0, data.PlaneArcanus)
+
+    done := make(chan bool, 1)
+    go func() {
+        _, ok := model.FindPath(0, 0, width / 2, 2, player1, stack, fog)
+        done <- ok
+    }()
+
+    select {
+        case ok := <-done:
+            if ok {
+                test.Errorf("land walker should not path across explored ocean")
+            }
+        case <-time.After(2 * time.Second):
+            test.Fatal("FindPath hung; overland neighbors are probably not wrapping X")
+    }
 }

--- a/game/magic/game/road.go
+++ b/game/magic/game/road.go
@@ -151,6 +151,9 @@ func (game *Game) FindRoadPath(oldX int, oldY int, newX int, newY int, player *p
         return nil
     }
 
+    oldX = useMap.WrapX(oldX)
+    newX = useMap.WrapX(newX)
+
     normalized := func (a image.Point) image.Point {
         return image.Pt(useMap.WrapX(a.X), a.Y)
     }
@@ -243,26 +246,7 @@ func (game *Game) FindRoadPath(oldX int, oldY int, newX int, newY int, player *p
     }
 
     neighbors := func (x int, y int) []image.Point {
-        out := make([]image.Point, 0, 8)
-        x = useMap.WrapX(x)
-
-        add := func(nx int, ny int) {
-            if ny < 0 || ny >= useMap.Height() {
-                return
-            }
-            out = append(out, image.Pt(useMap.WrapX(nx), ny))
-        }
-
-        add(x - 1, y)
-        add(x, y - 1)
-        add(x + 1, y)
-        add(x, y + 1)
-        add(x - 1, y - 1)
-        add(x - 1, y + 1)
-        add(x + 1, y - 1)
-        add(x + 1, y + 1)
-
-        return out
+        return pathfinding.NeighborsWrapX(x, y, useMap.Height(), useMap.WrapX)
     }
 
     path, ok := pathfinding.FindPath(image.Pt(oldX, oldY), image.Pt(newX, newY), 10000, tileCost, neighbors, tileEqual)

--- a/game/magic/game/road.go
+++ b/game/magic/game/road.go
@@ -244,43 +244,23 @@ func (game *Game) FindRoadPath(oldX int, oldY int, newX int, newY int, player *p
 
     neighbors := func (x int, y int) []image.Point {
         out := make([]image.Point, 0, 8)
+        x = useMap.WrapX(x)
 
-        // cardinals first, followed by diagonals
-        // left
-        out = append(out, image.Pt(x - 1, y))
-
-        // up
-        if y > 0 {
-            out = append(out, image.Pt(x, y - 1))
+        add := func(nx int, ny int) {
+            if ny < 0 || ny >= useMap.Height() {
+                return
+            }
+            out = append(out, image.Pt(useMap.WrapX(nx), ny))
         }
 
-        // right
-        out = append(out, image.Pt(x + 1, y))
-
-        // down
-        if y < useMap.Height() - 1 {
-            out = append(out, image.Pt(x, y + 1))
-        }
-
-        // up left
-        if y > 0 {
-            out = append(out, image.Pt(x - 1, y - 1))
-        }
-
-        // down left
-        if y < useMap.Height() - 1 {
-            out = append(out, image.Pt(x - 1, y + 1))
-        }
-
-        // up right
-        if y > 0 {
-            out = append(out, image.Pt(x + 1, y - 1))
-        }
-
-        // down right
-        if y < useMap.Height() - 1 {
-            out = append(out, image.Pt(x + 1, y + 1))
-        }
+        add(x - 1, y)
+        add(x, y - 1)
+        add(x + 1, y)
+        add(x, y + 1)
+        add(x - 1, y - 1)
+        add(x - 1, y + 1)
+        add(x + 1, y - 1)
+        add(x + 1, y + 1)
 
         return out
     }

--- a/game/magic/pathfinding/path.go
+++ b/game/magic/pathfinding/path.go
@@ -28,6 +28,33 @@ func PointEqual(a image.Point, b image.Point) bool {
     return a == b
 }
 
+// NeighborsWrapX returns the 8 adjacent tiles of (x,y) with X wrapped onto the
+// map and Y clamped. Emitting raw x-1/x+1 as distinct nodes makes Dijkstra
+// walk off a cylindrical map until maxPath, which hung late-game AI — especially
+// ships stuck on the north/south edge, where Y cannot expand.
+func NeighborsWrapX(x int, y int, height int, wrapX func(int) int) []image.Point {
+    out := make([]image.Point, 0, 8)
+    x = wrapX(x)
+
+    add := func(nx int, ny int) {
+        if ny < 0 || ny >= height {
+            return
+        }
+        out = append(out, image.Pt(wrapX(nx), ny))
+    }
+
+    add(x - 1, y)
+    add(x, y - 1)
+    add(x + 1, y)
+    add(x, y + 1)
+    add(x - 1, y - 1)
+    add(x - 1, y + 1)
+    add(x + 1, y - 1)
+    add(x + 1, y + 1)
+
+    return out
+}
+
 /* returns an array of points that is the shortest/cheapest path from start->end and true, or false if no such path exists
  * basically djikstra's shortest path algorithm
  */

--- a/game/magic/pathfinding/path_test.go
+++ b/game/magic/pathfinding/path_test.go
@@ -5,6 +5,7 @@ import (
     "strings"
     "image"
     "slices"
+    "time"
     "math/rand/v2"
 )
 
@@ -185,21 +186,7 @@ func TestFindPathWrapsX(test *testing.T) {
     }
 
     neighbors := func(x int, y int) []image.Point {
-        var out []image.Point
-        x = wrapX(x)
-        for dx := -1; dx <= 1; dx++ {
-            for dy := -1; dy <= 1; dy++ {
-                if dx == 0 && dy == 0 {
-                    continue
-                }
-                ny := y + dy
-                if ny < 0 || ny >= height {
-                    continue
-                }
-                out = append(out, image.Pt(wrapX(x + dx), ny))
-            }
-        }
-        return out
+        return NeighborsWrapX(x, y, height, wrapX)
     }
 
     tileCost := func(x1 int, y1 int, x2 int, y2 int) float64 {
@@ -214,6 +201,86 @@ func TestFindPathWrapsX(test *testing.T) {
     }
     if len(path) != 2 {
         test.Errorf("wrapping path should be one step (start+end), got %v", path)
+    }
+}
+
+func TestNeighborsWrapX(test *testing.T) {
+    const width = 8
+    const height = 3
+
+    wrapX := func(x int) int {
+        x = x % width
+        if x < 0 {
+            x += width
+        }
+        return x
+    }
+
+    neighbors := NeighborsWrapX(0, 0, height, wrapX)
+
+    has := func(x int, y int) bool {
+        return slices.Contains(neighbors, image.Pt(x, y))
+    }
+
+    if has(-1, 0) || has(width, 0) {
+        test.Errorf("neighbors must wrap X, got %v", neighbors)
+    }
+    if has(0, -1) {
+        test.Errorf("neighbors must not include off-map Y, got %v", neighbors)
+    }
+    if !has(width - 1, 0) {
+        test.Errorf("west edge should wrap to x=%d, got %v", width - 1, neighbors)
+    }
+    if !has(1, 0) || !has(0, 1) {
+        test.Errorf("expected in-map neighbors, got %v", neighbors)
+    }
+}
+
+func TestFindPathUnreachableDoesNotWalkOffMap(test *testing.T) {
+    const width = 8
+    const height = 3
+
+    wrapX := func(x int) int {
+        x = x % width
+        if x < 0 {
+            x += width
+        }
+        return x
+    }
+
+    samePoint := func(a image.Point, b image.Point) bool {
+        return wrapX(a.X) == wrapX(b.X) && a.Y == b.Y
+    }
+
+    // water along y=0, land (impassable) on y=1. Destination is inland.
+    tileCost := func(x1 int, y1 int, x2 int, y2 int) float64 {
+        x2 = wrapX(x2)
+        if y2 < 0 || y2 >= height {
+            return Infinity
+        }
+        if y2 != 0 {
+            return Infinity
+        }
+        return 1
+    }
+
+    neighbors := func(x int, y int) []image.Point {
+        return NeighborsWrapX(x, y, height, wrapX)
+    }
+
+    done := make(chan bool, 1)
+    go func() {
+        _, ok := FindPath(image.Pt(0, 0), image.Pt(4, 2), 10000, tileCost, neighbors, samePoint)
+        done <- ok
+    }()
+
+    select {
+        case ok := <-done:
+            if ok {
+                test.Errorf("expected no path from polar water to inland")
+            }
+        case <-time.After(2 * time.Second):
+            test.Fatal("FindPath hung; neighbors are probably not wrapping X")
     }
 }
 

--- a/game/magic/pathfinding/path_test.go
+++ b/game/magic/pathfinding/path_test.go
@@ -168,6 +168,55 @@ XXXX
     }
 }
 
+func TestFindPathWrapsX(test *testing.T) {
+    const width = 8
+    const height = 3
+
+    wrapX := func(x int) int {
+        x = x % width
+        if x < 0 {
+            x += width
+        }
+        return x
+    }
+
+    samePoint := func(a image.Point, b image.Point) bool {
+        return wrapX(a.X) == wrapX(b.X) && a.Y == b.Y
+    }
+
+    neighbors := func(x int, y int) []image.Point {
+        var out []image.Point
+        x = wrapX(x)
+        for dx := -1; dx <= 1; dx++ {
+            for dy := -1; dy <= 1; dy++ {
+                if dx == 0 && dy == 0 {
+                    continue
+                }
+                ny := y + dy
+                if ny < 0 || ny >= height {
+                    continue
+                }
+                out = append(out, image.Pt(wrapX(x + dx), ny))
+            }
+        }
+        return out
+    }
+
+    tileCost := func(x1 int, y1 int, x2 int, y2 int) float64 {
+        return 1
+    }
+
+    // from the west edge to the east edge, wrapping is one step
+    path, ok := FindPath(image.Pt(0, 1), image.Pt(width - 1, 1), 100, tileCost, neighbors, samePoint)
+    if !ok {
+        test.Errorf("expected a wrapping path from x=0 to x=%d", width - 1)
+        return
+    }
+    if len(path) != 2 {
+        test.Errorf("wrapping path should be one step (start+end), got %v", path)
+    }
+}
+
 func makeRandomMap(rows int, columns int, value int) [][]float64 {
     var out [][]float64
 

--- a/game/magic/player/player.go
+++ b/game/magic/player/player.go
@@ -141,6 +141,8 @@ type AIServices interface {
     FindSettlableLocations(x int, y int, plane data.Plane, fog data.FogMap) []image.Point
     IsSettlableLocation(x int, y int, plane data.Plane) bool
     GetDifficulty() data.DifficultySetting
+    // session-only settings checkbox; false is Classic Enemy2 pacing
+    GetAggressiveAI() bool
     GetMap(data.Plane) *maplib.Map
 
     // get friendly cities on the same continent as the given point

--- a/game/magic/settings/data.go
+++ b/game/magic/settings/data.go
@@ -14,6 +14,9 @@ type Settings struct {
     EndOfTurnWait bool
     StrategicCombatOnly bool
     RandomEvents bool
+    // AggressiveAI is session-only (same as RandomEvents). When on, Enemy2
+    // uses the meaner expansion/offense knobs; default off is Classic pacing.
+    AggressiveAI bool
     Keybindings *keybinds.Keybindings
 }
 
@@ -22,6 +25,7 @@ func MakeSettings(cache *lbx.LbxCache) *Settings {
         EndOfTurnWait: true,
         StrategicCombatOnly: false,
         RandomEvents: true,
+        AggressiveAI: false,
         Keybindings: keybinds.MakeKeybindings(),
     }
 }

--- a/game/magic/settings/settings.go
+++ b/game/magic/settings/settings.go
@@ -186,7 +186,13 @@ func MakeSettingsUI(yield coroutine.YieldFunc, parentUI *uilib.UI, cache *lbx.Lb
     addCheckbox(group, fonts, &getAlpha, 30, 150, "Random Events",
         func() bool { return settings.RandomEvents },
         func(value bool) { settings.RandomEvents = value },
-     )
+    )
+
+    // session-only, same as Random Events. Enemy2 reads this via AIServices.
+    addCheckbox(group, fonts, &getAlpha, 175, 150, "Aggressive AI",
+        func() bool { return settings.AggressiveAI },
+        func(value bool) { settings.AggressiveAI = value },
+    )
 
     return group, quit
 }

--- a/game/magic/settings/settings_test.go
+++ b/game/magic/settings/settings_test.go
@@ -19,4 +19,8 @@ func TestMakeSettingsDefaults(test *testing.T) {
     if !s.RandomEvents {
         test.Errorf("RandomEvents should default to true")
      }
+
+    if s.AggressiveAI {
+        test.Errorf("AggressiveAI should default to false (Classic)")
+    }
 }


### PR DESCRIPTION
## Summary
- Enemy2 now uses `GetDifficulty()` plus a session-only **Aggressive AI** checkbox (next to Random Events). Classic Average is not wildly meaner; Aggressive and Hard+ settle earlier, will queue settlers at 0 food, and start roads at 2 cities.
- City offense no longer requires a visible rival **stack** first: wizards march on visible or remembered scouted cities. Settlers/melders stay off attacks; lair raid margins are unchanged.
- Tests cover the new gates without LBX (city attack without stacks, Classic vs Aggressive settler/food/road knobs).

## Watch the AI
Need original LBX files on disk (not required for unit tests). Then:

```bash
go build -o magic ./game/magic
./magic -data data/mom -watch -music=false
```

(`-data` can be any directory or zip of the `.LBX` files.) Watch mode is AI-only (4 opponents, Average). Year summaries print to the log (`Cities:`, `Food:`). Turn on **Aggressive AI** from the in-game settings overlay (same row as Random Events) to compare; speed slider is at the bottom of the watch UI, press D for goal debug.

## Test plan
- [ ] `go test ./game/magic/ai ./game/magic/settings` (no LBX)
- [ ] Settings: Aggressive AI defaults off; toggling it live affects Enemy2
- [ ] Watch Classic: second cities well before the old ~year 150 stall; food-0 empires still hold settlers
- [ ] Watch Aggressive: earlier settlers, 2-city roads, small stacks marching on seen hamlets with no rival stack on the map
- [ ] Confirm settlers/melders are not sent on city attacks


Made with [Cursor](https://cursor.com)