### PR TITLE
terrain: paint a one-row tundra cap at each pole

### DIFF
--- a/game/magic/maplib/map.go
+++ b/game/magic/maplib/map.go
@@ -881,6 +881,10 @@ func MakeMap(terrainData *terrain.TerrainData, landSize int, magicSetting data.M
 
     canPlaceEncounter := func (x int, y int) bool {
         // an encounter can be placed if the specified tile is plain land, and is not near some other node/encounter
+        // original MoM never put lairs on the polar ice row
+        if terrain.IsPolarIceRow(y, landHeight) {
+            return false
+        }
 
         tile := terrainData.Tiles[map_.Terrain[x][y]].Tile
         if !tile.IsLand() || tile.IsMagic() {

--- a/game/magic/terrain/map.go
+++ b/game/magic/terrain/map.go
@@ -352,6 +352,9 @@ func (map_ *Map) placeRandomTerrainTiles(plane data.Plane, continents []Continen
             }
 
             point := points[index]
+            if IsPolarIceRow(point.Y, map_.Rows()) {
+                continue
+            }
             if magicNodeOk(point) {
                 map_.Terrain[point.X][point.Y] = algorithm.ChooseRandomElement(magicTiles)
                 maxNodes -= 1
@@ -654,6 +657,41 @@ func (map_ *Map) SetTerrainAt(x int, y int, terrainType TerrainType, data *Terra
 }
 
 
+func PolarIceRows(rows int) int {
+    // original MoM had a single full-width tundra row at each pole. tiny
+    // maps skip it so 3x3 tile tests do not become all ice.
+    if rows < 6 {
+        return 0
+    }
+
+    return 1
+}
+
+func IsPolarIceRow(y int, rows int) bool {
+    ice := PolarIceRows(rows)
+    if ice == 0 {
+        return false
+    }
+
+    return y < ice || y >= rows-ice
+}
+
+func (map_ *Map) placePolarIce(plane data.Plane) {
+    rows := map_.Rows()
+    ice := PolarIceRows(rows)
+    if ice == 0 {
+        return
+    }
+
+    tundra := TileTundra.Index(plane)
+    for x := 0; x < map_.Columns(); x++ {
+        for y := 0; y < ice; y++ {
+            map_.Terrain[x][y] = tundra
+            map_.Terrain[x][rows - 1 - y] = tundra
+        }
+    }
+}
+
 func GenerateLandCellularAutomata(columns int, rows int, data *TerrainData, plane data.Plane) *Map {
     // run a cellular automata simulation for a few rounds to generate
     // land and ocean tiles. then call ResolveTiles() to clean up the edges
@@ -664,6 +702,7 @@ func GenerateLandCellularAutomata(columns int, rows int, data *TerrainData, plan
     continents := map_.FindContinents()
     map_.placeRandomTerrainTiles(plane, continents)
     map_.placeRivers(100, data, plane, continents)
+    map_.placePolarIce(plane)
     map_.ResolveTiles(data, plane)
     end := time.Now()
     log.Printf("Generated %vx%v %v map in %v", columns, rows, plane, end.Sub(start))

--- a/game/magic/terrain/map_test.go
+++ b/game/magic/terrain/map_test.go
@@ -184,6 +184,67 @@ func TestContinents(test *testing.T) {
 
 }
 
+func TestPolarIceRowsSkippedOnTinyMaps(test *testing.T) {
+    if PolarIceRows(3) != 0 {
+        test.Errorf("3-row maps should not be painted as ice")
+    }
+    if PolarIceRows(50) != 1 {
+        test.Errorf("standard maps should have a 1-row ice cap")
+    }
+    if IsPolarIceRow(0, 50) != true || IsPolarIceRow(49, 50) != true {
+        test.Errorf("y=0 and y=height-1 should be the ice cap")
+    }
+    if IsPolarIceRow(1, 50) || IsPolarIceRow(48, 50) {
+        test.Errorf("tiles adjacent to the ice cap should not be the cap")
+    }
+}
+
+func TestPlacePolarIcePaintsFullWidthCaps(test *testing.T) {
+    rows := 10
+    columns := 12
+    map_ := MakeMap(rows, columns)
+    ocean := TileOcean.Index(data.PlaneArcanus)
+    for x := 0; x < columns; x++ {
+        for y := 0; y < rows; y++ {
+            map_.Terrain[x][y] = ocean
+        }
+    }
+
+    map_.placePolarIce(data.PlaneArcanus)
+
+    ice := PolarIceRows(rows)
+    tundra := TileTundra.Index(data.PlaneArcanus)
+    for x := 0; x < columns; x++ {
+        for y := 0; y < ice; y++ {
+            if map_.Terrain[x][y] != tundra {
+                test.Errorf("north cap %d,%d want tundra", x, y)
+            }
+            if map_.Terrain[x][rows-1-y] != tundra {
+                test.Errorf("south cap %d,%d want tundra", x, rows-1-y)
+            }
+        }
+        if map_.Terrain[x][ice] != ocean {
+            test.Errorf("row inside the north cap should stay ocean at x=%d", x)
+        }
+    }
+}
+
+func TestGenerateLandHasPolarIceCaps(test *testing.T) {
+    terrainData := createTerrainData()
+    map_ := GenerateLandCellularAutomata(20, 20, terrainData, data.PlaneArcanus)
+    ice := PolarIceRows(20)
+    for x := 0; x < 20; x++ {
+        for y := 0; y < ice; y++ {
+            if GetTile(map_.Terrain[x][y]).TerrainType() != Tundra {
+                test.Errorf("north cap %d,%d is %v", x, y, GetTile(map_.Terrain[x][y]).TerrainType())
+            }
+            if GetTile(map_.Terrain[x][19-y]).TerrainType() != Tundra {
+                test.Errorf("south cap %d,%d is %v", x, 19-y, GetTile(map_.Terrain[x][19-y]).TerrainType())
+            }
+        }
+    }
+}
+
 func BenchmarkGeneration(bench *testing.B){
     terrainData := createTerrainData()
     plane := data.PlaneArcanus


### PR DESCRIPTION
Match original MoM's full-width polar ice and keep lairs and random magic nodes off those rows. Tiny test maps skip the cap so 3x3 fixtures stay land.

Split out of mixed local POC work on `test-today`.

## Changes
- `PolarIceRows` / `IsPolarIceRow` / `placePolarIce` after rivers, before `ResolveTiles`
- One tundra row at y=0 and y=height-1 on maps with at least 6 rows
- Encounter placement refuses polar ice rows
- Random magic nodes skip polar ice rows

## Test plan
- [x] `go test ./game/magic/terrain/...`
- New game: confirm a full-width tundra belt at both poles, no lairs on those rows