### PR TITLE
combat: dont automatically meet wizards due to combat

### DIFF
--- a/game/magic/game/game.go
+++ b/game/magic/game/game.go
@@ -4934,8 +4934,6 @@ func (game *Game) maybeDoNaturesWrath(caster *playerlib.Player) {
  * this also shows the raze city ui so that fame can be incorporated based on whether the city is razed or not
  */
 func (game *Game) doCombat(yield coroutine.YieldFunc, attacker *playerlib.Player, attackerStack *playerlib.UnitStack, defender *playerlib.Player, defenderStack *playerlib.UnitStack, zone combat.ZoneType) combat.CombatState {
-    game.meetWizards(yield, attacker, defender)
-
     landscape := game.GetCombatLandscape(defenderStack.X(), defenderStack.Y(), defenderStack.Plane())
 
     // do graphic combat only if a human is involved


### PR DESCRIPTION
Entering a lair would inadvertently run a diplomacy screen because the first thing combat does is invoke meetWizards() on the two players, but in a lair one of the players is fake and only exists because combat requires a Player object to be passed in.

Combat could not occur without an army moving within sight of an enemy, so discoverWizards() in the movement code should already handle the case where an enemy is discovered just before combat starts.