### PR TITLE
input: move units with the numeric keypad

### DIFF
--- a/game/magic/combat/combat-screen.go
+++ b/game/magic/combat/combat-screen.go
@@ -3094,6 +3094,30 @@ func (combat *CombatScreen) Update(yield coroutine.YieldFunc) CombatState {
         selectTileY = combat.MouseTileY
     }
 
+    // original MoM moved the selected unit with the numeric keypad. Arrow keys
+    // still pan the camera (ProcessInput), so only numpad keys issue a move.
+    if !leftClick &&
+       combat.UI.GetHighestLayerValue() == 0 &&
+       combat.Model.SelectedUnit != nil &&
+       !combat.Model.IsAIControlled(combat.Model.SelectedUnit) &&
+       !combat.Model.SelectedUnit.Moving {
+
+        var justKeys []ebiten.Key
+        justKeys = inpututil.AppendJustPressedKeys(justKeys)
+        var numpadKeys []ebiten.Key
+        for _, key := range justKeys {
+            if inputmanager.IsNumpadMoveKey(key) {
+                numpadKeys = append(numpadKeys, key)
+            }
+        }
+        dx, dy := inputmanager.CombineMoveDeltas(numpadKeys)
+        if dx != 0 || dy != 0 {
+            leftClick = true
+            selectTileX = combat.Model.SelectedUnit.X + dx
+            selectTileY = combat.Model.SelectedUnit.Y + dy
+        }
+    }
+
     combatActions := &CombatActions{
         AIUnitActions: &actions,
         yield: yield,

--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -3838,17 +3838,7 @@ func (game *Game) doPlayerUpdate(yield coroutine.YieldFunc, player *playerlib.Pl
 
         if true || len(stack.CurrentPath) == 0 || stack.OutOfMoves() {
 
-            dx := 0
-            dy := 0
-
-            for _, key := range keys {
-                switch key {
-                    case ebiten.KeyUp: dy = -1
-                    case ebiten.KeyDown: dy = 1
-                    case ebiten.KeyLeft: dx = -1
-                    case ebiten.KeyRight: dx = 1
-                }
-            }
+            dx, dy := inputmanager.CombineMoveDeltas(keys)
 
             newX := game.Model.CurrentMap().WrapX(stack.X() + dx)
             newY := stack.Y() + dy

--- a/game/magic/inputmanager/move.go
+++ b/game/magic/inputmanager/move.go
@@ -1,0 +1,61 @@
+package inputmanager
+
+import (
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+// MoveDelta returns the tile step for a unit-movement key. Arrow keys are the
+// four cardinals; numpad 1-4 and 6-9 are the original MoM 8-direction keypad
+// (5 is unused). Y grows south, matching the overland map.
+func MoveDelta(key ebiten.Key) (dx int, dy int, ok bool) {
+    switch key {
+        case ebiten.KeyUp, ebiten.KeyNumpad8:
+            return 0, -1, true
+        case ebiten.KeyDown, ebiten.KeyNumpad2:
+            return 0, 1, true
+        case ebiten.KeyLeft, ebiten.KeyNumpad4:
+            return -1, 0, true
+        case ebiten.KeyRight, ebiten.KeyNumpad6:
+            return 1, 0, true
+        case ebiten.KeyNumpad7:
+            return -1, -1, true
+        case ebiten.KeyNumpad9:
+            return 1, -1, true
+        case ebiten.KeyNumpad1:
+            return -1, 1, true
+        case ebiten.KeyNumpad3:
+            return 1, 1, true
+    }
+
+    return 0, 0, false
+}
+
+func IsNumpadMoveKey(key ebiten.Key) bool {
+    switch key {
+        case ebiten.KeyNumpad1, ebiten.KeyNumpad2, ebiten.KeyNumpad3, ebiten.KeyNumpad4,
+             ebiten.KeyNumpad6, ebiten.KeyNumpad7, ebiten.KeyNumpad8, ebiten.KeyNumpad9:
+            return true
+    }
+
+    return false
+}
+
+// CombineMoveDeltas folds movement keys into a single step. Cardinals set one
+// axis so Up+Left in the same frame is northwest; a diagonal numpad key sets
+// both. Later keys override the axes they touch.
+func CombineMoveDeltas(keys []ebiten.Key) (dx int, dy int) {
+    for _, key := range keys {
+        kdx, kdy, ok := MoveDelta(key)
+        if !ok {
+            continue
+        }
+        if kdx != 0 {
+            dx = kdx
+        }
+        if kdy != 0 {
+            dy = kdy
+        }
+    }
+
+    return dx, dy
+}

--- a/game/magic/inputmanager/move_test.go
+++ b/game/magic/inputmanager/move_test.go
@@ -1,0 +1,81 @@
+package inputmanager
+
+import (
+    "testing"
+
+    "github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestMoveDeltaArrows(test *testing.T) {
+    checks := []struct {
+        key ebiten.Key
+        dx int
+        dy int
+    }{
+        {ebiten.KeyUp, 0, -1},
+        {ebiten.KeyDown, 0, 1},
+        {ebiten.KeyLeft, -1, 0},
+        {ebiten.KeyRight, 1, 0},
+    }
+
+    for _, check := range checks {
+        dx, dy, ok := MoveDelta(check.key)
+        if !ok || dx != check.dx || dy != check.dy {
+            test.Errorf("%v: got (%d,%d) ok=%v, want (%d,%d)", check.key, dx, dy, ok, check.dx, check.dy)
+        }
+    }
+}
+
+func TestMoveDeltaNumpadEightWay(test *testing.T) {
+    checks := []struct {
+        key ebiten.Key
+        dx int
+        dy int
+    }{
+        {ebiten.KeyNumpad8, 0, -1},
+        {ebiten.KeyNumpad2, 0, 1},
+        {ebiten.KeyNumpad4, -1, 0},
+        {ebiten.KeyNumpad6, 1, 0},
+        {ebiten.KeyNumpad7, -1, -1},
+        {ebiten.KeyNumpad9, 1, -1},
+        {ebiten.KeyNumpad1, -1, 1},
+        {ebiten.KeyNumpad3, 1, 1},
+    }
+
+    for _, check := range checks {
+        dx, dy, ok := MoveDelta(check.key)
+        if !ok || dx != check.dx || dy != check.dy {
+            test.Errorf("%v: got (%d,%d) ok=%v, want (%d,%d)", check.key, dx, dy, ok, check.dx, check.dy)
+        }
+        if !IsNumpadMoveKey(check.key) {
+            test.Errorf("%v should be a numpad move key", check.key)
+        }
+    }
+
+    if _, _, ok := MoveDelta(ebiten.KeyNumpad5); ok {
+        test.Errorf("numpad 5 should not move a unit")
+    }
+    if IsNumpadMoveKey(ebiten.KeyNumpad5) {
+        test.Errorf("numpad 5 should not be a numpad move key")
+    }
+    if IsNumpadMoveKey(ebiten.KeyUp) {
+        test.Errorf("arrow keys are not numpad move keys")
+    }
+}
+
+func TestCombineMoveDeltas(test *testing.T) {
+    dx, dy := CombineMoveDeltas([]ebiten.Key{ebiten.KeyUp, ebiten.KeyLeft})
+    if dx != -1 || dy != -1 {
+        test.Errorf("Up+Left should be northwest, got (%d,%d)", dx, dy)
+    }
+
+    dx, dy = CombineMoveDeltas([]ebiten.Key{ebiten.KeyNumpad3})
+    if dx != 1 || dy != 1 {
+        test.Errorf("numpad 3 should be southeast, got (%d,%d)", dx, dy)
+    }
+
+    dx, dy = CombineMoveDeltas([]ebiten.Key{ebiten.KeyN, ebiten.KeySpace})
+    if dx != 0 || dy != 0 {
+        test.Errorf("non-move keys should be ignored, got (%d,%d)", dx, dy)
+    }
+}


### PR DESCRIPTION
Share 8-way numpad deltas between overland stacks and combat. Arrow keys still pan the combat camera; only numpad 1-4 / 6-9 issue a unit step, matching original MoM. Numpad 5 does nothing.

Split out of mixed local POC work on `test-today`.

## Changes
- `inputmanager.MoveDelta` / `CombineMoveDeltas` / `IsNumpadMoveKey`
- Overland `doPlayerUpdate` uses the shared helper (arrows still work, and Up+Left in one frame is northwest)
- Combat treats a numpad press as a click on the adjacent tile

## Test plan
- [x] `go test ./game/magic/inputmanager/...`
- Overland: numpad 8/2/4/6 and diagonals 7/9/1/3
- Combat: numpad moves the selected unit; arrow keys still pan