### PR TITLE
settings: persist remake preferences in save files

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -563,6 +563,9 @@ func MakeGame(lbxCache *lbx.LbxCache, music *musiclib.Music, gameSettings *setti
 }
 
 func MakeGameFromSerialized(lbxCache *lbx.LbxCache, music *musiclib.Music, gameSettings *settingslib.Settings, serializedGame *SerializedGame) *Game {
+    if serializedGame != nil {
+        serializedGame.Preferences.Apply(gameSettings)
+    }
 
     heroNames := herolib.ReadNamesPerWizard(lbxCache)
 
@@ -1715,7 +1718,7 @@ func (saver *GameSaver) SaveToPath(path string, saveName string) error {
 }
 
 func (saver *GameSaver) Save(writer io.Writer, saveName string) error {
-    data := SerializeModel(saver.Game.Model, saveName)
+    data := SerializeModel(saver.Game.Model, saveName, saver.Game.Settings)
     marshaler := json.NewEncoder(writer)
     return marshaler.Encode(data)
 }

--- a/game/magic/game/serialize.go
+++ b/game/magic/game/serialize.go
@@ -10,6 +10,7 @@ import (
     citylib "github.com/kazzmir/master-of-magic/game/magic/city"
     "github.com/kazzmir/master-of-magic/game/magic/data"
     "github.com/kazzmir/master-of-magic/game/magic/serialize"
+    settingslib "github.com/kazzmir/master-of-magic/game/magic/settings"
     "github.com/kazzmir/master-of-magic/game/magic/setup"
     "github.com/kazzmir/master-of-magic/game/magic/artifact"
     "github.com/kazzmir/master-of-magic/game/magic/spellbook"
@@ -77,6 +78,10 @@ type SerializedGame struct {
     ArtifactCatalog []artifact.SerializedArtifact `json:"artifact-catalog,omitempty"`
     ArtifactAvailable []bool `json:"artifact-available,omitempty"`
     Settings setup.NewGameSettings `json:"settings"`
+    // remake UI prefs (end-of-turn wait, keybindings, ...). Omitted in
+    // saves written before this field existed; json "settings" is the
+    // new-game difficulty/land/magic struct, not this.
+    Preferences *settingslib.SerializedSettings `json:"preferences,omitempty"`
     CurrentPlayer int `json:"current-player"`
     Turn uint64 `json:"turn"`
     LastEventTurn uint64 `json:"last-event-turn"`
@@ -84,7 +89,7 @@ type SerializedGame struct {
     Events []SerializedRandomEvent `json:"events"`
 }
 
-func SerializeModel(model *GameModel, saveName string) SerializedGame {
+func SerializeModel(model *GameModel, saveName string, prefs *settingslib.Settings) SerializedGame {
     var players []playerlib.SerializedPlayer
     for _, player := range model.Players {
         players = append(players, playerlib.SerializePlayer(player))
@@ -103,6 +108,7 @@ func SerializeModel(model *GameModel, saveName string) SerializedGame {
         ArtifactAvailable: model.ArtifactPool.AvailableMask(),
         Plane:  model.Plane,
         Settings: model.Settings,
+        Preferences: settingslib.SerializeSettings(prefs),
         CurrentPlayer: model.CurrentPlayer,
         Turn: model.TurnNumber,
         LastEventTurn: model.LastEventTurn,

--- a/game/magic/game/serialize_test.go
+++ b/game/magic/game/serialize_test.go
@@ -1,0 +1,63 @@
+package game
+
+import (
+    "encoding/json"
+    "testing"
+
+    "github.com/hajimehoshi/ebiten/v2"
+    "github.com/kazzmir/master-of-magic/game/magic/keybinds"
+    settingslib "github.com/kazzmir/master-of-magic/game/magic/settings"
+    "github.com/kazzmir/master-of-magic/game/magic/setup"
+)
+
+func TestSerializedGameOldJSONLeavesPreferencesNil(test *testing.T) {
+    var serialized SerializedGame
+    err := json.Unmarshal([]byte(`{"metadata":{"version":1,"name":"Gabe"},"settings":{"Difficulty":2,"Opponents":2,"LandSize":2,"Magic":1},"turn":1}`), &serialized)
+    if err != nil {
+        test.Fatalf("unmarshal: %v", err)
+    }
+    if serialized.Preferences != nil {
+        test.Errorf("old save must not invent a preferences object")
+    }
+    if serialized.Settings.Difficulty != 2 {
+        test.Errorf("new-game settings should still decode")
+    }
+}
+
+func TestSerializedGamePreferencesRoundTrip(test *testing.T) {
+    prefs := settingslib.MakeSettings(nil)
+    prefs.EndOfTurnWait = false
+    prefs.StrategicCombatOnly = true
+    prefs.Keybindings.Set(keybinds.ActionNextTurn, ebiten.KeySpace)
+
+    original := SerializedGame{
+        Settings: setup.NewGameSettings{Opponents: 3},
+        Preferences: settingslib.SerializeSettings(prefs),
+        Turn: 12,
+    }
+
+    raw, err := json.Marshal(original)
+    if err != nil {
+        test.Fatalf("marshal: %v", err)
+    }
+
+    var loaded SerializedGame
+    if err := json.Unmarshal(raw, &loaded); err != nil {
+        test.Fatalf("unmarshal: %v", err)
+    }
+    if loaded.Turn != 12 || loaded.Settings.Opponents != 3 {
+        test.Errorf("game fields: turn=%d opponents=%d", loaded.Turn, loaded.Settings.Opponents)
+    }
+    if loaded.Preferences == nil {
+        test.Fatalf("preferences missing after round trip")
+    }
+
+    restored := settingslib.MakeSettings(nil)
+    loaded.Preferences.Apply(restored)
+    if restored.EndOfTurnWait || !restored.StrategicCombatOnly {
+        test.Errorf("bools: wait=%v strategic=%v", restored.EndOfTurnWait, restored.StrategicCombatOnly)
+    }
+    if restored.Keybindings.Get(keybinds.ActionNextTurn) != ebiten.KeySpace {
+        test.Errorf("keybindings did not round trip")
+    }
+}

--- a/game/magic/keybinds/keybinds.go
+++ b/game/magic/keybinds/keybinds.go
@@ -83,6 +83,48 @@ func (action Action) Name() string {
     return "Unknown"
 }
 
+// ID is the stable save-file name for this action. Display names in Name() can
+// change; these IDs should not, so old saves keep resolving after a rename.
+func (action Action) ID() string {
+    switch action {
+        case ActionGameScreen: return "game-screen"
+        case ActionOpenSpellbook: return "open-spellbook"
+        case ActionArmiesScreen: return "armies-screen"
+        case ActionCitiesScreen: return "cities-screen"
+        case ActionMagicScreen: return "magic-screen"
+        case ActionAdvisors: return "advisors"
+        case ActionSwitchPlanes: return "switch-planes"
+        case ActionSurveyor: return "surveyor"
+        case ActionCartographer: return "cartographer"
+        case ActionApprentice: return "apprentice"
+        case ActionHistorian: return "historian"
+        case ActionAstrologer: return "astrologer"
+        case ActionChancellor: return "chancellor"
+        case ActionTaxCollector: return "tax-collector"
+        case ActionGrandVizier: return "grand-vizier"
+        case ActionMirror: return "mirror"
+        case ActionNextTurn: return "next-turn"
+        case ActionQuitWithoutSaving: return "quit-without-saving"
+        case ActionDefaultItemEditor: return "default-item-editor"
+    }
+
+    return ""
+}
+
+func ActionByID(id string) (Action, bool) {
+    if id == "" {
+        return ActionGameScreen, false
+    }
+
+    for _, action := range AllActions {
+        if action.ID() == id {
+            return action, true
+        }
+    }
+
+    return ActionGameScreen, false
+}
+
 // Default returns the original game's default key binding for this action,
 // or Unbound if the original game leaves it unbound by default.
 func (action Action) Default() ebiten.Key {
@@ -112,9 +154,9 @@ func (action Action) Default() ebiten.Key {
     return Unbound
 }
 
-// Keybindings holds the current key bound to each action. Session-only,
-// like every other setting in this codebase (e.g. music volume) - nothing
-// here is persisted to disk.
+// Keybindings holds the current key bound to each action. Bindings are written
+// into remake save files with the rest of Settings; music volume is still
+// session-only.
 type Keybindings struct {
     bindings map[Action]ebiten.Key
 }

--- a/game/magic/keybinds/serialize.go
+++ b/game/magic/keybinds/serialize.go
@@ -1,0 +1,78 @@
+package keybinds
+
+import (
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+const unboundName = "unbound"
+
+func keyName(key ebiten.Key) string {
+    if key == Unbound {
+        return unboundName
+    }
+
+    name := key.String()
+    if name == "" {
+        return unboundName
+    }
+
+    return name
+}
+
+func KeyFromName(name string) (ebiten.Key, bool) {
+    if name == "" || name == unboundName {
+        return Unbound, true
+    }
+
+    for key := ebiten.Key(0); key <= ebiten.KeyMax; key++ {
+        if key.String() == name {
+            return key, true
+        }
+    }
+
+    return Unbound, false
+}
+
+// Serialize writes every action as ID -> ebiten key name (or "unbound").
+func (keybindings *Keybindings) Serialize() map[string]string {
+    out := make(map[string]string, len(AllActions))
+    if keybindings == nil {
+        return out
+    }
+
+    for _, action := range AllActions {
+        out[action.ID()] = keyName(keybindings.Get(action))
+    }
+
+    return out
+}
+
+// ApplySerialized overlays saved bindings onto the current map. Unknown action
+// IDs and key names are skipped so a newer binary can still load an older save
+// (new actions keep their defaults). A key claimed by two actions unbinds the
+// previous owner, matching the Keys screen.
+func (keybindings *Keybindings) ApplySerialized(serialized map[string]string) {
+    if keybindings == nil || serialized == nil {
+        return
+    }
+
+    for _, action := range AllActions {
+        name, ok := serialized[action.ID()]
+        if !ok {
+            continue
+        }
+
+        key, ok := KeyFromName(name)
+        if !ok {
+            continue
+        }
+
+        if key != Unbound {
+            if other, conflict := keybindings.ConflictingActionForKey(key); conflict && other != action {
+                keybindings.Set(other, Unbound)
+            }
+        }
+
+        keybindings.Set(action, key)
+    }
+}

--- a/game/magic/keybinds/serialize_test.go
+++ b/game/magic/keybinds/serialize_test.go
@@ -1,0 +1,108 @@
+package keybinds
+
+import (
+    "testing"
+
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestAllActionsHaveUniqueIDs(test *testing.T) {
+    seen := make(map[string]Action)
+
+    for _, action := range AllActions {
+        id := action.ID()
+        if id == "" {
+            test.Errorf("action %v (%s) has no ID()", int(action), action.Name())
+            continue
+        }
+
+        if other, ok := seen[id]; ok {
+            test.Errorf("%v and %v share ID %q", action.Name(), other.Name(), id)
+        }
+        seen[id] = action
+
+        got, ok := ActionByID(id)
+        if !ok || got != action {
+            test.Errorf("ActionByID(%q) = %v ok=%v, want %v", id, got, ok, action)
+        }
+    }
+}
+
+func TestKeyFromNameRoundTrip(test *testing.T) {
+    checks := []ebiten.Key{ebiten.KeyN, ebiten.KeyF1, ebiten.KeySpace, ebiten.KeyEscape}
+
+    for _, key := range checks {
+        got, ok := KeyFromName(key.String())
+        if !ok || got != key {
+            test.Errorf("%v: KeyFromName(%q) = %v ok=%v", key, key.String(), got, ok)
+        }
+    }
+
+    unbound, ok := KeyFromName(unboundName)
+    if !ok || unbound != Unbound {
+        test.Errorf("unbound name should parse as Unbound")
+    }
+    unbound, ok = KeyFromName("")
+    if !ok || unbound != Unbound {
+        test.Errorf("empty name should parse as Unbound")
+    }
+    if _, ok := KeyFromName("not-a-key"); ok {
+        test.Errorf("unknown key name should not parse")
+    }
+}
+
+func TestKeybindingsSerializeRoundTrip(test *testing.T) {
+    original := MakeKeybindings()
+    original.Set(ActionNextTurn, ebiten.KeySpace)
+    original.Set(ActionCitiesScreen, ebiten.KeyC)
+    original.Set(ActionQuitWithoutSaving, Unbound)
+
+    restored := MakeKeybindings()
+    restored.ApplySerialized(original.Serialize())
+
+    for _, action := range AllActions {
+        if restored.Get(action) != original.Get(action) {
+            test.Errorf("%s: got %v, want %v", action.Name(), restored.Get(action), original.Get(action))
+        }
+    }
+}
+
+func TestApplySerializedKeepsDefaultForMissingAction(test *testing.T) {
+    restored := MakeKeybindings()
+    restored.ApplySerialized(map[string]string{
+        "next-turn": "Space",
+    })
+
+    if restored.Get(ActionNextTurn) != ebiten.KeySpace {
+        test.Errorf("next-turn should be Space, got %v", restored.Get(ActionNextTurn))
+    }
+    if restored.Get(ActionSurveyor) != ActionSurveyor.Default() {
+        test.Errorf("missing actions should keep defaults")
+    }
+}
+
+func TestApplySerializedUnbindsConflict(test *testing.T) {
+    restored := MakeKeybindings()
+    restored.ApplySerialized(map[string]string{
+        "game-screen": "N",
+    })
+
+    if restored.Get(ActionGameScreen) != ebiten.KeyN {
+        test.Errorf("game-screen should take N")
+    }
+    if restored.Get(ActionNextTurn) != Unbound {
+        test.Errorf("next-turn should be unbound after losing N, got %v", restored.Get(ActionNextTurn))
+    }
+}
+
+func TestApplySerializedSkipsUnknown(test *testing.T) {
+    restored := MakeKeybindings()
+    restored.ApplySerialized(map[string]string{
+        "not-an-action": "N",
+        "next-turn": "not-a-key",
+    })
+
+    if restored.Get(ActionNextTurn) != ActionNextTurn.Default() {
+        test.Errorf("unknown key name should leave next-turn at default")
+    }
+}

--- a/game/magic/settings/data.go
+++ b/game/magic/settings/data.go
@@ -7,9 +7,8 @@ import (
 
 // Settings is the single top-level holder for every user preference that
 // needs to be readable/settable from both the main menu and an in-progress
-// game (the same set of screens that already share Music). Everything here
-// is session-only, matching how Music's own volume already behaves -
-// nothing is persisted to disk.
+// game (the same set of screens that already share Music). Bools and
+// keybindings are stored in remake save files; music volume stays session-only.
 type Settings struct {
     EndOfTurnWait bool
     StrategicCombatOnly bool

--- a/game/magic/settings/serialize.go
+++ b/game/magic/settings/serialize.go
@@ -1,0 +1,66 @@
+package settings
+
+import (
+    "github.com/kazzmir/master-of-magic/game/magic/keybinds"
+)
+
+// SerializedSettings is the remake-only preferences blob stored next to the
+// game state. Pointers distinguish "field omitted" (old save) from false.
+type SerializedSettings struct {
+    EndOfTurnWait *bool `json:"end-of-turn-wait,omitempty"`
+    StrategicCombatOnly *bool `json:"strategic-combat-only,omitempty"`
+    RandomEvents *bool `json:"random-events,omitempty"`
+    AggressiveAI *bool `json:"aggressive-ai,omitempty"`
+    Keybindings map[string]string `json:"keybindings,omitempty"`
+}
+
+func boolPtr(value bool) *bool {
+    return &value
+}
+
+func SerializeSettings(settings *Settings) *SerializedSettings {
+    if settings == nil {
+        return nil
+    }
+
+    out := &SerializedSettings{
+        EndOfTurnWait: boolPtr(settings.EndOfTurnWait),
+        StrategicCombatOnly: boolPtr(settings.StrategicCombatOnly),
+        RandomEvents: boolPtr(settings.RandomEvents),
+        AggressiveAI: boolPtr(settings.AggressiveAI),
+    }
+
+    if settings.Keybindings != nil {
+        out.Keybindings = settings.Keybindings.Serialize()
+    }
+
+    return out
+}
+
+// Apply copies saved preferences onto settings. Nil fields are left alone so
+// an old save without preferences does not flip EndOfTurnWait/RandomEvents
+// from their defaults to false.
+func (serialized *SerializedSettings) Apply(settings *Settings) {
+    if serialized == nil || settings == nil {
+        return
+    }
+
+    if serialized.EndOfTurnWait != nil {
+        settings.EndOfTurnWait = *serialized.EndOfTurnWait
+    }
+    if serialized.StrategicCombatOnly != nil {
+        settings.StrategicCombatOnly = *serialized.StrategicCombatOnly
+    }
+    if serialized.RandomEvents != nil {
+        settings.RandomEvents = *serialized.RandomEvents
+    }
+    if serialized.AggressiveAI != nil {
+        settings.AggressiveAI = *serialized.AggressiveAI
+    }
+    if serialized.Keybindings != nil {
+        if settings.Keybindings == nil {
+            settings.Keybindings = keybinds.MakeKeybindings()
+        }
+        settings.Keybindings.ApplySerialized(serialized.Keybindings)
+    }
+}

--- a/game/magic/settings/serialize_test.go
+++ b/game/magic/settings/serialize_test.go
@@ -1,0 +1,86 @@
+package settings
+
+import (
+    "encoding/json"
+    "testing"
+
+    "github.com/hajimehoshi/ebiten/v2"
+    "github.com/kazzmir/master-of-magic/game/magic/keybinds"
+)
+
+func TestSerializeSettingsRoundTrip(test *testing.T) {
+    original := MakeSettings(nil)
+    original.EndOfTurnWait = false
+    original.StrategicCombatOnly = true
+    original.RandomEvents = false
+    original.AggressiveAI = true
+    original.Keybindings.Set(keybinds.ActionNextTurn, ebiten.KeySpace)
+
+    restored := MakeSettings(nil)
+    SerializeSettings(original).Apply(restored)
+
+    if restored.EndOfTurnWait {
+        test.Errorf("EndOfTurnWait should restore false")
+    }
+    if !restored.StrategicCombatOnly {
+        test.Errorf("StrategicCombatOnly should restore true")
+    }
+    if restored.RandomEvents {
+        test.Errorf("RandomEvents should restore false")
+    }
+    if !restored.AggressiveAI {
+        test.Errorf("AggressiveAI should restore true")
+    }
+    if restored.Keybindings.Get(keybinds.ActionNextTurn) != ebiten.KeySpace {
+        test.Errorf("next-turn should restore as Space")
+    }
+}
+
+func TestApplyNilLeavesDefaults(test *testing.T) {
+    settings := MakeSettings(nil)
+    var serialized *SerializedSettings
+    serialized.Apply(settings)
+
+    if !settings.EndOfTurnWait || settings.StrategicCombatOnly || !settings.RandomEvents {
+        test.Errorf("nil preferences should leave defaults, got %+v", *settings)
+    }
+}
+
+func TestOldSaveJSONDoesNotZeroBools(test *testing.T) {
+    // gzip JSON from before preferences existed has no such object at all.
+    var serialized SerializedSettings
+    if err := json.Unmarshal([]byte(`{}`), &serialized); err != nil {
+        test.Fatalf("unmarshal: %v", err)
+    }
+
+    settings := MakeSettings(nil)
+    serialized.Apply(settings)
+
+    if !settings.EndOfTurnWait {
+        test.Errorf("missing end-of-turn-wait must not become false")
+    }
+    if settings.StrategicCombatOnly {
+        test.Errorf("missing strategic-combat-only should stay default false")
+    }
+    if !settings.RandomEvents {
+        test.Errorf("missing random-events must not become false")
+    }
+}
+
+func TestSerializeSettingsJSONKeys(test *testing.T) {
+    raw, err := json.Marshal(SerializeSettings(MakeSettings(nil)))
+    if err != nil {
+        test.Fatalf("marshal: %v", err)
+    }
+
+    var payload map[string]any
+    if err := json.Unmarshal(raw, &payload); err != nil {
+        test.Fatalf("unmarshal: %v", err)
+    }
+
+    for _, key := range []string{"end-of-turn-wait", "strategic-combat-only", "random-events", "aggressive-ai", "keybindings"} {
+        if _, ok := payload[key]; !ok {
+            test.Errorf("expected %q in preferences JSON", key)
+        }
+    }
+}

--- a/test/serialize/main.go
+++ b/test/serialize/main.go
@@ -147,7 +147,7 @@ func main() {
         Cost: 300,
     }
 
-    serialized := gamelib.SerializeModel(game.Model, "test")
+    serialized := gamelib.SerializeModel(game.Model, "test", useSettings)
 
     // log.Printf("Serialized model: %v", serialized)
     jsonData, err := json.Marshal(serialized)


### PR DESCRIPTION
Write remake UI prefs into save files so EndOfTurnWait, StrategicCombatOnly, RandomEvents, AggressiveAI, and keybindings survive load. Old saves without the new `preferences` object keep current defaults instead of flipping bools to false.

The existing JSON `settings` field stays the new-game difficulty/land/magic struct.

Split out of mixed local POC work on `test-today`.

## Changes
- `settings.SerializedSettings` with pointer bools so omitted fields stay default
- `keybinds` action IDs + serialize/apply, including conflict-unbind matching the Keys screen
- `SerializedGame.Preferences` written on save and applied in `MakeGameFromSerialized`

## Test plan
- [x] `go test ./game/magic/settings/... ./game/magic/keybinds/... ./game/magic/game/...`
- Load a pre-preferences save and confirm EndOfTurnWait/RandomEvents stay on
- Change a keybind, save, load, confirm it round-trips