### PR TITLE
earthquake: spare buildings required by an intact higher-tier building

### DIFF
--- a/game/magic/game/earthquake_test.go
+++ b/game/magic/game/earthquake_test.go
@@ -1,0 +1,90 @@
+package game
+
+import (
+    "testing"
+
+    buildinglib "github.com/kazzmir/master-of-magic/game/magic/building"
+    citylib "github.com/kazzmir/master-of-magic/game/magic/city"
+    "github.com/kazzmir/master-of-magic/game/magic/data"
+    herolib "github.com/kazzmir/master-of-magic/game/magic/hero"
+    playerlib "github.com/kazzmir/master-of-magic/game/magic/player"
+    "github.com/kazzmir/master-of-magic/game/magic/setup"
+    "github.com/kazzmir/master-of-magic/lib/set"
+)
+
+func TestEarthquakeBuildingProtected(test *testing.T) {
+    expect := func(name string, building buildinglib.Building, intact *set.Set[buildinglib.Building], want bool) {
+        got := earthquakeBuildingProtected(building, intact)
+        if got != want {
+            test.Errorf("%s: protected=%v, want %v", name, got, want)
+        }
+    }
+
+    shrineTempleParthenon := set.NewSet(
+        buildinglib.BuildingShrine,
+        buildinglib.BuildingTemple,
+        buildinglib.BuildingParthenon,
+    )
+    expect("shrine under parthenon", buildinglib.BuildingShrine, shrineTempleParthenon, true)
+    expect("temple under parthenon", buildinglib.BuildingTemple, shrineTempleParthenon, true)
+    expect("parthenon is top of line", buildinglib.BuildingParthenon, shrineTempleParthenon, false)
+
+    shrineTemple := set.NewSet(buildinglib.BuildingShrine, buildinglib.BuildingTemple)
+    expect("shrine under temple", buildinglib.BuildingShrine, shrineTemple, true)
+    expect("temple is top of line", buildinglib.BuildingTemple, shrineTemple, false)
+
+    shrineOnly := set.NewSet(buildinglib.BuildingShrine)
+    expect("lone shrine", buildinglib.BuildingShrine, shrineOnly, false)
+
+    granaryOnly := set.NewSet(buildinglib.BuildingGranary)
+    expect("granary without farmers market", buildinglib.BuildingGranary, granaryOnly, false)
+
+    marketplaceBank := set.NewSet(buildinglib.BuildingMarketplace, buildinglib.BuildingBank)
+    expect("marketplace under bank", buildinglib.BuildingMarketplace, marketplaceBank, true)
+    expect("bank is top of line", buildinglib.BuildingBank, marketplaceBank, false)
+}
+
+func TestEarthquakeSparesLowerTierBuildings(test *testing.T) {
+    model := &GameModel{}
+    player := playerlib.MakePlayer(
+        setup.WizardCustom{Banner: data.BannerRed, Race: data.RaceHighMen},
+        true, 1, 1, make(map[herolib.HeroType]string), nil,
+    )
+
+    parthenonDestroyed := 0
+    for i := 0; i < 200; i++ {
+        city := &citylib.City{
+            X: 1,
+            Y: 1,
+            Plane: data.PlaneArcanus,
+            Buildings: set.NewSet(
+                buildinglib.BuildingShrine,
+                buildinglib.BuildingTemple,
+                buildinglib.BuildingParthenon,
+            ),
+        }
+
+        people, _, destroyed := model.doEarthquake(city, player)
+        if people != 0 {
+            test.Fatalf("trial %d: earthquake killed %d citizens, want 0", i, people)
+        }
+        if !city.Buildings.Contains(buildinglib.BuildingShrine) {
+            test.Fatalf("trial %d: shrine was destroyed while temple/parthenon still existed at quake start", i)
+        }
+        if !city.Buildings.Contains(buildinglib.BuildingTemple) {
+            test.Fatalf("trial %d: temple was destroyed while parthenon still existed at quake start", i)
+        }
+        if !city.Buildings.Contains(buildinglib.BuildingParthenon) {
+            parthenonDestroyed++
+        }
+        for _, building := range destroyed {
+            if building == buildinglib.BuildingShrine || building == buildinglib.BuildingTemple {
+                test.Fatalf("trial %d: destroyed list included protected building %v", i, building)
+            }
+        }
+    }
+
+    if parthenonDestroyed == 0 {
+        test.Errorf("parthenon was never destroyed in 200 quakes; it should be a valid target")
+    }
+}

--- a/game/magic/game/model.go
+++ b/game/magic/game/model.go
@@ -1538,10 +1538,16 @@ func (model *GameModel) RefreshUI() {
     }
 }
 
+func earthquakeBuildingProtected(building buildinglib.Building, intact *set.Set[buildinglib.Building]) bool {
+    replacement := building.ReplacedBy()
+    return replacement != buildinglib.BuildingNone && intact.Contains(replacement)
+}
+
 // returns the number of people, units, buildings that were lost
 func (model *GameModel) doEarthquake(city *citylib.City, player *playerlib.Player) (int, int, []buildinglib.Building) {
-    // FIXME: destroy buildings with 15% chance and non-flying units with 25% chance
     // https://masterofmagic.fandom.com/wiki/Earthquake
+    // Spare a building if ReplacedBy() is still intact at the start of the quake
+    // (only the top of a line, e.g. Parthenon when Shrine+Temple+Parthenon exist, can collapse).
 
     // earthquake never kills any citizens
     people := 0
@@ -1566,8 +1572,13 @@ func (model *GameModel) doEarthquake(city *citylib.City, player *playerlib.Playe
         player.RemoveUnit(unit)
     }
 
+    intact := set.NewSet(city.Buildings.Values()...)
     var destroyedBuildings []buildinglib.Building
-    for _, building := range city.Buildings.Values() {
+    for _, building := range intact.Values() {
+        if earthquakeBuildingProtected(building, intact) {
+            continue
+        }
+
         roll := rand.N(100)
         if roll < 15 {
             destroyedBuildings = append(destroyedBuildings, building)


### PR DESCRIPTION
Earthquake already rolled 15% per building and 25% per non-flying/corporeal unit, but it could collapse a Shrine or Temple even while a Parthenon was still standing.

Original MoM spares a structure when it is required by another building that is still intact at the start of the quake, so only the top of a line is a valid target. This uses the existing `Building.ReplacedBy()` chain (Shrine→Temple→Parthenon→Cathedral, and the other cityscape replacements) and snapshots the buildings before any removals so destroying the Parthenon in the same quake cannot make the Temple eligible.

The stale FIXME is gone; the wiki link stays.

Tests cover the protection helper (shrine/temple/parthenon, granary, marketplace/bank) and 200 trials of `doEarthquake` asserting shrine and temple never fall while parthenon is a valid target. Citizens remain 0.

https://masterofmagic.fandom.com/wiki/Earthquake